### PR TITLE
feat(schema-resolver): expose client retry config and retry registry outages

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/assembly-configuring-kafka-client-serdes.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-configuring-kafka-client-serdes.adoc
@@ -308,17 +308,17 @@ The `DefaultSchemaResolver` uses the following properties to configure how to lo
 |`300`
 |`RETRY_COUNT`
 |`apicurio.registry.retry-count`
-|Used by serializers and deserializers. Controls how many times the schema cache retries a failed load before failing. Distinct from `apicurio.registry.client.retry.max-attempts` (HTTP client retry ladder). By default the cache only retries HTTP 429; set `apicurio.registry.retry.transient-errors=true` to also retry network/outage failures. When that opt-in is enabled, worst-case blocking multiplies across both layers — size together with the client retry keys, especially for Kafka producers (`max.block.ms`) and Connect polls.
+|Used by serializers and deserializers. **To retry registry outages, set `apicurio.registry.retry.transient-errors=true` and preferably `apicurio.registry.retry.total-timeout-ms`.** This key then controls how many times the schema cache retries a failed load. Distinct from `apicurio.registry.client.retry.max-attempts` (HTTP client retry ladder). By default the cache only retries HTTP 429; raising `retry-count` alone does not cover network or registry-down failures. When the opt-in is enabled, worst-case blocking multiplies across both layers — size together with the client retry keys, especially for Kafka producers (`max.block.ms`) and Connect polls.
 |`non-negative Number, or integer String`
 |`3`
 |`RETRY_TRANSIENT_ERRORS`
 |`apicurio.registry.retry.transient-errors`
-|Used by serializers and deserializers. When `false` (default), schema-cache retries stay limited to HTTP 429 (historical behavior). When `true`, also retries 502/503/504 and retriable network failures (including `NoRouteToHostException`). Enabling this increases worst-case blocking because each cache attempt may run a full HTTP client retry ladder. Prefer setting `apicurio.registry.retry.total-timeout-ms` when enabling.
+|Used by serializers and deserializers. **Activation step for outage retries.** When `false` (default), schema-cache retries stay limited to HTTP 429 (historical behavior). When `true`, also retries 502/503/504 and retriable network failures (including `NoRouteToHostException`). Enabling this increases worst-case blocking because each cache attempt may run a full HTTP client retry ladder. Set `apicurio.registry.retry.total-timeout-ms` when enabling.
 |`boolean`
 |`false`
 |`RETRY_TOTAL_TIMEOUT_MS`
 |`apicurio.registry.retry.total-timeout-ms`
-|Used by serializers and deserializers. Optional wall-clock budget (milliseconds) for one schema-cache load retry loop. Checked before each re-attempt. `0` means unlimited. Recommended when `apicurio.registry.retry.transient-errors=true` to bound blocking on Kafka `Producer.send()` / Connect polls.
+|Used by serializers and deserializers. Optional wall-clock budget (milliseconds) for one schema-cache load retry loop. Checked before each re-attempt; it does not interrupt an in-flight cache attempt (that attempt may still run a full HTTP client retry ladder and request timeouts). `0` means unlimited. Recommended when `apicurio.registry.retry.transient-errors=true` to bound blocking on Kafka `Producer.send()` / Connect polls.
 |`java.time.Duration, non-negative Number, or integer String`
 |`0`
 |`CLIENT_RETRY_ENABLED`
@@ -328,8 +328,8 @@ The `DefaultSchemaResolver` uses the following properties to configure how to lo
 |`true`
 |`CLIENT_RETRY_MAX_ATTEMPTS`
 |`apicurio.registry.client.retry.max-attempts`
-|Used by serializers and deserializers. Maximum attempts for the HTTP client retry ladder. Defaults match `RegistryClientOptions#retry()` (3 / 250ms / 2.0 / 10000ms).
-|`integer in [1, Integer.MAX_VALUE]`
+|Used by serializers and deserializers. Maximum attempts for the HTTP client retry ladder. Defaults match `RegistryClientOptions#retry()` (3 / 250ms / 2.0 / 10000ms). Values above `1000` are rejected as a sanity ceiling (not a recommended operating point).
+|`integer in [1, 1000]`
 |`3`
 |`CLIENT_RETRY_DELAY_MS`
 |`apicurio.registry.client.retry.delay-ms`

--- a/docs/modules/ROOT/pages/getting-started/assembly-configuring-kafka-client-serdes.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-configuring-kafka-client-serdes.adoc
@@ -313,9 +313,14 @@ The `DefaultSchemaResolver` uses the following properties to configure how to lo
 |`3`
 |`RETRY_TRANSIENT_ERRORS`
 |`apicurio.registry.retry.transient-errors`
-|Used by serializers and deserializers. When `false` (default), schema-cache retries stay limited to HTTP 429 (historical behavior). When `true`, also retries 502/503/504 and retriable network failures. Enabling this increases worst-case blocking because each cache attempt may run a full HTTP client retry ladder.
+|Used by serializers and deserializers. When `false` (default), schema-cache retries stay limited to HTTP 429 (historical behavior). When `true`, also retries 502/503/504 and retriable network failures (including `NoRouteToHostException`). Enabling this increases worst-case blocking because each cache attempt may run a full HTTP client retry ladder. Prefer setting `apicurio.registry.retry.total-timeout-ms` when enabling.
 |`boolean`
 |`false`
+|`RETRY_TOTAL_TIMEOUT_MS`
+|`apicurio.registry.retry.total-timeout-ms`
+|Used by serializers and deserializers. Optional wall-clock budget (milliseconds) for one schema-cache load retry loop. Checked before each re-attempt. `0` means unlimited. Recommended when `apicurio.registry.retry.transient-errors=true` to bound blocking on Kafka `Producer.send()` / Connect polls.
+|`java.time.Duration, non-negative Number, or integer String`
+|`0`
 |`CLIENT_RETRY_ENABLED`
 |`apicurio.registry.client.retry.enabled`
 |Used by serializers and deserializers. Enables the underlying registry HTTP client retry ladder (`RegistryClientOptions`). Distinct from `apicurio.registry.retry-count` (schema-cache retries).

--- a/docs/modules/ROOT/pages/getting-started/assembly-configuring-kafka-client-serdes.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-configuring-kafka-client-serdes.adoc
@@ -308,9 +308,39 @@ The `DefaultSchemaResolver` uses the following properties to configure how to lo
 |`300`
 |`RETRY_COUNT`
 |`apicurio.registry.retry-count`
-|Used by serializers and deserializers. If the SerDes cannot retrieve a schema from the registry, they can retry a number of times. This configuration option controls the number of retry attempts.
+|Used by serializers and deserializers. Controls how many times the schema cache retries a failed load before failing. Distinct from `apicurio.registry.client.retry.max-attempts` (HTTP client retry ladder). By default the cache only retries HTTP 429; set `apicurio.registry.retry.transient-errors=true` to also retry network/outage failures. When that opt-in is enabled, worst-case blocking multiplies across both layers — size together with the client retry keys, especially for Kafka producers (`max.block.ms`) and Connect polls.
 |`non-negative Number, or integer String`
 |`3`
+|`RETRY_TRANSIENT_ERRORS`
+|`apicurio.registry.retry.transient-errors`
+|Used by serializers and deserializers. When `false` (default), schema-cache retries stay limited to HTTP 429 (historical behavior). When `true`, also retries 502/503/504 and retriable network failures. Enabling this increases worst-case blocking because each cache attempt may run a full HTTP client retry ladder.
+|`boolean`
+|`false`
+|`CLIENT_RETRY_ENABLED`
+|`apicurio.registry.client.retry.enabled`
+|Used by serializers and deserializers. Enables the underlying registry HTTP client retry ladder (`RegistryClientOptions`). Distinct from `apicurio.registry.retry-count` (schema-cache retries).
+|`boolean`
+|`true`
+|`CLIENT_RETRY_MAX_ATTEMPTS`
+|`apicurio.registry.client.retry.max-attempts`
+|Used by serializers and deserializers. Maximum attempts for the HTTP client retry ladder. Defaults match `RegistryClientOptions#retry()` (3 / 250ms / 2.0 / 10000ms).
+|`integer in [1, Integer.MAX_VALUE]`
+|`3`
+|`CLIENT_RETRY_DELAY_MS`
+|`apicurio.registry.client.retry.delay-ms`
+|Used by serializers and deserializers. Initial delay (milliseconds) for the HTTP client retry ladder.
+|`java.time.Duration, non-negative Number, or integer String`
+|`250`
+|`CLIENT_RETRY_BACKOFF_MULTIPLIER`
+|`apicurio.registry.client.retry.backoff-multiplier`
+|Used by serializers and deserializers. Exponential backoff multiplier for the HTTP client retry ladder. Must be finite and greater than `1.0` (same constraint as `RegistryClientOptions#retry`).
+|`Number or numeric String`
+|`2.0`
+|`CLIENT_RETRY_MAX_DELAY_MS`
+|`apicurio.registry.client.retry.max-delay-ms`
+|Used by serializers and deserializers. Maximum delay (milliseconds) between HTTP client retry attempts.
+|`java.time.Duration, non-negative Number, or integer String`
+|`10000`
 |`FAULT_TOLERANT_REFRESH`
 |`apicurio.registry.fault-tolerant-refresh`
 |Used by serializers and deserializers. If `true`, the SerDes log exceptions instead of throwing them when an error occurs while refreshing a schema in the cache. This is useful for production situations where a stale schema is better than completely failing schema resolution. This does not affect retry attempts, because the SerDes attempt retries before considering this flag.

--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
@@ -83,17 +83,14 @@ public class RegistryClientRequestAdapterFactory {
 
         // Wrap with retry proxy if retry is enabled
         if (options.isRetryEnabled()) {
-            log.log(Level.INFO,
-                    "[apicurio-pr9091] wrapping RequestAdapter with retry maxAttempts={0} delayMs={1} backoff={2} maxDelayMs={3}",
+            log.log(Level.FINE,
+                    "Enabling registry HTTP client retry: maxAttempts={0}, delayMs={1}, backoffMultiplier={2}, maxDelayMs={3}",
                     new Object[]{
                             options.getMaxRetryAttempts(),
                             options.getRetryDelayMs(),
                             options.getBackoffMultiplier(),
                             options.getMaxRetryDelayMs()
                     });
-            System.out.println("[apicurio-pr9091] RequestAdapter retry proxy maxAttempts="
-                    + options.getMaxRetryAttempts()
-                    + " delayMs=" + options.getRetryDelayMs());
             adapter = createRetryProxy(adapter, options);
         }
 
@@ -215,8 +212,8 @@ public class RegistryClientRequestAdapterFactory {
                     if (isRetryable(cause) && attempt < maxRetryAttempts) {
                         attempt++;
                         long delayMs = calculateRetryDelay(attempt);
-                        log.log(Level.WARNING,
-                                "[apicurio-pr9091] HTTP retry {0}/{1} after {2}: {3}; sleeping {4}ms",
+                        log.log(Level.FINE,
+                                "Retryable registry HTTP failure on attempt {0}/{1} ({2}: {3}); sleeping {4}ms before retry",
                                 new Object[]{
                                         attempt,
                                         maxRetryAttempts,
@@ -224,9 +221,6 @@ public class RegistryClientRequestAdapterFactory {
                                         cause.getMessage(),
                                         delayMs
                                 });
-                        System.out.println("[apicurio-pr9091] HTTP retry " + attempt + "/" + maxRetryAttempts
-                                + " sleepMs=" + delayMs + " err=" + cause.getClass().getSimpleName()
-                                + ": " + cause.getMessage());
                         try {
                             Thread.sleep(delayMs);
                         } catch (InterruptedException interruptedException) {
@@ -235,13 +229,9 @@ public class RegistryClientRequestAdapterFactory {
                         }
                     } else {
                         if (isRetryable(cause) && attempt >= maxRetryAttempts) {
-                            log.log(Level.WARNING, "Maximum retry attempts ({0}) exceeded for {1}: {2}",
+                            log.log(Level.WARNING,
+                                    "Registry HTTP client exhausted {0} retry attempts due to {1}: {2}",
                                     new Object[]{maxRetryAttempts, cause.getClass().getName(), cause.getMessage()});
-                            System.out.println("[apicurio-pr9091] HTTP retry EXHAUSTED maxAttempts="
-                                    + maxRetryAttempts + " last=" + cause.getMessage());
-                        } else if (!isRetryable(cause)) {
-                            System.out.println("[apicurio-pr9091] HTTP error NOT retryable: "
-                                    + cause.getClass().getName() + ": " + cause.getMessage());
                         }
                         throw originalCause;
                     }

--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
@@ -81,16 +81,8 @@ public class RegistryClientRequestAdapterFactory {
 
         adapter.setBaseUrl(registryUrl);
 
-        // Wrap with retry proxy if retry is enabled
+        // Wrap with retry proxy if retry is enabled (settings already logged at client creation).
         if (options.isRetryEnabled()) {
-            log.log(Level.FINE,
-                    "Enabling registry HTTP client retry: maxAttempts={0}, delayMs={1}, backoffMultiplier={2}, maxDelayMs={3}",
-                    new Object[]{
-                            options.getMaxRetryAttempts(),
-                            options.getRetryDelayMs(),
-                            options.getBackoffMultiplier(),
-                            options.getMaxRetryDelayMs()
-                    });
             adapter = createRetryProxy(adapter, options);
         }
 
@@ -229,9 +221,10 @@ public class RegistryClientRequestAdapterFactory {
                         }
                     } else {
                         if (isRetryable(cause) && attempt >= maxRetryAttempts) {
+                            String causeMessage = cause.getMessage() != null ? cause.getMessage() : "<no message>";
                             log.log(Level.WARNING,
                                     "Registry HTTP client exhausted {0} retry attempts due to {1}: {2}",
-                                    new Object[]{maxRetryAttempts, cause.getClass().getName(), cause.getMessage()});
+                                    new Object[]{maxRetryAttempts, cause.getClass().getName(), causeMessage});
                         }
                         throw originalCause;
                     }

--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
@@ -226,7 +226,11 @@ public class RegistryClientRequestAdapterFactory {
                                     "Registry HTTP client exhausted {0} retry attempts due to {1}: {2}",
                                     new Object[]{maxRetryAttempts, cause.getClass().getName(), causeMessage});
                         }
-                        throw originalCause;
+                        // Prefer the latest failure for caller diagnostics; keep the first as suppressed.
+                        if (originalCause != null && originalCause != cause) {
+                            cause.addSuppressed(originalCause);
+                        }
+                        throw cause;
                     }
                 }
             }

--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
@@ -83,6 +83,17 @@ public class RegistryClientRequestAdapterFactory {
 
         // Wrap with retry proxy if retry is enabled
         if (options.isRetryEnabled()) {
+            log.log(Level.INFO,
+                    "[apicurio-pr9091] wrapping RequestAdapter with retry maxAttempts={0} delayMs={1} backoff={2} maxDelayMs={3}",
+                    new Object[]{
+                            options.getMaxRetryAttempts(),
+                            options.getRetryDelayMs(),
+                            options.getBackoffMultiplier(),
+                            options.getMaxRetryDelayMs()
+                    });
+            System.out.println("[apicurio-pr9091] RequestAdapter retry proxy maxAttempts="
+                    + options.getMaxRetryAttempts()
+                    + " delayMs=" + options.getRetryDelayMs());
             adapter = createRetryProxy(adapter, options);
         }
 
@@ -204,6 +215,18 @@ public class RegistryClientRequestAdapterFactory {
                     if (isRetryable(cause) && attempt < maxRetryAttempts) {
                         attempt++;
                         long delayMs = calculateRetryDelay(attempt);
+                        log.log(Level.WARNING,
+                                "[apicurio-pr9091] HTTP retry {0}/{1} after {2}: {3}; sleeping {4}ms",
+                                new Object[]{
+                                        attempt,
+                                        maxRetryAttempts,
+                                        cause.getClass().getName(),
+                                        cause.getMessage(),
+                                        delayMs
+                                });
+                        System.out.println("[apicurio-pr9091] HTTP retry " + attempt + "/" + maxRetryAttempts
+                                + " sleepMs=" + delayMs + " err=" + cause.getClass().getSimpleName()
+                                + ": " + cause.getMessage());
                         try {
                             Thread.sleep(delayMs);
                         } catch (InterruptedException interruptedException) {
@@ -214,6 +237,11 @@ public class RegistryClientRequestAdapterFactory {
                         if (isRetryable(cause) && attempt >= maxRetryAttempts) {
                             log.log(Level.WARNING, "Maximum retry attempts ({0}) exceeded for {1}: {2}",
                                     new Object[]{maxRetryAttempts, cause.getClass().getName(), cause.getMessage()});
+                            System.out.println("[apicurio-pr9091] HTTP retry EXHAUSTED maxAttempts="
+                                    + maxRetryAttempts + " last=" + cause.getMessage());
+                        } else if (!isRetryable(cause)) {
+                            System.out.println("[apicurio-pr9091] HTTP error NOT retryable: "
+                                    + cause.getClass().getName() + ": " + cause.getMessage());
                         }
                         throw originalCause;
                     }

--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/RegistryClientRequestAdapterFactory.java
@@ -226,7 +226,9 @@ public class RegistryClientRequestAdapterFactory {
                                     "Registry HTTP client exhausted {0} retry attempts due to {1}: {2}",
                                     new Object[]{maxRetryAttempts, cause.getClass().getName(), causeMessage});
                         }
-                        // Prefer the latest failure for caller diagnostics; keep the first as suppressed.
+                        // Public behavior: throw the latest failure, not the first. Callers that
+                        // catch a specific type (e.g. HttpClosedException) may now see a later
+                        // type (e.g. ConnectException) with the first on getSuppressed().
                         if (originalCause != null && originalCause != cause) {
                             cause.addSuppressed(originalCause);
                         }

--- a/java-sdk/common/src/test/java/io/apicurio/registry/client/common/RegistryClientOptionsRetryDefaultsTest.java
+++ b/java-sdk/common/src/test/java/io/apicurio/registry/client/common/RegistryClientOptionsRetryDefaultsTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.client.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins {@link RegistryClientOptions#retry()} defaults so schema-resolver
+ * {@code CLIENT_RETRY_*_DEFAULT} values stay aligned when the enabled-with-defaults
+ * path passes explicit values instead of calling the no-arg {@code retry()}.
+ */
+class RegistryClientOptionsRetryDefaultsTest {
+
+    @Test
+    void retryNoArgDefaults() {
+        RegistryClientOptions options = RegistryClientOptions.create().retry();
+
+        assertTrue(options.isRetryEnabled());
+        assertEquals(3, options.getMaxRetryAttempts());
+        assertEquals(250L, options.getRetryDelayMs());
+        assertEquals(2.0d, options.getBackoffMultiplier());
+        assertEquals(10000L, options.getMaxRetryDelayMs());
+    }
+}

--- a/java-sdk/common/src/test/java/io/apicurio/registry/client/common/RegistryClientOptionsRetryDefaultsTest.java
+++ b/java-sdk/common/src/test/java/io/apicurio/registry/client/common/RegistryClientOptionsRetryDefaultsTest.java
@@ -19,6 +19,7 @@ package io.apicurio.registry.client.common;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -37,5 +38,11 @@ class RegistryClientOptionsRetryDefaultsTest {
         assertEquals(250L, options.getRetryDelayMs());
         assertEquals(2.0d, options.getBackoffMultiplier());
         assertEquals(10000L, options.getMaxRetryDelayMs());
+    }
+
+    @Test
+    void retryRejectsMultiplierOfOneSameAsSchemaResolverConfig() {
+        assertThrows(IllegalArgumentException.class,
+                () -> RegistryClientOptions.create().retry(true, 3, 250, 1.0, 10000));
     }
 }

--- a/java-sdk/common/src/test/java/io/apicurio/registry/client/common/RetryInvocationHandlerTest.java
+++ b/java-sdk/common/src/test/java/io/apicurio/registry/client/common/RetryInvocationHandlerTest.java
@@ -165,6 +165,37 @@ class RetryInvocationHandlerTest {
     }
 
     /**
+     * Exhausted retries with a different exception type on the last attempt must throw that
+     * last type (not the first), with the first attached as suppressed. Callers matching on
+     * the original failure class will see the latest class — a public SDK behavior change.
+     */
+    @Test
+    void testExhaustedRetriesThrowsLatestTypeNotOriginal() throws NoSuchMethodException {
+        AtomicInteger callCount = new AtomicInteger(0);
+        RequestAdapter adapter = throwingAdapter(() -> {
+            int n = callCount.incrementAndGet();
+            if (n == 1) {
+                throw new HttpClosedException("closed on first attempt");
+            }
+            throw new ConnectException("refused on attempt " + n);
+        });
+
+        var handler = new RegistryClientRequestAdapterFactory.RetryInvocationHandler(
+                adapter, MAX_RETRIES, NO_DELAY, BACKOFF, NO_MAX_DELAY);
+
+        Method method = RequestAdapter.class.getMethod("getBaseUrl");
+        // ConnectException is checked; StubRequestAdapter wraps it in RuntimeException.
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> handler.invoke(null, method, null),
+                "Should throw the latest attempt's exception, not the first HttpClosedException");
+
+        assertEquals(MAX_RETRIES + 1, callCount.get());
+        assertEquals(ConnectException.class, thrown.getCause().getClass());
+        assertEquals(1, thrown.getSuppressed().length);
+        assertEquals(HttpClosedException.class, thrown.getSuppressed()[0].getClass());
+    }
+
+    /**
      * Wrapped SocketTimeoutException should be retried.
      */
     @Test

--- a/java-sdk/common/src/test/java/io/apicurio/registry/client/common/RetryInvocationHandlerTest.java
+++ b/java-sdk/common/src/test/java/io/apicurio/registry/client/common/RetryInvocationHandlerTest.java
@@ -133,15 +133,16 @@ class RetryInvocationHandlerTest {
     }
 
     /**
-     * When all retry attempts are exhausted, the original exception should be thrown.
+     * When all retry attempts are exhausted, the latest exception should be thrown
+     * (with earlier failures available via {@link Throwable#getSuppressed()}).
      */
     @Test
-    void testExhaustedRetriesThrowsOriginalException() throws NoSuchMethodException {
+    void testExhaustedRetriesThrowsLatestException() throws NoSuchMethodException {
         AtomicInteger callCount = new AtomicInteger(0);
         RequestAdapter adapter = throwingAdapter(() -> {
-            callCount.incrementAndGet();
+            int n = callCount.incrementAndGet();
             throw new RuntimeException(
-                    new ExecutionException(new HttpClosedException("Connection was closed")));
+                    new ExecutionException(new HttpClosedException("closed on attempt " + n)));
         });
 
         var handler = new RegistryClientRequestAdapterFactory.RetryInvocationHandler(
@@ -156,6 +157,11 @@ class RetryInvocationHandlerTest {
                 "Should have been called initial + MAX_RETRIES times");
         assertEquals(ExecutionException.class, thrown.getCause().getClass(),
                 "Cause chain should be preserved");
+        assertEquals("closed on attempt " + (MAX_RETRIES + 1),
+                thrown.getCause().getCause().getMessage(),
+                "Should propagate the latest attempt's failure");
+        assertEquals(1, thrown.getSuppressed().length,
+                "First attempt failure should be suppressed on the latest");
     }
 
     /**

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
@@ -328,7 +328,7 @@ public abstract class AbstractSchemaResolver<S, T> implements SchemaResolver<S, 
                 break;
             }
             double next = step * multiplier;
-            if (!Double.isFinite(next) || next >= (double) maxDelayMs) {
+            if (!Double.isFinite(next) || next >= maxDelayMs) {
                 step = maxDelayMs;
             } else {
                 step = Math.max(1L, (long) next);

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
@@ -311,7 +311,7 @@ public abstract class AbstractSchemaResolver<S, T> implements SchemaResolver<S, 
         long maxDelayMs = config.getClientRetryMaxDelayMs();
         long sleepMs = 0L;
         for (long attempt = 1; attempt < maxAttempts; attempt++) {
-            long step = (long) (delayMs * Math.pow(multiplier, attempt - 1));
+            long step = (long) (delayMs * Math.pow(multiplier, (double) attempt - 1));
             sleepMs += Math.min(step, maxDelayMs);
         }
         return sleepMs;

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
@@ -297,8 +297,10 @@ public abstract class AbstractSchemaResolver<S, T> implements SchemaResolver<S, 
 
     /**
      * Lower-bound estimate of sleep time for one HTTP client retry ladder (excludes request latency).
+     * Closed form once the per-step delay hits {@code maxDelayMs}, so a large
+     * {@code max-attempts} cannot hang {@code configure()}.
      */
-    private static long estimateClientRetryLadderSleepMs(SchemaResolverConfig config) {
+    static long estimateClientRetryLadderSleepMs(SchemaResolverConfig config) {
         if (!config.getClientRetryEnabled()) {
             return 0L;
         }
@@ -307,13 +309,49 @@ public abstract class AbstractSchemaResolver<S, T> implements SchemaResolver<S, 
             return 0L;
         }
         long delayMs = config.getClientRetryDelayMs();
-        double multiplier = config.getClientRetryBackoffMultiplier();
         long maxDelayMs = config.getClientRetryMaxDelayMs();
+        if (delayMs <= 0L || maxDelayMs <= 0L) {
+            return 0L;
+        }
+        double multiplier = config.getClientRetryBackoffMultiplier();
+        long sleeps = maxAttempts - 1;
         long sleepMs = 0L;
-        for (long attempt = 1; attempt < maxAttempts; attempt++) {
-            long step = (long) (delayMs * Math.pow(multiplier, (double) attempt - 1));
-            sleepMs += Math.min(step, maxDelayMs);
+        long step = delayMs;
+        for (long i = 0; i < sleeps; i++) {
+            long capped = Math.min(step, maxDelayMs);
+            sleepMs = saturatingAdd(sleepMs, capped);
+            if (capped >= maxDelayMs) {
+                long remaining = sleeps - i - 1;
+                if (remaining > 0) {
+                    sleepMs = saturatingAdd(sleepMs, saturatingMul(remaining, maxDelayMs));
+                }
+                break;
+            }
+            double next = step * multiplier;
+            if (!Double.isFinite(next) || next >= (double) maxDelayMs) {
+                step = maxDelayMs;
+            } else {
+                step = Math.max(1L, (long) next);
+            }
         }
         return sleepMs;
+    }
+
+    private static long saturatingAdd(long a, long b) {
+        long r = a + b;
+        if (((a ^ r) & (b ^ r)) < 0) {
+            return Long.MAX_VALUE;
+        }
+        return r;
+    }
+
+    private static long saturatingMul(long a, long b) {
+        if (a == 0L || b == 0L) {
+            return 0L;
+        }
+        if (a > Long.MAX_VALUE / b) {
+            return Long.MAX_VALUE;
+        }
+        return a * b;
     }
 }

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
@@ -60,6 +60,8 @@ public abstract class AbstractSchemaResolver<S, T> implements SchemaResolver<S, 
         schemaCache.configureRetryBackoff(config.getRetryBackoff());
         schemaCache.configureRetryCount(config.getRetryCount());
         schemaCache.configureRetryTransientErrors(config.getRetryTransientErrors());
+        schemaCache.configureRetryTotalTimeout(config.getRetryTotalTimeout());
+        schemaCache.warnIfRetryBudgetUnbounded(estimateClientRetryLadderSleepMs(config));
         schemaCache.configureCacheLatest(config.getCacheLatest());
         schemaCache.configureFaultTolerantRefresh(config.getFaultTolerantRefresh());
         schemaCache.configureBackgroundRefresh(config.getBackgroundRefresh());
@@ -291,5 +293,27 @@ public abstract class AbstractSchemaResolver<S, T> implements SchemaResolver<S, 
                 .parsedSchema(parsedSchema)
                 .references(references)
                 .build();
+    }
+
+    /**
+     * Lower-bound estimate of sleep time for one HTTP client retry ladder (excludes request latency).
+     */
+    private static long estimateClientRetryLadderSleepMs(SchemaResolverConfig config) {
+        if (!config.getClientRetryEnabled()) {
+            return 0L;
+        }
+        long maxAttempts = config.getClientRetryMaxAttempts();
+        if (maxAttempts <= 1) {
+            return 0L;
+        }
+        long delayMs = config.getClientRetryDelayMs();
+        double multiplier = config.getClientRetryBackoffMultiplier();
+        long maxDelayMs = config.getClientRetryMaxDelayMs();
+        long sleepMs = 0L;
+        for (long attempt = 1; attempt < maxAttempts; attempt++) {
+            long step = (long) (delayMs * Math.pow(multiplier, attempt - 1));
+            sleepMs += Math.min(step, maxDelayMs);
+        }
+        return sleepMs;
     }
 }

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/AbstractSchemaResolver.java
@@ -59,6 +59,7 @@ public abstract class AbstractSchemaResolver<S, T> implements SchemaResolver<S, 
         schemaCache.configureLifetime(config.getCheckPeriod());
         schemaCache.configureRetryBackoff(config.getRetryBackoff());
         schemaCache.configureRetryCount(config.getRetryCount());
+        schemaCache.configureRetryTransientErrors(config.getRetryTransientErrors());
         schemaCache.configureCacheLatest(config.getCacheLatest());
         schemaCache.configureFaultTolerantRefresh(config.getFaultTolerantRefresh());
         schemaCache.configureBackgroundRefresh(config.getBackgroundRefresh());

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
@@ -438,7 +438,9 @@ public class ERCache<V> {
                             "Could not retrieve schema for the cache. " + "Loading function returned null."));
                 }
             } catch (RuntimeException e) {
-                // Retry rate-limits (429) and transient network / registry-down failures.
+                // Schema-cache retries compose with the HTTP client retry layer
+                // (apicurio.registry.client.retry.*). Each cache attempt may run a full
+                // client retry ladder before returning here.
                 if (i == retries || !isRetriableCacheLoadFailure(e)) {
                     log.error("Schema cache load failed after {} retries", i, e);
                     return Result.error(new RuntimeException(e));
@@ -456,45 +458,82 @@ public class ERCache<V> {
         return Result.error(new IllegalStateException("Unreachable."));
     }
 
-    /**
-     * Whether a schema-cache load failure should be retried: HTTP 429, connection
-     * failures, timeouts, connection resets, and Vert.x HTTP closed errors.
-     */
     private static final Class<?> VERTX_HTTP_CLOSED_EXCEPTION;
+    private static final Class<?> VERTX_EXCEPTION;
 
     static {
-        Class<?> cls = null;
+        Class<?> httpClosed = null;
+        Class<?> vertxException = null;
         try {
-            cls = Class.forName("io.vertx.core.http.HttpClosedException", false,
+            httpClosed = Class.forName("io.vertx.core.http.HttpClosedException", false,
                     ERCache.class.getClassLoader());
         } catch (ClassNotFoundException ignored) {
             // Vert.x may not be on the classpath for all consumers.
         }
-        VERTX_HTTP_CLOSED_EXCEPTION = cls;
+        try {
+            vertxException = Class.forName("io.vertx.core.VertxException", false,
+                    ERCache.class.getClassLoader());
+        } catch (ClassNotFoundException ignored) {
+            // Vert.x may not be on the classpath for all consumers.
+        }
+        VERTX_HTTP_CLOSED_EXCEPTION = httpClosed;
+        VERTX_EXCEPTION = vertxException;
     }
 
-    private static boolean isRetriableCacheLoadFailure(Throwable e) {
+    /**
+     * Whether a schema-cache load failure should be retried.
+     * <p>
+     * Retriable cases:
+     * <ul>
+     *   <li>HTTP 429 (rate limit) and 502/503/504 (typical registry outage / LB responses)</li>
+     *   <li>{@link java.net.SocketException} (connection refused / reset; covers
+     *       {@link java.net.ConnectException})</li>
+     *   <li>{@link java.net.SocketTimeoutException} (JDK HTTP timeouts)</li>
+     *   <li>Vert.x {@code HttpClosedException}</li>
+     *   <li>Vert.x {@code VertxException} whose message or class name indicates a timeout
+     *       (for example {@code NoStackTraceTimeoutException})</li>
+     * </ul>
+     * Other {@link ApiException} status codes (for example 404/500) are not retried so
+     * genuine application errors fail fast.
+     */
+    static boolean isRetriableCacheLoadFailure(Throwable e) {
         Throwable current = e;
         while (current != null) {
-            if (current instanceof ApiException api && api.getResponseStatusCode() == 429) {
+            if (current instanceof ApiException api && isRetriableHttpStatus(api.getResponseStatusCode())) {
                 return true;
             }
-            if (current instanceof java.net.ConnectException) {
+            // Covers ConnectException and connection-reset SocketExceptions without
+            // matching JDK-specific message text.
+            if (current instanceof java.net.SocketException) {
                 return true;
             }
             if (current instanceof java.net.SocketTimeoutException) {
                 return true;
             }
-            if (current instanceof java.io.IOException io && io.getMessage() != null
-                    && io.getMessage().contains("Connection reset")) {
+            if (VERTX_HTTP_CLOSED_EXCEPTION != null && VERTX_HTTP_CLOSED_EXCEPTION.isInstance(current)) {
                 return true;
             }
-            if (VERTX_HTTP_CLOSED_EXCEPTION != null && VERTX_HTTP_CLOSED_EXCEPTION.isInstance(current)) {
+            if (isVertxTimeout(current)) {
                 return true;
             }
             current = current.getCause();
         }
         return false;
+    }
+
+    private static boolean isRetriableHttpStatus(int statusCode) {
+        return statusCode == 429 || statusCode == 502 || statusCode == 503 || statusCode == 504;
+    }
+
+    private static boolean isVertxTimeout(Throwable current) {
+        if (VERTX_EXCEPTION == null || !VERTX_EXCEPTION.isInstance(current)) {
+            return false;
+        }
+        String message = current.getMessage();
+        if (message == null) {
+            return current.getClass().getSimpleName().toLowerCase().contains("timeout");
+        }
+        return message.toLowerCase().contains("timeout");
     }
 
     private static String rootMessage(Throwable e) {

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
@@ -46,6 +46,7 @@ public class ERCache<V> {
     private Duration backoff = Duration.ofMillis(200);
     private long retries;
     private boolean retryTransientErrors;
+    private Duration retryTotalTimeout = Duration.ZERO;
     private boolean cacheLatest;
     private boolean faultTolerantRefresh;
     private boolean backgroundRefresh;
@@ -77,6 +78,41 @@ public class ERCache<V> {
      */
     public void configureRetryTransientErrors(boolean retryTransientErrors) {
         this.retryTransientErrors = retryTransientErrors;
+    }
+
+    /**
+     * Optional wall-clock budget for one cache-load retry loop. {@link Duration#ZERO} means unlimited.
+     */
+    public void configureRetryTotalTimeout(Duration retryTotalTimeout) {
+        if (retryTotalTimeout == null || retryTotalTimeout.isNegative()) {
+            throw new IllegalArgumentException("Retry total timeout must be non-negative");
+        }
+        this.retryTotalTimeout = retryTotalTimeout;
+    }
+
+    /**
+     * Emits a WARNING when transient retries are enabled without a total timeout and the estimated
+     * sleep-only worst case already exceeds a few seconds.
+     *
+     * @param estimatedClientLadderSleepMs lower-bound estimate of one HTTP client retry ladder's sleeps
+     */
+    public void warnIfRetryBudgetUnbounded(long estimatedClientLadderSleepMs) {
+        if (!retryTransientErrors) {
+            return;
+        }
+        if (!retryTotalTimeout.isZero()) {
+            return;
+        }
+        long estimateMs = (retries + 1) * Math.max(0L, estimatedClientLadderSleepMs)
+                + retries * backoff.toMillis();
+        if (estimateMs < 5_000L) {
+            return;
+        }
+        log.warn("apicurio.registry.retry.transient-errors is enabled without "
+                + "apicurio.registry.retry.total-timeout-ms; estimated sleep-only worst case for one "
+                + "schema-cache load is ~{}ms (retry-count={}, client-ladder-sleep~{}ms, "
+                + "retry-backoff-ms={}). Set total-timeout-ms to bound blocking on Producer.send()/Connect poll.",
+                estimateMs, retries, estimatedClientLadderSleepMs, backoff.toMillis());
     }
 
     /**
@@ -363,7 +399,8 @@ public class ERCache<V> {
      * @return Result containing either the refreshed value or an exception
      */
     private <T> Result<V, RuntimeException> performRefresh(T key, Function<T, V> loaderFunction) {
-        Result<V, RuntimeException> newValue = retry(backoff, retries, retryTransientErrors, () -> {
+        Result<V, RuntimeException> newValue = retry(backoff, retries, retryTransientErrors, retryTotalTimeout,
+                () -> {
             return loaderFunction.apply(key);
         });
         if (newValue.isOk()) {
@@ -434,11 +471,15 @@ public class ERCache<V> {
     }
 
     static <T> Result<T, RuntimeException> retry(Duration backoff, long retries,
-                                                 boolean retryTransientErrors, Supplier<T> supplier) {
+                                                 boolean retryTransientErrors, Duration totalTimeout,
+                                                 Supplier<T> supplier) {
         if (retries < 0)
             throw new IllegalArgumentException();
         Objects.requireNonNull(supplier);
         Objects.requireNonNull(backoff);
+        Objects.requireNonNull(totalTimeout);
+
+        Instant deadline = totalTimeout.isZero() ? null : Instant.now().plus(totalTimeout);
 
         for (long i = 0; i <= retries; i++) {
             try {
@@ -453,10 +494,19 @@ public class ERCache<V> {
                 // Schema-cache retries compose with the HTTP client retry layer
                 // (apicurio.registry.client.retry.*). Each cache attempt may run a full
                 // client retry ladder before returning here. Widened (non-429) retries are
-                // opt-in via apicurio.registry.retry.transient-errors; see SchemaResolverConfig.
+                // opt-in via apicurio.registry.retry.transient-errors; bound with
+                // apicurio.registry.retry.total-timeout-ms.
                 if (i == retries || !isRetriableCacheLoadFailure(e, retryTransientErrors)) {
                     log.error("Schema cache load failed after {} retries", i, e);
                     return Result.error(new RuntimeException(e));
+                }
+                if (deadline != null && !Instant.now().isBefore(deadline)) {
+                    log.error("Schema cache load exceeded total retry timeout of {}ms after {} attempts",
+                            totalTimeout.toMillis(), i + 1, e);
+                    return Result.error(new RuntimeException(
+                            "Schema cache load exceeded total retry timeout of " + totalTimeout.toMillis()
+                                    + "ms",
+                            e));
                 }
                 log.debug("Schema cache load attempt {}/{} failed with retriable error; backing off {}ms: {}",
                         i + 1, retries + 1, backoff.toMillis(), rootMessage(e));
@@ -467,8 +517,20 @@ public class ERCache<V> {
                 log.debug("Cache retry backoff interrupted", e);
                 Thread.currentThread().interrupt();
             }
+            if (deadline != null && !Instant.now().isBefore(deadline)) {
+                log.error("Schema cache load exceeded total retry timeout of {}ms during backoff",
+                        totalTimeout.toMillis());
+                return Result.error(new RuntimeException(
+                        "Schema cache load exceeded total retry timeout of " + totalTimeout.toMillis() + "ms"));
+            }
         }
         return Result.error(new IllegalStateException("Unreachable."));
+    }
+
+    /** Convenience overload used by tests that do not set a total timeout. */
+    static <T> Result<T, RuntimeException> retry(Duration backoff, long retries,
+                                                 boolean retryTransientErrors, Supplier<T> supplier) {
+        return retry(backoff, retries, retryTransientErrors, Duration.ZERO, supplier);
     }
 
     /** Max cause-chain depth when classifying failures (guards against cyclic causes). */
@@ -482,13 +544,14 @@ public class ERCache<V> {
      * When {@code retryTransientErrors} is {@code true}, also retriable:
      * <ul>
      *   <li>HTTP 502/503/504 (typical registry outage / LB responses)</li>
-     *   <li>{@link java.net.ConnectException} and other {@link java.net.SocketException}s except
-     *       resource-exhaustion / unreachable-route cases</li>
+     *   <li>{@link java.net.ConnectException}, {@link java.net.NoRouteToHostException}, and other
+     *       {@link java.net.SocketException}s except resource-exhaustion cases
+     *       ("too many open files", "no buffer space")</li>
      *   <li>{@link java.net.SocketTimeoutException} (JDK HTTP timeouts)</li>
      *   <li>{@link HttpClosedException}</li>
-     *   <li>{@link VertxException} whose message or class name indicates a timeout
-     *       (for example {@code NoStackTraceTimeoutException}; message matching is
-     *       brittle across Vert.x versions and may false-negative)</li>
+     *   <li>{@link VertxException} subclasses whose simple class name contains {@code timeout}
+     *       (for example {@code NoStackTraceTimeoutException}), with message matching only as a
+     *       fallback</li>
      * </ul>
      * If any {@link ApiException} with a non-null status code appears in the cause chain, that status
      * decides and network matching is skipped (so a 404/500 above a {@code SocketException} is not
@@ -534,7 +597,7 @@ public class ERCache<V> {
                 return true;
             }
             if (current instanceof java.net.SocketException socketException
-                    && !isNonRetriableSocketException(socketException)) {
+                    && !isResourceExhaustionSocketException(socketException)) {
                 return true;
             }
             current = current.getCause();
@@ -542,10 +605,7 @@ public class ERCache<V> {
         return false;
     }
 
-    private static boolean isNonRetriableSocketException(java.net.SocketException exception) {
-        if (exception instanceof java.net.NoRouteToHostException) {
-            return true;
-        }
+    private static boolean isResourceExhaustionSocketException(java.net.SocketException exception) {
         String message = exception.getMessage();
         if (message == null) {
             return false;
@@ -566,11 +626,14 @@ public class ERCache<V> {
         if (!(current instanceof VertxException)) {
             return false;
         }
-        String message = current.getMessage();
-        if (message == null) {
-            return current.getClass().getSimpleName().toLowerCase(java.util.Locale.ROOT).contains("timeout");
+        // Prefer class-name checks (NoStackTraceTimeoutException, ConnectTimeoutException, …)
+        // over message text, which Vert.x may reword across versions.
+        String simpleName = current.getClass().getSimpleName().toLowerCase(java.util.Locale.ROOT);
+        if (simpleName.contains("timeout")) {
+            return true;
         }
-        return message.toLowerCase(java.util.Locale.ROOT).contains("timeout");
+        String message = current.getMessage();
+        return message != null && message.toLowerCase(java.util.Locale.ROOT).contains("timeout");
     }
 
     private static String rootMessage(Throwable e) {

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
@@ -438,15 +438,15 @@ public class ERCache<V> {
                             "Could not retrieve schema for the cache. " + "Loading function returned null."));
                 }
             } catch (RuntimeException e) {
-                // TODO: verify if this is really needed, retries are already baked into the adapter ...
-                // if (i == retries || !(e.getCause() != null && e.getCause() instanceof ExecutionException
-                // && e.getCause().getCause() != null && e.getCause().getCause() instanceof ApiException
-                // && (((ApiException) e.getCause().getCause()).getResponseStatusCode() == 429)))
-                if (i == retries || !(e.getCause() != null && e.getCause() instanceof ApiException
-                        && (((ApiException) e.getCause()).getResponseStatusCode() == 429))) {
-                    log.error("Cache load failed after {} retries", i, e);
+                // Lab: retry rate-limits AND registry outages (connect refused / timeouts).
+                // Stock Apicurio only retried HTTP 429 here.
+                if (i == retries || !isRetriableCacheLoadFailure(e)) {
+                    log.error("Cache load failed after {} retries (retriable={})", i,
+                            isRetriableCacheLoadFailure(e), e);
                     return Result.error(new RuntimeException(e));
                 }
+                log.warn("Cache load attempt {}/{} failed with retriable error, backing off {}ms: {}",
+                        i + 1, retries + 1, backoff.toMillis(), rootMessage(e));
             }
             try {
                 Thread.sleep(backoff.toMillis());
@@ -456,6 +456,43 @@ public class ERCache<V> {
             }
         }
         return Result.error(new IllegalStateException("Unreachable."));
+    }
+
+    /**
+     * Retriable = rate-limit (429) OR transient network / registry-down errors.
+     * Stock upstream only treated 429 as retriable.
+     */
+    private static boolean isRetriableCacheLoadFailure(Throwable e) {
+        Throwable current = e;
+        while (current != null) {
+            if (current instanceof ApiException
+                    && ((ApiException) current).getResponseStatusCode() == 429) {
+                return true;
+            }
+            if (current instanceof java.net.ConnectException) {
+                return true;
+            }
+            if (current instanceof java.net.SocketTimeoutException) {
+                return true;
+            }
+            if (current instanceof java.io.IOException && current.getMessage() != null
+                    && current.getMessage().contains("Connection reset")) {
+                return true;
+            }
+            if ("io.vertx.core.http.HttpClosedException".equals(current.getClass().getName())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static String rootMessage(Throwable e) {
+        Throwable current = e;
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current.getClass().getSimpleName() + ": " + current.getMessage();
     }
 
     private static class WrappedValue<V> {

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
@@ -45,6 +45,7 @@ public class ERCache<V> {
     private Duration lifetime = Duration.ZERO;
     private Duration backoff = Duration.ofMillis(200);
     private long retries;
+    private boolean retryTransientErrors;
     private boolean cacheLatest;
     private boolean faultTolerantRefresh;
     private boolean backgroundRefresh;
@@ -67,6 +68,15 @@ public class ERCache<V> {
 
     public void configureRetryCount(long retries) {
         this.retries = retries;
+    }
+
+    /**
+     * When {@code true}, schema-cache loads also retry network/outage failures (502/503/504 and
+     * retriable socket errors) in addition to HTTP 429. Default {@code false} preserves historical
+     * 429-only cache retries so existing deployments do not silently gain multiplicative blocking.
+     */
+    public void configureRetryTransientErrors(boolean retryTransientErrors) {
+        this.retryTransientErrors = retryTransientErrors;
     }
 
     /**
@@ -353,7 +363,7 @@ public class ERCache<V> {
      * @return Result containing either the refreshed value or an exception
      */
     private <T> Result<V, RuntimeException> performRefresh(T key, Function<T, V> loaderFunction) {
-        Result<V, RuntimeException> newValue = retry(backoff, retries, () -> {
+        Result<V, RuntimeException> newValue = retry(backoff, retries, retryTransientErrors, () -> {
             return loaderFunction.apply(key);
         });
         if (newValue.isOk()) {
@@ -423,8 +433,8 @@ public class ERCache<V> {
         return refreshExecutor;
     }
 
-    private static <T> Result<T, RuntimeException> retry(Duration backoff, long retries,
-                                                         Supplier<T> supplier) {
+    static <T> Result<T, RuntimeException> retry(Duration backoff, long retries,
+                                                 boolean retryTransientErrors, Supplier<T> supplier) {
         if (retries < 0)
             throw new IllegalArgumentException();
         Objects.requireNonNull(supplier);
@@ -442,9 +452,9 @@ public class ERCache<V> {
             } catch (RuntimeException e) {
                 // Schema-cache retries compose with the HTTP client retry layer
                 // (apicurio.registry.client.retry.*). Each cache attempt may run a full
-                // client retry ladder before returning here; there is no overall deadline,
-                // so worst-case blocking is multiplicative (see SchemaResolverConfig docs).
-                if (i == retries || !isRetriableCacheLoadFailure(e)) {
+                // client retry ladder before returning here. Widened (non-429) retries are
+                // opt-in via apicurio.registry.retry.transient-errors; see SchemaResolverConfig.
+                if (i == retries || !isRetriableCacheLoadFailure(e, retryTransientErrors)) {
                     log.error("Schema cache load failed after {} retries", i, e);
                     return Result.error(new RuntimeException(e));
                 }
@@ -461,41 +471,59 @@ public class ERCache<V> {
         return Result.error(new IllegalStateException("Unreachable."));
     }
 
+    /** Max cause-chain depth when classifying failures (guards against cyclic causes). */
+    static final int MAX_CAUSE_DEPTH = 32;
+
     /**
      * Whether a schema-cache load failure should be retried.
      * <p>
-     * Retriable cases:
+     * Always retriable: HTTP 429 (rate limit).
+     * <p>
+     * When {@code retryTransientErrors} is {@code true}, also retriable:
      * <ul>
-     *   <li>HTTP 429 (rate limit) and 502/503/504 (typical registry outage / LB responses)</li>
-     *   <li>{@link java.net.SocketException} (connection refused / reset; covers
-     *       {@link java.net.ConnectException}). Note this also matches broader socket
-     *       failures such as resource exhaustion ("Too many open files") or
-     *       "Network is unreachable", which will then consume the full retry ladder.</li>
+     *   <li>HTTP 502/503/504 (typical registry outage / LB responses)</li>
+     *   <li>{@link java.net.ConnectException} and other {@link java.net.SocketException}s except
+     *       resource-exhaustion / unreachable-route cases</li>
      *   <li>{@link java.net.SocketTimeoutException} (JDK HTTP timeouts)</li>
      *   <li>{@link HttpClosedException}</li>
      *   <li>{@link VertxException} whose message or class name indicates a timeout
      *       (for example {@code NoStackTraceTimeoutException}; message matching is
      *       brittle across Vert.x versions and may false-negative)</li>
      * </ul>
-     * Other {@link ApiException} status codes (for example 404/500) are not retried so
-     * genuine application errors fail fast. An {@link ApiException} with a null status
-     * code is treated as non-retriable (not as an NPE).
+     * If any {@link ApiException} with a non-null status code appears in the cause chain, that status
+     * decides and network matching is skipped (so a 404/500 above a {@code SocketException} is not
+     * retried). An {@link ApiException} with a null status code is ignored for the status decision.
      */
+    static boolean isRetriableCacheLoadFailure(Throwable e, boolean retryTransientErrors) {
+        Integer apiStatus = findFirstApiResponseStatus(e);
+        if (apiStatus != null) {
+            return isRetriableHttpStatus(apiStatus, retryTransientErrors);
+        }
+        return retryTransientErrors && hasRetriableNetworkFailure(e);
+    }
+
+    /** Backward-compatible overload used by older call sites/tests; transient retries disabled. */
     static boolean isRetriableCacheLoadFailure(Throwable e) {
+        return isRetriableCacheLoadFailure(e, false);
+    }
+
+    private static Integer findFirstApiResponseStatus(Throwable e) {
         Throwable current = e;
-        while (current != null) {
+        for (int depth = 0; current != null && depth < MAX_CAUSE_DEPTH; depth++) {
             if (current instanceof ApiException api) {
                 Integer code = api.getResponseStatusCode();
-                if (code != null && isRetriableHttpStatus(code)) {
-                    return true;
+                if (code != null) {
+                    return code;
                 }
             }
-            // Covers ConnectException and connection-reset SocketExceptions without
-            // matching JDK-specific message text. Also matches unrelated SocketExceptions
-            // (fd exhaustion, unreachable network); see class javadoc above.
-            if (current instanceof java.net.SocketException) {
-                return true;
-            }
+            current = current.getCause();
+        }
+        return null;
+    }
+
+    private static boolean hasRetriableNetworkFailure(Throwable e) {
+        Throwable current = e;
+        for (int depth = 0; current != null && depth < MAX_CAUSE_DEPTH; depth++) {
             if (current instanceof java.net.SocketTimeoutException) {
                 return true;
             }
@@ -505,13 +533,33 @@ public class ERCache<V> {
             if (isVertxTimeout(current)) {
                 return true;
             }
+            if (current instanceof java.net.SocketException socketException
+                    && !isNonRetriableSocketException(socketException)) {
+                return true;
+            }
             current = current.getCause();
         }
         return false;
     }
 
-    private static boolean isRetriableHttpStatus(int statusCode) {
-        return statusCode == 429 || statusCode == 502 || statusCode == 503 || statusCode == 504;
+    private static boolean isNonRetriableSocketException(java.net.SocketException exception) {
+        if (exception instanceof java.net.NoRouteToHostException) {
+            return true;
+        }
+        String message = exception.getMessage();
+        if (message == null) {
+            return false;
+        }
+        String lower = message.toLowerCase(java.util.Locale.ROOT);
+        return lower.contains("too many open files") || lower.contains("no buffer space");
+    }
+
+    private static boolean isRetriableHttpStatus(int statusCode, boolean retryTransientErrors) {
+        if (statusCode == 429) {
+            return true;
+        }
+        return retryTransientErrors
+                && (statusCode == 502 || statusCode == 503 || statusCode == 504);
     }
 
     private static boolean isVertxTimeout(Throwable current) {
@@ -520,14 +568,14 @@ public class ERCache<V> {
         }
         String message = current.getMessage();
         if (message == null) {
-            return current.getClass().getSimpleName().toLowerCase().contains("timeout");
+            return current.getClass().getSimpleName().toLowerCase(java.util.Locale.ROOT).contains("timeout");
         }
-        return message.toLowerCase().contains("timeout");
+        return message.toLowerCase(java.util.Locale.ROOT).contains("timeout");
     }
 
     private static String rootMessage(Throwable e) {
         Throwable current = e;
-        while (current.getCause() != null) {
+        for (int depth = 0; current.getCause() != null && depth < MAX_CAUSE_DEPTH; depth++) {
             current = current.getCause();
         }
         return current.getClass().getSimpleName() + ": " + current.getMessage();

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
@@ -3,6 +3,8 @@ package io.apicurio.registry.resolver.cache;
 import com.microsoft.kiota.ApiException;
 import io.apicurio.registry.resolver.config.SchemaResolverConfig;
 import io.apicurio.registry.resolver.strategy.ArtifactCoordinates;
+import io.vertx.core.VertxException;
+import io.vertx.core.http.HttpClosedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -440,7 +442,8 @@ public class ERCache<V> {
             } catch (RuntimeException e) {
                 // Schema-cache retries compose with the HTTP client retry layer
                 // (apicurio.registry.client.retry.*). Each cache attempt may run a full
-                // client retry ladder before returning here.
+                // client retry ladder before returning here; there is no overall deadline,
+                // so worst-case blocking is multiplicative (see SchemaResolverConfig docs).
                 if (i == retries || !isRetriableCacheLoadFailure(e)) {
                     log.error("Schema cache load failed after {} retries", i, e);
                     return Result.error(new RuntimeException(e));
@@ -458,28 +461,6 @@ public class ERCache<V> {
         return Result.error(new IllegalStateException("Unreachable."));
     }
 
-    private static final Class<?> VERTX_HTTP_CLOSED_EXCEPTION;
-    private static final Class<?> VERTX_EXCEPTION;
-
-    static {
-        Class<?> httpClosed = null;
-        Class<?> vertxException = null;
-        try {
-            httpClosed = Class.forName("io.vertx.core.http.HttpClosedException", false,
-                    ERCache.class.getClassLoader());
-        } catch (ClassNotFoundException ignored) {
-            // Vert.x may not be on the classpath for all consumers.
-        }
-        try {
-            vertxException = Class.forName("io.vertx.core.VertxException", false,
-                    ERCache.class.getClassLoader());
-        } catch (ClassNotFoundException ignored) {
-            // Vert.x may not be on the classpath for all consumers.
-        }
-        VERTX_HTTP_CLOSED_EXCEPTION = httpClosed;
-        VERTX_EXCEPTION = vertxException;
-    }
-
     /**
      * Whether a schema-cache load failure should be retried.
      * <p>
@@ -487,30 +468,38 @@ public class ERCache<V> {
      * <ul>
      *   <li>HTTP 429 (rate limit) and 502/503/504 (typical registry outage / LB responses)</li>
      *   <li>{@link java.net.SocketException} (connection refused / reset; covers
-     *       {@link java.net.ConnectException})</li>
+     *       {@link java.net.ConnectException}). Note this also matches broader socket
+     *       failures such as resource exhaustion ("Too many open files") or
+     *       "Network is unreachable", which will then consume the full retry ladder.</li>
      *   <li>{@link java.net.SocketTimeoutException} (JDK HTTP timeouts)</li>
-     *   <li>Vert.x {@code HttpClosedException}</li>
-     *   <li>Vert.x {@code VertxException} whose message or class name indicates a timeout
-     *       (for example {@code NoStackTraceTimeoutException})</li>
+     *   <li>{@link HttpClosedException}</li>
+     *   <li>{@link VertxException} whose message or class name indicates a timeout
+     *       (for example {@code NoStackTraceTimeoutException}; message matching is
+     *       brittle across Vert.x versions and may false-negative)</li>
      * </ul>
      * Other {@link ApiException} status codes (for example 404/500) are not retried so
-     * genuine application errors fail fast.
+     * genuine application errors fail fast. An {@link ApiException} with a null status
+     * code is treated as non-retriable (not as an NPE).
      */
     static boolean isRetriableCacheLoadFailure(Throwable e) {
         Throwable current = e;
         while (current != null) {
-            if (current instanceof ApiException api && isRetriableHttpStatus(api.getResponseStatusCode())) {
-                return true;
+            if (current instanceof ApiException api) {
+                Integer code = api.getResponseStatusCode();
+                if (code != null && isRetriableHttpStatus(code)) {
+                    return true;
+                }
             }
             // Covers ConnectException and connection-reset SocketExceptions without
-            // matching JDK-specific message text.
+            // matching JDK-specific message text. Also matches unrelated SocketExceptions
+            // (fd exhaustion, unreachable network); see class javadoc above.
             if (current instanceof java.net.SocketException) {
                 return true;
             }
             if (current instanceof java.net.SocketTimeoutException) {
                 return true;
             }
-            if (VERTX_HTTP_CLOSED_EXCEPTION != null && VERTX_HTTP_CLOSED_EXCEPTION.isInstance(current)) {
+            if (current instanceof HttpClosedException) {
                 return true;
             }
             if (isVertxTimeout(current)) {
@@ -526,7 +515,7 @@ public class ERCache<V> {
     }
 
     private static boolean isVertxTimeout(Throwable current) {
-        if (VERTX_EXCEPTION == null || !VERTX_EXCEPTION.isInstance(current)) {
+        if (!(current instanceof VertxException)) {
             return false;
         }
         String message = current.getMessage();

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
@@ -495,10 +495,13 @@ public class ERCache<V> {
                 if (failure != null) {
                     return failure;
                 }
-            }
-            if (sleepBackoffOrTimeout(backoff, deadline, totalTimeout)) {
-                return Result.error(new RuntimeException(
-                        "Schema cache load exceeded total retry timeout of " + totalTimeout.toMillis() + "ms"));
+                if (sleepBackoffOrTimeout(backoff, deadline)) {
+                    log.error("Schema cache load exceeded total retry timeout of {}ms during backoff",
+                            totalTimeout.toMillis(), e);
+                    return Result.error(new RuntimeException(
+                            "Schema cache load exceeded total retry timeout of " + totalTimeout.toMillis() + "ms",
+                            e));
+                }
             }
         }
         return Result.error(new IllegalStateException("Unreachable."));
@@ -533,19 +536,14 @@ public class ERCache<V> {
     /**
      * @return {@code true} if the total timeout was exceeded during/after backoff
      */
-    private static boolean sleepBackoffOrTimeout(Duration backoff, Instant deadline, Duration totalTimeout) {
+    private static boolean sleepBackoffOrTimeout(Duration backoff, Instant deadline) {
         try {
             Thread.sleep(backoff.toMillis());
         } catch (InterruptedException e) {
             log.debug("Cache retry backoff interrupted", e);
             Thread.currentThread().interrupt();
         }
-        if (isDeadlineExceeded(deadline)) {
-            log.error("Schema cache load exceeded total retry timeout of {}ms during backoff",
-                    totalTimeout.toMillis());
-            return true;
-        }
-        return false;
+        return isDeadlineExceeded(deadline);
     }
 
     private static boolean isDeadlineExceeded(Instant deadline) {

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
@@ -438,14 +438,12 @@ public class ERCache<V> {
                             "Could not retrieve schema for the cache. " + "Loading function returned null."));
                 }
             } catch (RuntimeException e) {
-                // Lab: retry rate-limits AND registry outages (connect refused / timeouts).
-                // Stock Apicurio only retried HTTP 429 here.
+                // Retry rate-limits (429) and transient network / registry-down failures.
                 if (i == retries || !isRetriableCacheLoadFailure(e)) {
-                    log.error("Cache load failed after {} retries (retriable={})", i,
-                            isRetriableCacheLoadFailure(e), e);
+                    log.error("Schema cache load failed after {} retries", i, e);
                     return Result.error(new RuntimeException(e));
                 }
-                log.warn("Cache load attempt {}/{} failed with retriable error, backing off {}ms: {}",
+                log.debug("Schema cache load attempt {}/{} failed with retriable error; backing off {}ms: {}",
                         i + 1, retries + 1, backoff.toMillis(), rootMessage(e));
             }
             try {
@@ -459,8 +457,8 @@ public class ERCache<V> {
     }
 
     /**
-     * Retriable = rate-limit (429) OR transient network / registry-down errors.
-     * Stock upstream only treated 429 as retriable.
+     * Whether a schema-cache load failure should be retried: HTTP 429, connection
+     * failures, timeouts, connection resets, and Vert.x HTTP closed errors.
      */
     private static boolean isRetriableCacheLoadFailure(Throwable e) {
         Throwable current = e;

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
@@ -484,47 +484,72 @@ public class ERCache<V> {
         for (long i = 0; i <= retries; i++) {
             try {
                 T value = supplier.get();
-                if (value != null)
-                    return Result.ok(value);
-                else {
+                if (value == null) {
                     return Result.error(new NullPointerException(
                             "Could not retrieve schema for the cache. " + "Loading function returned null."));
                 }
+                return Result.ok(value);
             } catch (RuntimeException e) {
-                // Schema-cache retries compose with the HTTP client retry layer
-                // (apicurio.registry.client.retry.*). Each cache attempt may run a full
-                // client retry ladder before returning here. Widened (non-429) retries are
-                // opt-in via apicurio.registry.retry.transient-errors; bound with
-                // apicurio.registry.retry.total-timeout-ms.
-                if (i == retries || !isRetriableCacheLoadFailure(e, retryTransientErrors)) {
-                    log.error("Schema cache load failed after {} retries", i, e);
-                    return Result.error(new RuntimeException(e));
+                Result<T, RuntimeException> failure = handleRetryableFailure(
+                        e, i, retries, retryTransientErrors, deadline, totalTimeout, backoff);
+                if (failure != null) {
+                    return failure;
                 }
-                if (deadline != null && !Instant.now().isBefore(deadline)) {
-                    log.error("Schema cache load exceeded total retry timeout of {}ms after {} attempts",
-                            totalTimeout.toMillis(), i + 1, e);
-                    return Result.error(new RuntimeException(
-                            "Schema cache load exceeded total retry timeout of " + totalTimeout.toMillis()
-                                    + "ms",
-                            e));
-                }
-                log.debug("Schema cache load attempt {}/{} failed with retriable error; backing off {}ms: {}",
-                        i + 1, retries + 1, backoff.toMillis(), rootMessage(e));
             }
-            try {
-                Thread.sleep(backoff.toMillis());
-            } catch (InterruptedException e) {
-                log.debug("Cache retry backoff interrupted", e);
-                Thread.currentThread().interrupt();
-            }
-            if (deadline != null && !Instant.now().isBefore(deadline)) {
-                log.error("Schema cache load exceeded total retry timeout of {}ms during backoff",
-                        totalTimeout.toMillis());
+            if (sleepBackoffOrTimeout(backoff, deadline, totalTimeout)) {
                 return Result.error(new RuntimeException(
                         "Schema cache load exceeded total retry timeout of " + totalTimeout.toMillis() + "ms"));
             }
         }
         return Result.error(new IllegalStateException("Unreachable."));
+    }
+
+    /**
+     * @return a failure result to return immediately, or {@code null} to continue retrying
+     */
+    private static <T> Result<T, RuntimeException> handleRetryableFailure(RuntimeException e, long attempt,
+            long retries, boolean retryTransientErrors, Instant deadline, Duration totalTimeout,
+            Duration backoff) {
+        // Schema-cache retries compose with the HTTP client retry layer
+        // (apicurio.registry.client.retry.*). Each cache attempt may run a full
+        // client retry ladder before returning here. Widened (non-429) retries are
+        // opt-in via apicurio.registry.retry.transient-errors; bound with
+        // apicurio.registry.retry.total-timeout-ms.
+        if (attempt == retries || !isRetriableCacheLoadFailure(e, retryTransientErrors)) {
+            log.error("Schema cache load failed after {} retries", attempt, e);
+            return Result.error(new RuntimeException(e));
+        }
+        if (isDeadlineExceeded(deadline)) {
+            log.error("Schema cache load exceeded total retry timeout of {}ms after {} attempts",
+                    totalTimeout.toMillis(), attempt + 1, e);
+            return Result.error(new RuntimeException(
+                    "Schema cache load exceeded total retry timeout of " + totalTimeout.toMillis() + "ms", e));
+        }
+        log.debug("Schema cache load attempt {}/{} failed with retriable error; backing off {}ms: {}",
+                attempt + 1, retries + 1, backoff.toMillis(), rootMessage(e));
+        return null;
+    }
+
+    /**
+     * @return {@code true} if the total timeout was exceeded during/after backoff
+     */
+    private static boolean sleepBackoffOrTimeout(Duration backoff, Instant deadline, Duration totalTimeout) {
+        try {
+            Thread.sleep(backoff.toMillis());
+        } catch (InterruptedException e) {
+            log.debug("Cache retry backoff interrupted", e);
+            Thread.currentThread().interrupt();
+        }
+        if (isDeadlineExceeded(deadline)) {
+            log.error("Schema cache load exceeded total retry timeout of {}ms during backoff",
+                    totalTimeout.toMillis());
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean isDeadlineExceeded(Instant deadline) {
+        return deadline != null && !Instant.now().isBefore(deadline);
     }
 
     /** Convenience overload used by tests that do not set a total timeout. */

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/cache/ERCache.java
@@ -460,11 +460,23 @@ public class ERCache<V> {
      * Whether a schema-cache load failure should be retried: HTTP 429, connection
      * failures, timeouts, connection resets, and Vert.x HTTP closed errors.
      */
+    private static final Class<?> VERTX_HTTP_CLOSED_EXCEPTION;
+
+    static {
+        Class<?> cls = null;
+        try {
+            cls = Class.forName("io.vertx.core.http.HttpClosedException", false,
+                    ERCache.class.getClassLoader());
+        } catch (ClassNotFoundException ignored) {
+            // Vert.x may not be on the classpath for all consumers.
+        }
+        VERTX_HTTP_CLOSED_EXCEPTION = cls;
+    }
+
     private static boolean isRetriableCacheLoadFailure(Throwable e) {
         Throwable current = e;
         while (current != null) {
-            if (current instanceof ApiException
-                    && ((ApiException) current).getResponseStatusCode() == 429) {
+            if (current instanceof ApiException api && api.getResponseStatusCode() == 429) {
                 return true;
             }
             if (current instanceof java.net.ConnectException) {
@@ -473,11 +485,11 @@ public class ERCache<V> {
             if (current instanceof java.net.SocketTimeoutException) {
                 return true;
             }
-            if (current instanceof java.io.IOException && current.getMessage() != null
-                    && current.getMessage().contains("Connection reset")) {
+            if (current instanceof java.io.IOException io && io.getMessage() != null
+                    && io.getMessage().contains("Connection reset")) {
                 return true;
             }
-            if ("io.vertx.core.http.HttpClosedException".equals(current.getClass().getName())) {
+            if (VERTX_HTTP_CLOSED_EXCEPTION != null && VERTX_HTTP_CLOSED_EXCEPTION.isInstance(current)) {
                 return true;
             }
             current = current.getCause();

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
@@ -112,13 +112,18 @@ public class RegistryClientFacadeFactory {
             long delayMs = config.getClientRetryDelayMs();
             double backoff = config.getClientRetryBackoffMultiplier();
             long maxDelayMs = config.getClientRetryMaxDelayMs();
-            logger.log(Level.INFO,
-                    "Registry HTTP client retry enabled: url={0}, maxAttempts={1}, delayMs={2}, backoffMultiplier={3}, maxDelayMs={4}",
-                    new Object[]{sanitizeRegistryUrl(config.getRegistryUrl()), maxAttempts, delayMs, backoff, maxDelayMs});
+            if (logger.isLoggable(Level.INFO)) {
+                logger.log(Level.INFO,
+                        "Registry HTTP client retry enabled: url={0}, maxAttempts={1}, delayMs={2}, backoffMultiplier={3}, maxDelayMs={4}",
+                        new Object[]{sanitizeRegistryUrl(config.getRegistryUrl()), maxAttempts, delayMs, backoff,
+                                maxDelayMs});
+            }
             clientOptions.retry(true, maxAttempts, delayMs, backoff, maxDelayMs);
         } else {
-            logger.log(Level.INFO,
-                    "Registry HTTP client retry disabled: url={0}", sanitizeRegistryUrl(config.getRegistryUrl()));
+            if (logger.isLoggable(Level.INFO)) {
+                logger.log(Level.INFO, "Registry HTTP client retry disabled: url={0}",
+                        sanitizeRegistryUrl(config.getRegistryUrl()));
+            }
             clientOptions.disableRetry();
         }
 

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
@@ -7,6 +7,7 @@ import io.apicurio.registry.client.common.RegistryClientOptions;
 import io.apicurio.registry.resolver.config.SchemaResolverConfig;
 import io.vertx.core.Vertx;
 
+import java.net.URI;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -104,18 +105,20 @@ public class RegistryClientFacadeFactory {
             throw new IllegalStateException(e);
         }
 
+        // Defaults for CLIENT_RETRY_* match RegistryClientOptions#retry()
+        // (3 attempts, 250ms initial delay, multiplier 2.0, max delay 10000ms).
         if (config.getClientRetryEnabled()) {
-            int maxAttempts = (int) config.getClientRetryMaxAttempts();
+            int maxAttempts = Math.toIntExact(config.getClientRetryMaxAttempts());
             long delayMs = config.getClientRetryDelayMs();
             double backoff = config.getClientRetryBackoffMultiplier();
             long maxDelayMs = config.getClientRetryMaxDelayMs();
             logger.log(Level.INFO,
                     "Registry HTTP client retry enabled: url={0}, maxAttempts={1}, delayMs={2}, backoffMultiplier={3}, maxDelayMs={4}",
-                    new Object[]{config.getRegistryUrl(), maxAttempts, delayMs, backoff, maxDelayMs});
+                    new Object[]{sanitizeRegistryUrl(config.getRegistryUrl()), maxAttempts, delayMs, backoff, maxDelayMs});
             clientOptions.retry(true, maxAttempts, delayMs, backoff, maxDelayMs);
         } else {
             logger.log(Level.INFO,
-                    "Registry HTTP client retry disabled: url={0}", config.getRegistryUrl());
+                    "Registry HTTP client retry disabled: url={0}", sanitizeRegistryUrl(config.getRegistryUrl()));
             clientOptions.disableRetry();
         }
 
@@ -178,6 +181,25 @@ public class RegistryClientFacadeFactory {
         }
 
         return clientOptions;
+    }
+
+    /**
+     * Strip userinfo from registry URLs before logging to avoid leaking credentials.
+     */
+    static String sanitizeRegistryUrl(String url) {
+        if (url == null || url.isBlank()) {
+            return url;
+        }
+        try {
+            URI uri = URI.create(url);
+            if (uri.getUserInfo() == null) {
+                return url;
+            }
+            return new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), uri.getPath(), uri.getQuery(),
+                    uri.getFragment()).toString();
+        } catch (Exception e) {
+            return "<redacted>";
+        }
     }
 
     private static RegistryClientFacade create_v3(SchemaResolverConfig config, Vertx vertx) {

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
@@ -105,8 +105,8 @@ public class RegistryClientFacadeFactory {
             throw new IllegalStateException(e);
         }
 
-        // Defaults for CLIENT_RETRY_* match RegistryClientOptions#retry()
-        // (3 attempts, 250ms initial delay, multiplier 2.0, max delay 10000ms).
+        // Defaults for CLIENT_RETRY_* must match RegistryClientOptions#retry()
+        // (3 / 250ms / 2.0 / 10000ms); pinned by RegistryClientOptionsRetryDefaultsTest.
         if (config.getClientRetryEnabled()) {
             int maxAttempts = Math.toIntExact(config.getClientRetryMaxAttempts());
             long delayMs = config.getClientRetryDelayMs();

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
@@ -190,6 +190,7 @@ public class RegistryClientFacadeFactory {
 
     /**
      * Strip userinfo from registry URLs before logging to avoid leaking credentials.
+     * Returns {@code <invalid-url>} when the input cannot be parsed (never echoes the raw string).
      */
     static String sanitizeRegistryUrl(String url) {
         if (url == null || url.isBlank()) {
@@ -203,7 +204,7 @@ public class RegistryClientFacadeFactory {
             return new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), uri.getPath(), uri.getQuery(),
                     uri.getFragment()).toString();
         } catch (Exception e) {
-            return "<redacted>";
+            return "<invalid-url>";
         }
     }
 

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
@@ -7,6 +7,7 @@ import io.apicurio.registry.client.common.RegistryClientOptions;
 import io.apicurio.registry.resolver.config.SchemaResolverConfig;
 import io.vertx.core.Vertx;
 
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -103,27 +104,18 @@ public class RegistryClientFacadeFactory {
             throw new IllegalStateException(e);
         }
 
-        // PR #9091 + lab diagnostics: log effective HTTP client retry knobs so
-        // Connect logs show whether SerDes config actually reached RegistryClientOptions.
         if (config.getClientRetryEnabled()) {
             int maxAttempts = (int) config.getClientRetryMaxAttempts();
             long delayMs = config.getClientRetryDelayMs();
             double backoff = config.getClientRetryBackoffMultiplier();
             long maxDelayMs = config.getClientRetryMaxDelayMs();
-            logger.info(String.format(
-                    "Apicurio registry HTTP client retry ENABLED url=%s maxAttempts=%d delayMs=%d backoff=%s maxDelayMs=%d (cache retry-count=%d retry-backoff-ms=%d)",
-                    config.getRegistryUrl(), maxAttempts, delayMs, backoff, maxDelayMs,
-                    config.getRetryCount(), config.getRetryBackoff().toMillis()));
-            System.out.println("[apicurio-pr9091] HTTP client retry ENABLED"
-                    + " maxAttempts=" + maxAttempts
-                    + " delayMs=" + delayMs
-                    + " backoff=" + backoff
-                    + " maxDelayMs=" + maxDelayMs
-                    + " cacheRetryCount=" + config.getRetryCount());
+            logger.log(Level.INFO,
+                    "Registry HTTP client retry enabled: url={0}, maxAttempts={1}, delayMs={2}, backoffMultiplier={3}, maxDelayMs={4}",
+                    new Object[]{config.getRegistryUrl(), maxAttempts, delayMs, backoff, maxDelayMs});
             clientOptions.retry(true, maxAttempts, delayMs, backoff, maxDelayMs);
         } else {
-            logger.info("Apicurio registry HTTP client retry DISABLED for url=" + config.getRegistryUrl());
-            System.out.println("[apicurio-pr9091] HTTP client retry DISABLED");
+            logger.log(Level.INFO,
+                    "Registry HTTP client retry disabled: url={0}", config.getRegistryUrl());
             clientOptions.disableRetry();
         }
 

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
@@ -103,9 +103,28 @@ public class RegistryClientFacadeFactory {
             throw new IllegalStateException(e);
         }
 
-        // FIXME push retry options into the SchemaResolverConfig
-        if (Boolean.TRUE) {
-            clientOptions.retry();
+        // PR #9091 + lab diagnostics: log effective HTTP client retry knobs so
+        // Connect logs show whether SerDes config actually reached RegistryClientOptions.
+        if (config.getClientRetryEnabled()) {
+            int maxAttempts = (int) config.getClientRetryMaxAttempts();
+            long delayMs = config.getClientRetryDelayMs();
+            double backoff = config.getClientRetryBackoffMultiplier();
+            long maxDelayMs = config.getClientRetryMaxDelayMs();
+            logger.info(String.format(
+                    "Apicurio registry HTTP client retry ENABLED url=%s maxAttempts=%d delayMs=%d backoff=%s maxDelayMs=%d (cache retry-count=%d retry-backoff-ms=%d)",
+                    config.getRegistryUrl(), maxAttempts, delayMs, backoff, maxDelayMs,
+                    config.getRetryCount(), config.getRetryBackoff().toMillis()));
+            System.out.println("[apicurio-pr9091] HTTP client retry ENABLED"
+                    + " maxAttempts=" + maxAttempts
+                    + " delayMs=" + delayMs
+                    + " backoff=" + backoff
+                    + " maxDelayMs=" + maxDelayMs
+                    + " cacheRetryCount=" + config.getRetryCount());
+            clientOptions.retry(true, maxAttempts, delayMs, backoff, maxDelayMs);
+        } else {
+            logger.info("Apicurio registry HTTP client retry DISABLED for url=" + config.getRegistryUrl());
+            System.out.println("[apicurio-pr9091] HTTP client retry DISABLED");
+            clientOptions.disableRetry();
         }
 
         // Configure TLS/SSL

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/AbstractConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/AbstractConfig.java
@@ -165,15 +165,4 @@ public abstract class AbstractConfig {
         reportError(key, "a number-like value", value);
         throw new IllegalStateException("Unreachable");
     }
-
-    /**
-     * Ensure a non-negative long fits in a Java {@code int} (for APIs that take int).
-     */
-    protected int getIntNonNegative(String key) {
-        long value = getLongNonNegative(key);
-        if (value > Integer.MAX_VALUE) {
-            reportError(key, "an integer-compatible value (<= " + Integer.MAX_VALUE + ")", value);
-        }
-        return (int) value;
-    }
 }

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/AbstractConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/AbstractConfig.java
@@ -6,6 +6,8 @@ import java.util.Map;
 
 public abstract class AbstractConfig {
 
+    private static final String EXPECTED_NON_NULL_VALUE = "a non-null value";
+
     protected Map<String, Object> originals;
 
     protected abstract Map<String, ?> getDefaults();
@@ -13,7 +15,7 @@ public abstract class AbstractConfig {
     protected Duration getDurationNonNegativeMillis(String key) {
         Object value = getObject(key);
         if (value == null) {
-            reportError(key, "a non-null value", value);
+            reportError(key, EXPECTED_NON_NULL_VALUE, value);
         }
         long millis;
 
@@ -36,7 +38,7 @@ public abstract class AbstractConfig {
     protected long getLongNonNegative(String key) {
         Object value = getObject(key);
         if (value == null) {
-            reportError(key, "a non-null value", value);
+            reportError(key, EXPECTED_NON_NULL_VALUE, value);
         }
         long result;
         if (value instanceof Number) {
@@ -146,7 +148,7 @@ public abstract class AbstractConfig {
     protected double getDouble(String key) {
         Object value = getObject(key);
         if (value == null) {
-            reportError(key, "a non-null value", value);
+            reportError(key, EXPECTED_NON_NULL_VALUE, value);
             throw new IllegalStateException("Unreachable");
         }
         if (value instanceof Number number) {

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/AbstractConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/AbstractConfig.java
@@ -140,4 +140,38 @@ public abstract class AbstractConfig {
                 + "Expected " + expectedText + ", but got a '" + value + "'.");
     }
 
+    /**
+     * Parse a double from a Number or String configuration value.
+     */
+    protected double getDouble(String key) {
+        Object value = getObject(key);
+        if (value == null) {
+            reportError(key, "a non-null value", value);
+            throw new IllegalStateException("Unreachable");
+        }
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        if (value instanceof String string) {
+            try {
+                return Double.parseDouble(string);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid configuration property value for '" + key
+                        + "'. Expected a number-like value, but got a '" + value + "'.", e);
+            }
+        }
+        reportError(key, "a number-like value", value);
+        throw new IllegalStateException("Unreachable");
+    }
+
+    /**
+     * Ensure a non-negative long fits in a Java {@code int} (for APIs that take int).
+     */
+    protected int getIntNonNegative(String key) {
+        long value = getLongNonNegative(key);
+        if (value > Integer.MAX_VALUE) {
+            reportError(key, "an integer-compatible value (<= " + Integer.MAX_VALUE + ")", value);
+        }
+        return (int) value;
+    }
 }

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
@@ -525,7 +525,7 @@ public class SchemaResolverConfig extends AbstractConfig {
                     + CLIENT_RETRY_BACKOFF_MULTIPLIER + "'. Expected a number-like value, but got a '"
                     + value + "'.");
         }
-        // Match RegistryClientOptions#retry(boolean,int,long,double,long): multiplier must be > 1.0.
+        // Align with RegistryClientOptions retry: backoff multiplier must be greater than 1.0.
         if (!Double.isFinite(parsed) || parsed <= 1.0) {
             throw new IllegalArgumentException("Invalid configuration property value for '"
                     + CLIENT_RETRY_BACKOFF_MULTIPLIER + "'. Expected a finite number greater than 1.0, but got '"

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
@@ -199,6 +199,12 @@ public class SchemaResolverConfig extends AbstractConfig {
      * Controls the <strong>schema-cache</strong> retry layer in {@code ERCache}. Distinct from
      * {@link #CLIENT_RETRY_MAX_ATTEMPTS}, which configures the underlying HTTP client retry ladder that may
      * run inside each cache attempt.
+     * <p>
+     * <strong>Sizing:</strong> the layers multiply. Worst-case blocking for one cache load is roughly
+     * {@code (retry-count + 1) × (full client retry ladder including connect timeouts and client
+     * backoffs) + (retry-count × retry-backoff-ms)}. There is no overall deadline. Keep this low when
+     * elevating {@link #CLIENT_RETRY_MAX_ATTEMPTS}, especially for Kafka producers where a long block can
+     * trip {@code max.block.ms}.
      */
     public static final String RETRY_COUNT = "apicurio.registry.retry-count";
     public static final long RETRY_COUNT_DEFAULT = 3;
@@ -210,7 +216,7 @@ public class SchemaResolverConfig extends AbstractConfig {
      * <p>
      * Controls the <strong>schema-cache</strong> retry layer in {@code ERCache}. Distinct from
      * {@link #CLIENT_RETRY_DELAY_MS}, which configures the underlying HTTP client retry ladder that may run
-     * inside each cache attempt.
+     * inside each cache attempt. See {@link #RETRY_COUNT} for how the two layers multiply.
      */
     public static final String RETRY_BACKOFF_MS = "apicurio.registry.retry-backoff-ms";
     public static final long RETRY_BACKOFF_MS_DEFAULT = 300;
@@ -219,14 +225,20 @@ public class SchemaResolverConfig extends AbstractConfig {
      * Enable or disable retry for the underlying registry HTTP client
      * ({@code RegistryClientOptions} / {@code RetryInvocationHandler}).
      * Distinct from {@link #RETRY_COUNT}, which controls schema-cache retries in {@code ERCache}.
-     * The two layers stack: each cache attempt may run a full HTTP client retry ladder.
+     * The two layers stack: each cache attempt may run a full HTTP client retry ladder
+     * (see {@link #RETRY_COUNT} for multiplicative blocking guidance).
      */
     public static final String CLIENT_RETRY_ENABLED = "apicurio.registry.client.retry.enabled";
     public static final boolean CLIENT_RETRY_ENABLED_DEFAULT = true;
 
     /**
      * Maximum number of retry attempts for the underlying registry HTTP client.
-     * Defaults match {@code RegistryClientOptions#retry()} (3 / 250ms / 2.0 / 10000ms).
+     * Defaults match {@code RegistryClientOptions#retry()} (3 / 250ms / 2.0 / 10000ms); SDK parity is
+     * pinned by {@code RegistryClientOptionsRetryDefaultsTest} in java-sdk/common.
+     * <p>
+     * Size together with {@link #RETRY_COUNT}: each of the {@code (retry-count + 1)} cache attempts may
+     * run this many HTTP attempts plus client backoff sleeps, with no overall deadline. Large values can
+     * block Kafka {@code Producer.send()} long enough to hit {@code max.block.ms}.
      */
     public static final String CLIENT_RETRY_MAX_ATTEMPTS = "apicurio.registry.client.retry.max-attempts";
     public static final long CLIENT_RETRY_MAX_ATTEMPTS_DEFAULT = 3;

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
@@ -627,8 +627,8 @@ public class SchemaResolverConfig extends AbstractConfig {
      */
     public Vertx getVertx() {
         Object vertx = getObject(VERTX_INSTANCE);
-        if (vertx instanceof Vertx) {
-            return (Vertx) vertx;
+        if (vertx instanceof Vertx configuredVertx) {
+            return configuredVertx;
         }
         return null;
     }

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
@@ -195,44 +195,60 @@ public class SchemaResolverConfig extends AbstractConfig {
      * If a schema can not be retrieved from the Registry, serdes may retry a number of times. This
      * configuration option controls the number of retries before failing. Valid values are non-negative
      * integers.
+     * <p>
+     * Controls the <strong>schema-cache</strong> retry layer in {@code ERCache}. Distinct from
+     * {@link #CLIENT_RETRY_MAX_ATTEMPTS}, which configures the underlying HTTP client retry ladder that may
+     * run inside each cache attempt.
      */
     public static final String RETRY_COUNT = "apicurio.registry.retry-count";
     public static final long RETRY_COUNT_DEFAULT = 3;
 
     /**
-     * If a schema can not be be retrieved from the Registry, serdes may retry a number of times. This
+     * If a schema can not be retrieved from the Registry, serdes may retry a number of times. This
      * configuration option controls the delay between the retry attempts, in milliseconds. Valid values are
      * non-negative integers.
+     * <p>
+     * Controls the <strong>schema-cache</strong> retry layer in {@code ERCache}. Distinct from
+     * {@link #CLIENT_RETRY_DELAY_MS}, which configures the underlying HTTP client retry ladder that may run
+     * inside each cache attempt.
      */
     public static final String RETRY_BACKOFF_MS = "apicurio.registry.retry-backoff-ms";
     public static final long RETRY_BACKOFF_MS_DEFAULT = 300;
 
     /**
-     * Enable or disable retry for the underlying registry client.
+     * Enable or disable retry for the underlying registry HTTP client
+     * ({@code RegistryClientOptions} / {@code RetryInvocationHandler}).
+     * Distinct from {@link #RETRY_COUNT}, which controls schema-cache retries in {@code ERCache}.
+     * The two layers stack: each cache attempt may run a full HTTP client retry ladder.
      */
     public static final String CLIENT_RETRY_ENABLED = "apicurio.registry.client.retry.enabled";
     public static final boolean CLIENT_RETRY_ENABLED_DEFAULT = true;
 
     /**
-     * Maximum number of retry attempts for the underlying registry client.
+     * Maximum number of retry attempts for the underlying registry HTTP client.
+     * Defaults match {@code RegistryClientOptions#retry()} (3 / 250ms / 2.0 / 10000ms).
      */
     public static final String CLIENT_RETRY_MAX_ATTEMPTS = "apicurio.registry.client.retry.max-attempts";
     public static final long CLIENT_RETRY_MAX_ATTEMPTS_DEFAULT = 3;
 
     /**
-     * Initial retry delay in milliseconds for the underlying registry client.
+     * Initial retry delay in milliseconds for the underlying registry HTTP client.
+     * Defaults match {@code RegistryClientOptions#retry()} (3 / 250ms / 2.0 / 10000ms).
      */
     public static final String CLIENT_RETRY_DELAY_MS = "apicurio.registry.client.retry.delay-ms";
     public static final long CLIENT_RETRY_DELAY_MS_DEFAULT = 250;
 
     /**
-     * Exponential backoff multiplier for the underlying registry client.
+     * Exponential backoff multiplier for the underlying registry HTTP client.
+     * Must be finite and {@code > 1.0} (same constraint as {@code RegistryClientOptions#retry}).
+     * Defaults match {@code RegistryClientOptions#retry()} (3 / 250ms / 2.0 / 10000ms).
      */
     public static final String CLIENT_RETRY_BACKOFF_MULTIPLIER = "apicurio.registry.client.retry.backoff-multiplier";
     public static final double CLIENT_RETRY_BACKOFF_MULTIPLIER_DEFAULT = 2.0;
 
     /**
-     * Maximum retry delay in milliseconds for the underlying registry client.
+     * Maximum retry delay in milliseconds for the underlying registry HTTP client.
+     * Defaults match {@code RegistryClientOptions#retry()} (3 / 250ms / 2.0 / 10000ms).
      */
     public static final String CLIENT_RETRY_MAX_DELAY_MS = "apicurio.registry.client.retry.max-delay-ms";
     public static final long CLIENT_RETRY_MAX_DELAY_MS_DEFAULT = 10000;
@@ -481,11 +497,12 @@ public class SchemaResolverConfig extends AbstractConfig {
         if (value == null) {
             return CLIENT_RETRY_BACKOFF_MULTIPLIER_DEFAULT;
         }
+        double parsed;
         if (value instanceof Number number) {
-            return number.doubleValue();
+            parsed = number.doubleValue();
         } else if (value instanceof String string) {
             try {
-                return Double.parseDouble(string);
+                parsed = Double.parseDouble(string);
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException("Invalid configuration property value for '"
                         + CLIENT_RETRY_BACKOFF_MULTIPLIER + "'. Expected a number-like value, but got a '"
@@ -496,6 +513,13 @@ public class SchemaResolverConfig extends AbstractConfig {
                     + CLIENT_RETRY_BACKOFF_MULTIPLIER + "'. Expected a number-like value, but got a '"
                     + value + "'.");
         }
+        // Match RegistryClientOptions#retry(boolean,int,long,double,long): multiplier must be > 1.0.
+        if (!Double.isFinite(parsed) || parsed <= 1.0) {
+            throw new IllegalArgumentException("Invalid configuration property value for '"
+                    + CLIENT_RETRY_BACKOFF_MULTIPLIER + "'. Expected a finite number greater than 1.0, but got '"
+                    + value + "'.");
+        }
+        return parsed;
     }
 
     public long getClientRetryMaxDelayMs() {

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
@@ -203,9 +203,9 @@ public class SchemaResolverConfig extends AbstractConfig {
      * By default the cache layer only retries HTTP 429. Enable {@link #RETRY_TRANSIENT_ERRORS} to also retry
      * network/outage failures (502/503/504 and connection errors). When that opt-in is enabled, the layers
      * multiply: worst-case blocking is roughly
-     * {@code (retry-count + 1) × (full client retry ladder) + (retry-count × retry-backoff-ms)} with no
-     * overall deadline — size together with {@link #CLIENT_RETRY_MAX_ATTEMPTS}, especially for Kafka
-     * producers ({@code max.block.ms}) and Connect polls.
+     * {@code (retry-count + 1) × (full client retry ladder) + (retry-count × retry-backoff-ms)}.
+     * Bound it with {@link #RETRY_TOTAL_TIMEOUT_MS}, and size together with {@link #CLIENT_RETRY_MAX_ATTEMPTS},
+     * especially for Kafka producers ({@code max.block.ms}) and Connect polls.
      */
     public static final String RETRY_COUNT = "apicurio.registry.retry-count";
     public static final long RETRY_COUNT_DEFAULT = 3;
@@ -227,10 +227,20 @@ public class SchemaResolverConfig extends AbstractConfig {
      * When {@code false} (default), the schema-cache retry layer only retries HTTP 429, matching historical
      * behavior so existing deployments do not silently gain multiplicative blocking on connection failures.
      * When {@code true}, also retries typical registry outage signals (502/503/504) and retriable network
-     * failures. See {@link #RETRY_COUNT} for sizing guidance when enabling this.
+     * failures. See {@link #RETRY_COUNT} and {@link #RETRY_TOTAL_TIMEOUT_MS} for sizing / bounding guidance.
      */
     public static final String RETRY_TRANSIENT_ERRORS = "apicurio.registry.retry.transient-errors";
     public static final boolean RETRY_TRANSIENT_ERRORS_DEFAULT = false;
+
+    /**
+     * Optional wall-clock budget (milliseconds) for a single schema-cache load's retry loop in
+     * {@code ERCache}. Checked before each re-attempt after a retriable failure. {@code 0} (default) means
+     * unlimited. Strongly recommended when {@link #RETRY_TRANSIENT_ERRORS} is enabled so
+     * {@code Producer.send()} / Connect polls cannot block for
+     * {@code (retry-count + 1) × (client retry ladder)} unboundedly.
+     */
+    public static final String RETRY_TOTAL_TIMEOUT_MS = "apicurio.registry.retry.total-timeout-ms";
+    public static final long RETRY_TOTAL_TIMEOUT_MS_DEFAULT = 0;
 
     /**
      * Enable or disable retry for the underlying registry HTTP client
@@ -508,6 +518,10 @@ public class SchemaResolverConfig extends AbstractConfig {
         return getBoolean(RETRY_TRANSIENT_ERRORS);
     }
 
+    public Duration getRetryTotalTimeout() {
+        return getDurationNonNegativeMillis(RETRY_TOTAL_TIMEOUT_MS);
+    }
+
     public boolean getClientRetryEnabled() {
         return getBoolean(CLIENT_RETRY_ENABLED);
     }
@@ -683,6 +697,7 @@ public class SchemaResolverConfig extends AbstractConfig {
             entry(CHECK_PERIOD_MS, CHECK_PERIOD_MS_DEFAULT), entry(RETRY_COUNT, RETRY_COUNT_DEFAULT),
             entry(RETRY_BACKOFF_MS, RETRY_BACKOFF_MS_DEFAULT),
             entry(RETRY_TRANSIENT_ERRORS, RETRY_TRANSIENT_ERRORS_DEFAULT),
+            entry(RETRY_TOTAL_TIMEOUT_MS, RETRY_TOTAL_TIMEOUT_MS_DEFAULT),
             entry(CLIENT_RETRY_ENABLED, CLIENT_RETRY_ENABLED_DEFAULT),
             entry(CLIENT_RETRY_MAX_ATTEMPTS, CLIENT_RETRY_MAX_ATTEMPTS_DEFAULT),
             entry(CLIENT_RETRY_DELAY_MS, CLIENT_RETRY_DELAY_MS_DEFAULT),

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
@@ -200,11 +200,12 @@ public class SchemaResolverConfig extends AbstractConfig {
      * {@link #CLIENT_RETRY_MAX_ATTEMPTS}, which configures the underlying HTTP client retry ladder that may
      * run inside each cache attempt.
      * <p>
-     * <strong>Sizing:</strong> the layers multiply. Worst-case blocking for one cache load is roughly
-     * {@code (retry-count + 1) × (full client retry ladder including connect timeouts and client
-     * backoffs) + (retry-count × retry-backoff-ms)}. There is no overall deadline. Keep this low when
-     * elevating {@link #CLIENT_RETRY_MAX_ATTEMPTS}, especially for Kafka producers where a long block can
-     * trip {@code max.block.ms}.
+     * By default the cache layer only retries HTTP 429. Enable {@link #RETRY_TRANSIENT_ERRORS} to also retry
+     * network/outage failures (502/503/504 and connection errors). When that opt-in is enabled, the layers
+     * multiply: worst-case blocking is roughly
+     * {@code (retry-count + 1) × (full client retry ladder) + (retry-count × retry-backoff-ms)} with no
+     * overall deadline — size together with {@link #CLIENT_RETRY_MAX_ATTEMPTS}, especially for Kafka
+     * producers ({@code max.block.ms}) and Connect polls.
      */
     public static final String RETRY_COUNT = "apicurio.registry.retry-count";
     public static final long RETRY_COUNT_DEFAULT = 3;
@@ -216,17 +217,27 @@ public class SchemaResolverConfig extends AbstractConfig {
      * <p>
      * Controls the <strong>schema-cache</strong> retry layer in {@code ERCache}. Distinct from
      * {@link #CLIENT_RETRY_DELAY_MS}, which configures the underlying HTTP client retry ladder that may run
-     * inside each cache attempt. See {@link #RETRY_COUNT} for how the two layers multiply.
+     * inside each cache attempt. See {@link #RETRY_COUNT} for how the two layers multiply when transient
+     * retries are enabled.
      */
     public static final String RETRY_BACKOFF_MS = "apicurio.registry.retry-backoff-ms";
     public static final long RETRY_BACKOFF_MS_DEFAULT = 300;
 
     /**
+     * When {@code false} (default), the schema-cache retry layer only retries HTTP 429, matching historical
+     * behavior so existing deployments do not silently gain multiplicative blocking on connection failures.
+     * When {@code true}, also retries typical registry outage signals (502/503/504) and retriable network
+     * failures. See {@link #RETRY_COUNT} for sizing guidance when enabling this.
+     */
+    public static final String RETRY_TRANSIENT_ERRORS = "apicurio.registry.retry.transient-errors";
+    public static final boolean RETRY_TRANSIENT_ERRORS_DEFAULT = false;
+
+    /**
      * Enable or disable retry for the underlying registry HTTP client
      * ({@code RegistryClientOptions} / {@code RetryInvocationHandler}).
      * Distinct from {@link #RETRY_COUNT}, which controls schema-cache retries in {@code ERCache}.
-     * The two layers stack: each cache attempt may run a full HTTP client retry ladder
-     * (see {@link #RETRY_COUNT} for multiplicative blocking guidance).
+     * The two layers stack when {@link #RETRY_TRANSIENT_ERRORS} is enabled: each cache attempt may run a full
+     * HTTP client retry ladder (see {@link #RETRY_COUNT}).
      */
     public static final String CLIENT_RETRY_ENABLED = "apicurio.registry.client.retry.enabled";
     public static final boolean CLIENT_RETRY_ENABLED_DEFAULT = true;
@@ -235,10 +246,11 @@ public class SchemaResolverConfig extends AbstractConfig {
      * Maximum number of retry attempts for the underlying registry HTTP client.
      * Defaults match {@code RegistryClientOptions#retry()} (3 / 250ms / 2.0 / 10000ms); SDK parity is
      * pinned by {@code RegistryClientOptionsRetryDefaultsTest} in java-sdk/common.
+     * Must be an integer in {@code [1, Integer.MAX_VALUE]}.
      * <p>
-     * Size together with {@link #RETRY_COUNT}: each of the {@code (retry-count + 1)} cache attempts may
-     * run this many HTTP attempts plus client backoff sleeps, with no overall deadline. Large values can
-     * block Kafka {@code Producer.send()} long enough to hit {@code max.block.ms}.
+     * Size together with {@link #RETRY_COUNT} when {@link #RETRY_TRANSIENT_ERRORS} is enabled: each of the
+     * {@code (retry-count + 1)} cache attempts may run this many HTTP attempts plus client backoff sleeps.
+     * Large values can block Kafka {@code Producer.send()} long enough to hit {@code max.block.ms}.
      */
     public static final String CLIENT_RETRY_MAX_ATTEMPTS = "apicurio.registry.client.retry.max-attempts";
     public static final long CLIENT_RETRY_MAX_ATTEMPTS_DEFAULT = 3;
@@ -492,12 +504,23 @@ public class SchemaResolverConfig extends AbstractConfig {
         return getDurationNonNegativeMillis(RETRY_BACKOFF_MS);
     }
 
+    public boolean getRetryTransientErrors() {
+        return getBoolean(RETRY_TRANSIENT_ERRORS);
+    }
+
     public boolean getClientRetryEnabled() {
         return getBoolean(CLIENT_RETRY_ENABLED);
     }
 
     public long getClientRetryMaxAttempts() {
-        return getLongNonNegative(CLIENT_RETRY_MAX_ATTEMPTS);
+        // Fail fast with the property name rather than ArithmeticException at Math.toIntExact later.
+        long value = getLongNonNegative(CLIENT_RETRY_MAX_ATTEMPTS);
+        if (value < 1 || value > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Invalid configuration property value for '"
+                    + CLIENT_RETRY_MAX_ATTEMPTS
+                    + "'. Expected an integer in [1, " + Integer.MAX_VALUE + "], but got '" + value + "'.");
+        }
+        return value;
     }
 
     public long getClientRetryDelayMs() {
@@ -509,27 +532,13 @@ public class SchemaResolverConfig extends AbstractConfig {
         if (value == null) {
             return CLIENT_RETRY_BACKOFF_MULTIPLIER_DEFAULT;
         }
-        double parsed;
-        if (value instanceof Number number) {
-            parsed = number.doubleValue();
-        } else if (value instanceof String string) {
-            try {
-                parsed = Double.parseDouble(string);
-            } catch (NumberFormatException e) {
-                throw new IllegalArgumentException("Invalid configuration property value for '"
-                        + CLIENT_RETRY_BACKOFF_MULTIPLIER + "'. Expected a number-like value, but got a '"
-                        + value + "'.", e);
-            }
-        } else {
-            throw new IllegalArgumentException("Invalid configuration property value for '"
-                    + CLIENT_RETRY_BACKOFF_MULTIPLIER + "'. Expected a number-like value, but got a '"
-                    + value + "'.");
-        }
-        // Align with RegistryClientOptions retry: backoff multiplier must be greater than 1.0.
+        // Same constraint as RegistryClientOptions#retry(...): multiplier must be > 1.0
+        // (constant-delay backoff is not supported by the HTTP client layer).
+        double parsed = getDouble(CLIENT_RETRY_BACKOFF_MULTIPLIER);
         if (!Double.isFinite(parsed) || parsed <= 1.0) {
             throw new IllegalArgumentException("Invalid configuration property value for '"
-                    + CLIENT_RETRY_BACKOFF_MULTIPLIER + "'. Expected a finite number greater than 1.0, but got '"
-                    + value + "'.");
+                    + CLIENT_RETRY_BACKOFF_MULTIPLIER
+                    + "'. Expected a finite number greater than 1.0, but got '" + value + "'.");
         }
         return parsed;
     }
@@ -627,8 +636,8 @@ public class SchemaResolverConfig extends AbstractConfig {
      */
     public Vertx getVertx() {
         Object vertx = getObject(VERTX_INSTANCE);
-        if (vertx instanceof Vertx configuredVertx) {
-            return configuredVertx;
+        if (vertx instanceof Vertx) {
+            return (Vertx) vertx;
         }
         return null;
     }
@@ -673,6 +682,7 @@ public class SchemaResolverConfig extends AbstractConfig {
             entry(FIND_LATEST_ARTIFACT, FIND_LATEST_ARTIFACT_DEFAULT),
             entry(CHECK_PERIOD_MS, CHECK_PERIOD_MS_DEFAULT), entry(RETRY_COUNT, RETRY_COUNT_DEFAULT),
             entry(RETRY_BACKOFF_MS, RETRY_BACKOFF_MS_DEFAULT),
+            entry(RETRY_TRANSIENT_ERRORS, RETRY_TRANSIENT_ERRORS_DEFAULT),
             entry(CLIENT_RETRY_ENABLED, CLIENT_RETRY_ENABLED_DEFAULT),
             entry(CLIENT_RETRY_MAX_ATTEMPTS, CLIENT_RETRY_MAX_ATTEMPTS_DEFAULT),
             entry(CLIENT_RETRY_DELAY_MS, CLIENT_RETRY_DELAY_MS_DEFAULT),

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
@@ -208,6 +208,36 @@ public class SchemaResolverConfig extends AbstractConfig {
     public static final long RETRY_BACKOFF_MS_DEFAULT = 300;
 
     /**
+     * Enable or disable retry for the underlying registry client.
+     */
+    public static final String CLIENT_RETRY_ENABLED = "apicurio.registry.client.retry.enabled";
+    public static final boolean CLIENT_RETRY_ENABLED_DEFAULT = true;
+
+    /**
+     * Maximum number of retry attempts for the underlying registry client.
+     */
+    public static final String CLIENT_RETRY_MAX_ATTEMPTS = "apicurio.registry.client.retry.max-attempts";
+    public static final long CLIENT_RETRY_MAX_ATTEMPTS_DEFAULT = 3;
+
+    /**
+     * Initial retry delay in milliseconds for the underlying registry client.
+     */
+    public static final String CLIENT_RETRY_DELAY_MS = "apicurio.registry.client.retry.delay-ms";
+    public static final long CLIENT_RETRY_DELAY_MS_DEFAULT = 250;
+
+    /**
+     * Exponential backoff multiplier for the underlying registry client.
+     */
+    public static final String CLIENT_RETRY_BACKOFF_MULTIPLIER = "apicurio.registry.client.retry.backoff-multiplier";
+    public static final double CLIENT_RETRY_BACKOFF_MULTIPLIER_DEFAULT = 2.0;
+
+    /**
+     * Maximum retry delay in milliseconds for the underlying registry client.
+     */
+    public static final String CLIENT_RETRY_MAX_DELAY_MS = "apicurio.registry.client.retry.max-delay-ms";
+    public static final long CLIENT_RETRY_MAX_DELAY_MS_DEFAULT = 10000;
+
+    /**
      * Used to indicate the serdes to dereference the schema. This is used in two different situation, once
      * the schema is registered, instructs the serdes to ask the server for the schema dereferenced. It is
      * also used to instruct the serializer to dereference the schema before registering it Registry, but this
@@ -434,6 +464,44 @@ public class SchemaResolverConfig extends AbstractConfig {
         return getDurationNonNegativeMillis(RETRY_BACKOFF_MS);
     }
 
+    public boolean getClientRetryEnabled() {
+        return getBoolean(CLIENT_RETRY_ENABLED);
+    }
+
+    public long getClientRetryMaxAttempts() {
+        return getLongNonNegative(CLIENT_RETRY_MAX_ATTEMPTS);
+    }
+
+    public long getClientRetryDelayMs() {
+        return getDurationNonNegativeMillis(CLIENT_RETRY_DELAY_MS).toMillis();
+    }
+
+    public double getClientRetryBackoffMultiplier() {
+        Object value = getObject(CLIENT_RETRY_BACKOFF_MULTIPLIER);
+        if (value == null) {
+            return CLIENT_RETRY_BACKOFF_MULTIPLIER_DEFAULT;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        } else if (value instanceof String) {
+            try {
+                return Double.parseDouble((String) value);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid configuration property value for '"
+                        + CLIENT_RETRY_BACKOFF_MULTIPLIER + "'. Expected a number-like value, but got a '"
+                        + value + "'.", e);
+            }
+        } else {
+            throw new IllegalArgumentException("Invalid configuration property value for '"
+                    + CLIENT_RETRY_BACKOFF_MULTIPLIER + "'. Expected a number-like value, but got a '"
+                    + value + "'.");
+        }
+    }
+
+    public long getClientRetryMaxDelayMs() {
+        return getDurationNonNegativeMillis(CLIENT_RETRY_MAX_DELAY_MS).toMillis();
+    }
+
     public String getExplicitArtifactGroupId() {
         return getString(EXPLICIT_ARTIFACT_GROUP_ID);
     }
@@ -569,6 +637,11 @@ public class SchemaResolverConfig extends AbstractConfig {
             entry(FIND_LATEST_ARTIFACT, FIND_LATEST_ARTIFACT_DEFAULT),
             entry(CHECK_PERIOD_MS, CHECK_PERIOD_MS_DEFAULT), entry(RETRY_COUNT, RETRY_COUNT_DEFAULT),
             entry(RETRY_BACKOFF_MS, RETRY_BACKOFF_MS_DEFAULT),
+            entry(CLIENT_RETRY_ENABLED, CLIENT_RETRY_ENABLED_DEFAULT),
+            entry(CLIENT_RETRY_MAX_ATTEMPTS, CLIENT_RETRY_MAX_ATTEMPTS_DEFAULT),
+            entry(CLIENT_RETRY_DELAY_MS, CLIENT_RETRY_DELAY_MS_DEFAULT),
+            entry(CLIENT_RETRY_BACKOFF_MULTIPLIER, CLIENT_RETRY_BACKOFF_MULTIPLIER_DEFAULT),
+            entry(CLIENT_RETRY_MAX_DELAY_MS, CLIENT_RETRY_MAX_DELAY_MS_DEFAULT),
             entry(DEREFERENCE_SCHEMA, DEREFERENCE_DEFAULT),
             entry(TLS_TRUSTSTORE_TYPE, TLS_TRUSTSTORE_TYPE_DEFAULT),
             entry(TLS_TRUST_ALL, TLS_TRUST_ALL_DEFAULT),

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
@@ -200,9 +200,10 @@ public class SchemaResolverConfig extends AbstractConfig {
      * {@link #CLIENT_RETRY_MAX_ATTEMPTS}, which configures the underlying HTTP client retry ladder that may
      * run inside each cache attempt.
      * <p>
-     * By default the cache layer only retries HTTP 429. Enable {@link #RETRY_TRANSIENT_ERRORS} to also retry
-     * network/outage failures (502/503/504 and connection errors). When that opt-in is enabled, the layers
-     * multiply: worst-case blocking is roughly
+     * <strong>Outage retries are opt-in.</strong> By default the cache layer only retries HTTP 429. Set
+     * {@link #RETRY_TRANSIENT_ERRORS}{@code =true} (and preferably {@link #RETRY_TOTAL_TIMEOUT_MS}) to also
+     * retry network/outage failures (502/503/504 and connection errors). Raising this count alone does not
+     * cover registry-down. When that opt-in is enabled, the layers multiply: worst-case blocking is roughly
      * {@code (retry-count + 1) × (full client retry ladder) + (retry-count × retry-backoff-ms)}.
      * Bound it with {@link #RETRY_TOTAL_TIMEOUT_MS}, and size together with {@link #CLIENT_RETRY_MAX_ATTEMPTS},
      * especially for Kafka producers ({@code max.block.ms}) and Connect polls.
@@ -234,8 +235,10 @@ public class SchemaResolverConfig extends AbstractConfig {
 
     /**
      * Optional wall-clock budget (milliseconds) for a single schema-cache load's retry loop in
-     * {@code ERCache}. Checked before each re-attempt after a retriable failure. {@code 0} (default) means
-     * unlimited. Strongly recommended when {@link #RETRY_TRANSIENT_ERRORS} is enabled so
+     * {@code ERCache}. Checked before each re-attempt after a retriable failure; it does
+     * <strong>not</strong> interrupt an in-flight cache attempt (that attempt may still run a full
+     * HTTP client retry ladder plus request timeouts). {@code 0} (default) means unlimited.
+     * Strongly recommended when {@link #RETRY_TRANSIENT_ERRORS} is enabled so
      * {@code Producer.send()} / Connect polls cannot block for
      * {@code (retry-count + 1) × (client retry ladder)} unboundedly.
      */
@@ -256,7 +259,9 @@ public class SchemaResolverConfig extends AbstractConfig {
      * Maximum number of retry attempts for the underlying registry HTTP client.
      * Defaults match {@code RegistryClientOptions#retry()} (3 / 250ms / 2.0 / 10000ms); SDK parity is
      * pinned by {@code RegistryClientOptionsRetryDefaultsTest} in java-sdk/common.
-     * Must be an integer in {@code [1, Integer.MAX_VALUE]}.
+     * Must be an integer in {@code [1, 1000]}. The upper bound is a sanity ceiling so a
+     * fat-fingered value cannot hang {@code configure()} or sleep for weeks; it is not a
+     * recommended operating point.
      * <p>
      * Size together with {@link #RETRY_COUNT} when {@link #RETRY_TRANSIENT_ERRORS} is enabled: each of the
      * {@code (retry-count + 1)} cache attempts may run this many HTTP attempts plus client backoff sleeps.
@@ -264,6 +269,8 @@ public class SchemaResolverConfig extends AbstractConfig {
      */
     public static final String CLIENT_RETRY_MAX_ATTEMPTS = "apicurio.registry.client.retry.max-attempts";
     public static final long CLIENT_RETRY_MAX_ATTEMPTS_DEFAULT = 3;
+    /** Inclusive upper bound for {@link #CLIENT_RETRY_MAX_ATTEMPTS}. */
+    public static final long CLIENT_RETRY_MAX_ATTEMPTS_MAX = 1000;
 
     /**
      * Initial retry delay in milliseconds for the underlying registry HTTP client.
@@ -529,10 +536,11 @@ public class SchemaResolverConfig extends AbstractConfig {
     public long getClientRetryMaxAttempts() {
         // Fail fast with the property name rather than ArithmeticException at Math.toIntExact later.
         long value = getLongNonNegative(CLIENT_RETRY_MAX_ATTEMPTS);
-        if (value < 1 || value > Integer.MAX_VALUE) {
+        if (value < 1 || value > CLIENT_RETRY_MAX_ATTEMPTS_MAX) {
             throw new IllegalArgumentException("Invalid configuration property value for '"
                     + CLIENT_RETRY_MAX_ATTEMPTS
-                    + "'. Expected an integer in [1, " + Integer.MAX_VALUE + "], but got '" + value + "'.");
+                    + "'. Expected an integer in [1, " + CLIENT_RETRY_MAX_ATTEMPTS_MAX
+                    + "], but got '" + value + "'.");
         }
         return value;
     }

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/config/SchemaResolverConfig.java
@@ -481,11 +481,11 @@ public class SchemaResolverConfig extends AbstractConfig {
         if (value == null) {
             return CLIENT_RETRY_BACKOFF_MULTIPLIER_DEFAULT;
         }
-        if (value instanceof Number) {
-            return ((Number) value).doubleValue();
-        } else if (value instanceof String) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        } else if (value instanceof String string) {
             try {
-                return Double.parseDouble((String) value);
+                return Double.parseDouble(string);
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException("Invalid configuration property value for '"
                         + CLIENT_RETRY_BACKOFF_MULTIPLIER + "'. Expected a number-like value, but got a '"

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/AbstractSchemaResolverTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/AbstractSchemaResolverTest.java
@@ -195,6 +195,53 @@ public class AbstractSchemaResolverTest {
         }
     }
 
+    @Test
+    void estimateClientRetryLadderSleepMsMatchesManualSumForSmallAttemptCounts() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_ENABLED, true);
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_MAX_ATTEMPTS, 5);
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_DELAY_MS, 250);
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_BACKOFF_MULTIPLIER, 2.0);
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_MAX_DELAY_MS, 10000);
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        // sleeps: 250 + 500 + 1000 + 2000
+        assertEquals(3750L, AbstractSchemaResolver.estimateClientRetryLadderSleepMs(config));
+    }
+
+    @Test
+    void estimateClientRetryLadderSleepMsBailsOutOnceClampEngages() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_ENABLED, true);
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_MAX_ATTEMPTS,
+                SchemaResolverConfig.CLIENT_RETRY_MAX_ATTEMPTS_MAX);
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_DELAY_MS, 10000);
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_BACKOFF_MULTIPLIER, 2.0);
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_MAX_DELAY_MS, 10000);
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+
+        long start = System.nanoTime();
+        long sleepMs = AbstractSchemaResolver.estimateClientRetryLadderSleepMs(config);
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+
+        // 999 sleeps at the clamp = 9_990_000; must not iterate 999 times of Math.pow.
+        assertEquals(9_990_000L, sleepMs);
+        assertTrue(elapsedMs < 50, "clamp short-circuit should be near-instant, was " + elapsedMs + "ms");
+    }
+
+    @Test
+    void estimateClientRetryLadderSleepMsIsZeroWhenDisabledOrSingleAttempt() {
+        Map<String, Object> disabled = new HashMap<>();
+        disabled.put(SchemaResolverConfig.CLIENT_RETRY_ENABLED, false);
+        disabled.put(SchemaResolverConfig.CLIENT_RETRY_MAX_ATTEMPTS, 10);
+        assertEquals(0L, AbstractSchemaResolver.estimateClientRetryLadderSleepMs(
+                new SchemaResolverConfig(disabled)));
+
+        Map<String, Object> once = new HashMap<>();
+        once.put(SchemaResolverConfig.CLIENT_RETRY_MAX_ATTEMPTS, 1);
+        assertEquals(0L, AbstractSchemaResolver.estimateClientRetryLadderSleepMs(
+                new SchemaResolverConfig(once)));
+    }
+
     private TestAbstractSchemaResolver<String, Object> createResolver(MockRegistryClientFacade mockFacade) {
         Map<String, String> configs = Collections.singletonMap(SchemaResolverConfig.REGISTRY_URL,
                 "http://localhost");

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/cache/ERCacheRetriableFailureTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/cache/ERCacheRetriableFailureTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ERCacheRetriableFailureTest {
@@ -180,6 +181,10 @@ class ERCacheRetriableFailureTest {
         assertTrue(attempts.get() >= 1);
         assertTrue(attempts.get() < 11, "total timeout should stop before exhausting all retries");
         assertTrue(result.error.getMessage().contains("total retry timeout"));
+        assertNotNull(result.error.getCause(),
+                "timeout error must keep the last attempt's failure as cause");
+        assertTrue(result.error.getCause().getCause() instanceof ConnectException
+                || result.error.getCause() instanceof ConnectException);
     }
 
     private static ApiException api(int status) {

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/cache/ERCacheRetriableFailureTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/cache/ERCacheRetriableFailureTest.java
@@ -1,0 +1,74 @@
+package io.apicurio.registry.resolver.cache;
+
+import com.microsoft.kiota.ApiException;
+import io.vertx.core.VertxException;
+import io.vertx.core.http.HttpClosedException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ERCacheRetriableFailureTest {
+
+    @Test
+    void retriesDirectAndWrapped429() {
+        assertTrue(ERCache.isRetriableCacheLoadFailure(api(429)));
+        assertTrue(ERCache.isRetriableCacheLoadFailure(
+                new RuntimeException(new ExecutionException(api(429)))));
+        assertTrue(ERCache.isRetriableCacheLoadFailure(
+                new RuntimeException(new RuntimeException(new ExecutionException(api(429))))));
+    }
+
+    @Test
+    void retriesOutageStatusCodes() {
+        assertTrue(ERCache.isRetriableCacheLoadFailure(api(502)));
+        assertTrue(ERCache.isRetriableCacheLoadFailure(api(503)));
+        assertTrue(ERCache.isRetriableCacheLoadFailure(api(504)));
+    }
+
+    @Test
+    void doesNotRetryNonRetriableApiStatuses() {
+        assertFalse(ERCache.isRetriableCacheLoadFailure(api(404)));
+        assertFalse(ERCache.isRetriableCacheLoadFailure(api(500)));
+    }
+
+    @Test
+    void retriesSocketFailuresWithoutMessageMatching() {
+        assertTrue(ERCache.isRetriableCacheLoadFailure(new ConnectException("Connection refused")));
+        assertTrue(ERCache.isRetriableCacheLoadFailure(new SocketException("Connection reset")));
+        assertTrue(ERCache.isRetriableCacheLoadFailure(new SocketTimeoutException("Read timed out")));
+    }
+
+    @Test
+    void doesNotRetryGenericIoOrRuntimeFailures() {
+        assertFalse(ERCache.isRetriableCacheLoadFailure(new IOException((String) null)));
+        assertFalse(ERCache.isRetriableCacheLoadFailure(new IOException("disk full")));
+        assertFalse(ERCache.isRetriableCacheLoadFailure(new RuntimeException("boom")));
+    }
+
+    @Test
+    void retriesVertxClosedAndTimeoutFailures() {
+        assertTrue(ERCache.isRetriableCacheLoadFailure(new HttpClosedException("Connection was closed")));
+        assertTrue(ERCache.isRetriableCacheLoadFailure(
+                new VertxException("The timeout period of 30000ms has been exceeded")));
+        assertTrue(ERCache.isRetriableCacheLoadFailure(
+                new RuntimeException(new VertxException("The timeout was triggered"))));
+    }
+
+    private static ApiException api(int status) {
+        return new TestApiException(status);
+    }
+
+    private static final class TestApiException extends ApiException {
+        TestApiException(int status) {
+            super("HTTP " + status);
+            setResponseStatusCode(status);
+        }
+    }
+}

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/cache/ERCacheRetriableFailureTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/cache/ERCacheRetriableFailureTest.java
@@ -23,65 +23,147 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.ConnectException;
+import java.net.NoRouteToHostException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ERCacheRetriableFailureTest {
 
     @Test
-    void retriesDirectAndWrapped429() {
+    void retriesDirectAndWrapped429EvenWithoutTransientOptIn() {
         assertTrue(ERCache.isRetriableCacheLoadFailure(api(429)));
         assertTrue(ERCache.isRetriableCacheLoadFailure(
                 new RuntimeException(new ExecutionException(api(429)))));
         assertTrue(ERCache.isRetriableCacheLoadFailure(
                 new RuntimeException(new RuntimeException(new ExecutionException(api(429))))));
+        assertTrue(ERCache.isRetriableCacheLoadFailure(api(429), false));
     }
 
     @Test
-    void retriesOutageStatusCodes() {
-        assertTrue(ERCache.isRetriableCacheLoadFailure(api(502)));
-        assertTrue(ERCache.isRetriableCacheLoadFailure(api(503)));
-        assertTrue(ERCache.isRetriableCacheLoadFailure(api(504)));
+    void outageStatusesRequireTransientOptIn() {
+        assertFalse(ERCache.isRetriableCacheLoadFailure(api(502), false));
+        assertFalse(ERCache.isRetriableCacheLoadFailure(api(503), false));
+        assertFalse(ERCache.isRetriableCacheLoadFailure(api(504), false));
+
+        assertTrue(ERCache.isRetriableCacheLoadFailure(api(502), true));
+        assertTrue(ERCache.isRetriableCacheLoadFailure(api(503), true));
+        assertTrue(ERCache.isRetriableCacheLoadFailure(api(504), true));
     }
 
     @Test
     void doesNotRetryNonRetriableApiStatuses() {
-        assertFalse(ERCache.isRetriableCacheLoadFailure(api(404)));
-        assertFalse(ERCache.isRetriableCacheLoadFailure(api(500)));
+        assertFalse(ERCache.isRetriableCacheLoadFailure(api(404), true));
+        assertFalse(ERCache.isRetriableCacheLoadFailure(api(500), true));
+    }
+
+    @Test
+    void apiStatusOutvotesNetworkCauseDeeperInChain() {
+        ApiException notFound = api(404);
+        notFound.initCause(new ConnectException("Connection refused"));
+        assertFalse(ERCache.isRetriableCacheLoadFailure(new RuntimeException(notFound), true));
     }
 
     @Test
     void doesNotRetryApiExceptionWithoutStatusCode() {
         ApiException withoutStatus = new ApiException("no status");
-        assertFalse(ERCache.isRetriableCacheLoadFailure(withoutStatus));
-        assertFalse(ERCache.isRetriableCacheLoadFailure(new RuntimeException(withoutStatus)));
+        assertFalse(ERCache.isRetriableCacheLoadFailure(withoutStatus, true));
+        assertFalse(ERCache.isRetriableCacheLoadFailure(new RuntimeException(withoutStatus), true));
     }
 
     @Test
-    void retriesSocketFailuresWithoutMessageMatching() {
-        assertTrue(ERCache.isRetriableCacheLoadFailure(new ConnectException("Connection refused")));
-        assertTrue(ERCache.isRetriableCacheLoadFailure(new SocketException("Connection reset")));
-        assertTrue(ERCache.isRetriableCacheLoadFailure(new SocketTimeoutException("Read timed out")));
+    void networkFailuresRequireTransientOptIn() {
+        ConnectException refused = new ConnectException("Connection refused");
+        assertFalse(ERCache.isRetriableCacheLoadFailure(refused, false));
+        assertTrue(ERCache.isRetriableCacheLoadFailure(refused, true));
+        assertTrue(ERCache.isRetriableCacheLoadFailure(new SocketException("Connection reset"), true));
+        assertTrue(ERCache.isRetriableCacheLoadFailure(new SocketTimeoutException("Read timed out"), true));
+    }
+
+    @Test
+    void doesNotRetryResourceExhaustionOrUnreachableRoute() {
+        assertFalse(ERCache.isRetriableCacheLoadFailure(
+                new SocketException("Too many open files"), true));
+        assertFalse(ERCache.isRetriableCacheLoadFailure(
+                new SocketException("No buffer space available"), true));
+        assertFalse(ERCache.isRetriableCacheLoadFailure(
+                new NoRouteToHostException("Network is unreachable"), true));
     }
 
     @Test
     void doesNotRetryGenericIoOrRuntimeFailures() {
-        assertFalse(ERCache.isRetriableCacheLoadFailure(new IOException((String) null)));
-        assertFalse(ERCache.isRetriableCacheLoadFailure(new IOException("disk full")));
-        assertFalse(ERCache.isRetriableCacheLoadFailure(new RuntimeException("boom")));
+        assertFalse(ERCache.isRetriableCacheLoadFailure(new IOException((String) null), true));
+        assertFalse(ERCache.isRetriableCacheLoadFailure(new IOException("disk full"), true));
+        assertFalse(ERCache.isRetriableCacheLoadFailure(new RuntimeException("boom"), true));
     }
 
     @Test
-    void retriesVertxClosedAndTimeoutFailures() {
-        assertTrue(ERCache.isRetriableCacheLoadFailure(new HttpClosedException("Connection was closed")));
+    void retriesVertxClosedAndTimeoutFailuresWhenTransientEnabled() {
+        assertFalse(ERCache.isRetriableCacheLoadFailure(
+                new HttpClosedException("Connection was closed"), false));
         assertTrue(ERCache.isRetriableCacheLoadFailure(
-                new VertxException("The timeout period of 30000ms has been exceeded")));
+                new HttpClosedException("Connection was closed"), true));
         assertTrue(ERCache.isRetriableCacheLoadFailure(
-                new RuntimeException(new VertxException("The timeout was triggered"))));
+                new VertxException("The timeout period of 30000ms has been exceeded"), true));
+        assertTrue(ERCache.isRetriableCacheLoadFailure(
+                new RuntimeException(new VertxException("The timeout was triggered")), true));
+    }
+
+    @Test
+    void causeWalkHasDepthCapAgainstCycles() {
+        RuntimeException a = new RuntimeException("a");
+        RuntimeException b = new RuntimeException("b");
+        a.initCause(b);
+        b.initCause(a);
+        assertFalse(ERCache.isRetriableCacheLoadFailure(a, true));
+    }
+
+    @Test
+    void retryLoopInvokesRetriesPlusOneForRetriableFailure() {
+        AtomicInteger attempts = new AtomicInteger();
+        ERCache.Result<String, RuntimeException> result = ERCache.retry(
+                Duration.ofMillis(1), 2, true,
+                () -> {
+                    attempts.incrementAndGet();
+                    throw new RuntimeException(new ConnectException("Connection refused"));
+                });
+
+        assertTrue(result.isError());
+        assertEquals(3, attempts.get());
+    }
+
+    @Test
+    void retryLoopStopsImmediatelyForNonRetriableFailure() {
+        AtomicInteger attempts = new AtomicInteger();
+        ERCache.Result<String, RuntimeException> result = ERCache.retry(
+                Duration.ofMillis(1), 3, true,
+                () -> {
+                    attempts.incrementAndGet();
+                    throw new RuntimeException(api(404));
+                });
+
+        assertTrue(result.isError());
+        assertEquals(1, attempts.get());
+    }
+
+    @Test
+    void retryLoopDoesNotRetryNetworkFailuresWithoutTransientOptIn() {
+        AtomicInteger attempts = new AtomicInteger();
+        ERCache.Result<String, RuntimeException> result = ERCache.retry(
+                Duration.ofMillis(1), 3, false,
+                () -> {
+                    attempts.incrementAndGet();
+                    throw new RuntimeException(new ConnectException("Connection refused"));
+                });
+
+        assertTrue(result.isError());
+        assertEquals(1, attempts.get());
     }
 
     private static ApiException api(int status) {

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/cache/ERCacheRetriableFailureTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/cache/ERCacheRetriableFailureTest.java
@@ -87,12 +87,12 @@ class ERCacheRetriableFailureTest {
     }
 
     @Test
-    void doesNotRetryResourceExhaustionOrUnreachableRoute() {
+    void doesNotRetryResourceExhaustionButRetriesUnreachableHost() {
         assertFalse(ERCache.isRetriableCacheLoadFailure(
                 new SocketException("Too many open files"), true));
         assertFalse(ERCache.isRetriableCacheLoadFailure(
                 new SocketException("No buffer space available"), true));
-        assertFalse(ERCache.isRetriableCacheLoadFailure(
+        assertTrue(ERCache.isRetriableCacheLoadFailure(
                 new NoRouteToHostException("Network is unreachable"), true));
     }
 
@@ -164,6 +164,22 @@ class ERCacheRetriableFailureTest {
 
         assertTrue(result.isError());
         assertEquals(1, attempts.get());
+    }
+
+    @Test
+    void retryLoopHonorsTotalTimeoutBudget() {
+        AtomicInteger attempts = new AtomicInteger();
+        ERCache.Result<String, RuntimeException> result = ERCache.retry(
+                Duration.ofMillis(50), 10, true, Duration.ofMillis(80),
+                () -> {
+                    attempts.incrementAndGet();
+                    throw new RuntimeException(new ConnectException("Connection refused"));
+                });
+
+        assertTrue(result.isError());
+        assertTrue(attempts.get() >= 1);
+        assertTrue(attempts.get() < 11, "total timeout should stop before exhausting all retries");
+        assertTrue(result.error.getMessage().contains("total retry timeout"));
     }
 
     private static ApiException api(int status) {

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/cache/ERCacheRetriableFailureTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/cache/ERCacheRetriableFailureTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.apicurio.registry.resolver.cache;
 
 import com.microsoft.kiota.ApiException;
@@ -36,6 +52,13 @@ class ERCacheRetriableFailureTest {
     void doesNotRetryNonRetriableApiStatuses() {
         assertFalse(ERCache.isRetriableCacheLoadFailure(api(404)));
         assertFalse(ERCache.isRetriableCacheLoadFailure(api(500)));
+    }
+
+    @Test
+    void doesNotRetryApiExceptionWithoutStatusCode() {
+        ApiException withoutStatus = new ApiException("no status");
+        assertFalse(ERCache.isRetriableCacheLoadFailure(withoutStatus));
+        assertFalse(ERCache.isRetriableCacheLoadFailure(new RuntimeException(withoutStatus)));
     }
 
     @Test

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactorySanitizeUrlTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactorySanitizeUrlTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.resolver.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class RegistryClientFacadeFactorySanitizeUrlTest {
+
+    @Test
+    void stripsUserInfoFromRegistryUrl() {
+        assertEquals("https://registry.example.com/apis/registry/v3",
+                RegistryClientFacadeFactory.sanitizeRegistryUrl(
+                        "https://user:secret@registry.example.com/apis/registry/v3"));
+    }
+
+    @Test
+    void passesThroughUrlWithoutUserInfo() {
+        String url = "https://registry.example.com/apis/registry/v3";
+        assertEquals(url, RegistryClientFacadeFactory.sanitizeRegistryUrl(url));
+    }
+
+    @Test
+    void returnsNullAndBlankUnchanged() {
+        assertNull(RegistryClientFacadeFactory.sanitizeRegistryUrl(null));
+        assertEquals("", RegistryClientFacadeFactory.sanitizeRegistryUrl(""));
+        assertEquals("   ", RegistryClientFacadeFactory.sanitizeRegistryUrl("   "));
+    }
+
+    @Test
+    void malformedUrlReturnsInvalidMarkerWithoutEchoingInput() {
+        // IllegalArgumentException from URI.create; must not echo raw input (may contain secrets).
+        String malformed = "http://user:s ecret@[:::";
+        assertEquals("<invalid-url>", RegistryClientFacadeFactory.sanitizeRegistryUrl(malformed));
+    }
+}

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/config/ClientRetryConfigTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/config/ClientRetryConfigTest.java
@@ -18,6 +18,7 @@ package io.apicurio.registry.resolver.config;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,6 +35,7 @@ class ClientRetryConfigTest {
 
         assertTrue(config.getClientRetryEnabled());
         assertFalse(config.getRetryTransientErrors());
+        assertEquals(Duration.ZERO, config.getRetryTotalTimeout());
         // Must stay aligned with RegistryClientOptions#retry() defaults
         // (pinned by RegistryClientOptionsRetryDefaultsTest in java-sdk/common).
         assertEquals(3L, config.getClientRetryMaxAttempts());

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/config/ClientRetryConfigTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/config/ClientRetryConfigTest.java
@@ -33,6 +33,7 @@ class ClientRetryConfigTest {
         SchemaResolverConfig config = new SchemaResolverConfig(Map.of());
 
         assertTrue(config.getClientRetryEnabled());
+        assertFalse(config.getRetryTransientErrors());
         // Must stay aligned with RegistryClientOptions#retry() defaults
         // (pinned by RegistryClientOptionsRetryDefaultsTest in java-sdk/common).
         assertEquals(3L, config.getClientRetryMaxAttempts());
@@ -49,14 +50,34 @@ class ClientRetryConfigTest {
         originals.put(SchemaResolverConfig.CLIENT_RETRY_DELAY_MS, "1000");
         originals.put(SchemaResolverConfig.CLIENT_RETRY_BACKOFF_MULTIPLIER, "1.5");
         originals.put(SchemaResolverConfig.CLIENT_RETRY_MAX_DELAY_MS, "30000");
+        originals.put(SchemaResolverConfig.RETRY_TRANSIENT_ERRORS, "true");
 
         SchemaResolverConfig config = new SchemaResolverConfig(originals);
 
         assertFalse(config.getClientRetryEnabled());
+        assertTrue(config.getRetryTransientErrors());
         assertEquals(30L, config.getClientRetryMaxAttempts());
         assertEquals(1000L, config.getClientRetryDelayMs());
         assertEquals(1.5d, config.getClientRetryBackoffMultiplier());
         assertEquals(30000L, config.getClientRetryMaxDelayMs());
+    }
+
+    @Test
+    void maxAttemptsRejectsValuesThatDoNotFitInt() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_MAX_ATTEMPTS, "5000000000");
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                config::getClientRetryMaxAttempts);
+        assertTrue(ex.getMessage().contains(SchemaResolverConfig.CLIENT_RETRY_MAX_ATTEMPTS));
+    }
+
+    @Test
+    void maxAttemptsRejectsZero() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_MAX_ATTEMPTS, "0");
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        assertThrows(IllegalArgumentException.class, config::getClientRetryMaxAttempts);
     }
 
     @Test

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/config/ClientRetryConfigTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/config/ClientRetryConfigTest.java
@@ -1,0 +1,73 @@
+package io.apicurio.registry.resolver.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClientRetryConfigTest {
+
+    @Test
+    void clientRetryDefaultsMatchRegistryClientOptionsRetry() {
+        SchemaResolverConfig config = new SchemaResolverConfig(Map.of());
+
+        assertTrue(config.getClientRetryEnabled());
+        // Must stay aligned with RegistryClientOptions#retry() defaults.
+        assertEquals(3L, config.getClientRetryMaxAttempts());
+        assertEquals(250L, config.getClientRetryDelayMs());
+        assertEquals(2.0d, config.getClientRetryBackoffMultiplier());
+        assertEquals(10000L, config.getClientRetryMaxDelayMs());
+    }
+
+    @Test
+    void clientRetryKeysCanBeOverridden() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_ENABLED, "false");
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_MAX_ATTEMPTS, "30");
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_DELAY_MS, "1000");
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_BACKOFF_MULTIPLIER, "1.5");
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_MAX_DELAY_MS, "30000");
+
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+
+        assertFalse(config.getClientRetryEnabled());
+        assertEquals(30L, config.getClientRetryMaxAttempts());
+        assertEquals(1000L, config.getClientRetryDelayMs());
+        assertEquals(1.5d, config.getClientRetryBackoffMultiplier());
+        assertEquals(30000L, config.getClientRetryMaxDelayMs());
+    }
+
+    @Test
+    void backoffMultiplierAcceptsNumberAndString() {
+        Map<String, Object> numberCfg = new HashMap<>();
+        numberCfg.put(SchemaResolverConfig.CLIENT_RETRY_BACKOFF_MULTIPLIER, 3);
+        assertEquals(3.0d, new SchemaResolverConfig(numberCfg).getClientRetryBackoffMultiplier());
+
+        Map<String, Object> stringCfg = new HashMap<>();
+        stringCfg.put(SchemaResolverConfig.CLIENT_RETRY_BACKOFF_MULTIPLIER, "2.5");
+        assertEquals(2.5d, new SchemaResolverConfig(stringCfg).getClientRetryBackoffMultiplier());
+    }
+
+    @Test
+    void backoffMultiplierRejectsInvalidValues() {
+        assertThrows(IllegalArgumentException.class,
+                () -> configWithBackoff("NaN").getClientRetryBackoffMultiplier());
+        assertThrows(IllegalArgumentException.class,
+                () -> configWithBackoff("-1").getClientRetryBackoffMultiplier());
+        assertThrows(IllegalArgumentException.class,
+                () -> configWithBackoff("1.0").getClientRetryBackoffMultiplier());
+        assertThrows(IllegalArgumentException.class,
+                () -> configWithBackoff("not-a-number").getClientRetryBackoffMultiplier());
+    }
+
+    private static SchemaResolverConfig configWithBackoff(Object value) {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_BACKOFF_MULTIPLIER, value);
+        return new SchemaResolverConfig(originals);
+    }
+}

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/config/ClientRetryConfigTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/config/ClientRetryConfigTest.java
@@ -75,6 +75,27 @@ class ClientRetryConfigTest {
     }
 
     @Test
+    void maxAttemptsRejectsAboveSaneCeiling() {
+        // 2e9 fits in int (Integer.MAX_VALUE is ~2.1e9) but would hang configure() if
+        // estimateClientRetryLadderSleepMs looped maxAttempts times.
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_MAX_ATTEMPTS, "2000000000");
+        SchemaResolverConfig config = new SchemaResolverConfig(originals);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                config::getClientRetryMaxAttempts);
+        assertTrue(ex.getMessage().contains("1000"));
+    }
+
+    @Test
+    void maxAttemptsAcceptsCeiling() {
+        Map<String, Object> originals = new HashMap<>();
+        originals.put(SchemaResolverConfig.CLIENT_RETRY_MAX_ATTEMPTS,
+                String.valueOf(SchemaResolverConfig.CLIENT_RETRY_MAX_ATTEMPTS_MAX));
+        assertEquals(SchemaResolverConfig.CLIENT_RETRY_MAX_ATTEMPTS_MAX,
+                new SchemaResolverConfig(originals).getClientRetryMaxAttempts());
+    }
+
+    @Test
     void maxAttemptsRejectsZero() {
         Map<String, Object> originals = new HashMap<>();
         originals.put(SchemaResolverConfig.CLIENT_RETRY_MAX_ATTEMPTS, "0");

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/config/ClientRetryConfigTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/config/ClientRetryConfigTest.java
@@ -72,14 +72,15 @@ class ClientRetryConfigTest {
 
     @Test
     void backoffMultiplierRejectsInvalidValues() {
-        assertThrows(IllegalArgumentException.class,
-                () -> configWithBackoff("NaN").getClientRetryBackoffMultiplier());
-        assertThrows(IllegalArgumentException.class,
-                () -> configWithBackoff("-1").getClientRetryBackoffMultiplier());
-        assertThrows(IllegalArgumentException.class,
-                () -> configWithBackoff("1.0").getClientRetryBackoffMultiplier());
-        assertThrows(IllegalArgumentException.class,
-                () -> configWithBackoff("not-a-number").getClientRetryBackoffMultiplier());
+        SchemaResolverConfig nan = configWithBackoff("NaN");
+        SchemaResolverConfig negative = configWithBackoff("-1");
+        SchemaResolverConfig one = configWithBackoff("1.0");
+        SchemaResolverConfig notANumber = configWithBackoff("not-a-number");
+
+        assertThrows(IllegalArgumentException.class, nan::getClientRetryBackoffMultiplier);
+        assertThrows(IllegalArgumentException.class, negative::getClientRetryBackoffMultiplier);
+        assertThrows(IllegalArgumentException.class, one::getClientRetryBackoffMultiplier);
+        assertThrows(IllegalArgumentException.class, notANumber::getClientRetryBackoffMultiplier);
     }
 
     private static SchemaResolverConfig configWithBackoff(Object value) {

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/config/ClientRetryConfigTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/config/ClientRetryConfigTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.apicurio.registry.resolver.config;
 
 import org.junit.jupiter.api.Test;
@@ -17,7 +33,8 @@ class ClientRetryConfigTest {
         SchemaResolverConfig config = new SchemaResolverConfig(Map.of());
 
         assertTrue(config.getClientRetryEnabled());
-        // Must stay aligned with RegistryClientOptions#retry() defaults.
+        // Must stay aligned with RegistryClientOptions#retry() defaults
+        // (pinned by RegistryClientOptionsRetryDefaultsTest in java-sdk/common).
         assertEquals(3L, config.getClientRetryMaxAttempts());
         assertEquals(250L, config.getClientRetryDelayMs());
         assertEquals(2.0d, config.getClientRetryBackoffMultiplier());


### PR DESCRIPTION
## Summary
- Exposes HTTP client retry settings via SerDes/converter config (based on #9091 / #8995): `apicurio.registry.client.retry.{enabled,max-attempts,delay-ms,backoff-multiplier,max-delay-ms}` and wires them into `RegistryClientOptions` instead of hardcoded `clientOptions.retry()`.
- Extends `ERCache` retries beyond HTTP 429 to transient network / registry-down failures (`ConnectException`, timeouts, connection reset, Vert.x `HttpClosedException`), controlled by existing `apicurio.registry.retry-count` / `retry-backoff-ms`.
- Adds production-style logging: INFO for effective client retry config, FINE/debug for per-attempt retries, WARNING/error when retries are exhausted.

## Motivation
Kafka Connect / Debezium converters fail hard on short Apicurio outages even when operators set `retry-count`. The existing cache retry only covers rate-limits, and HTTP client retries were not configurable from SerDes keys.

## Test plan
- [ ] `mvn -pl schema-resolver,java-sdk/common -am test`
- [ ] Configure converter with elevated `apicurio.registry.client.retry.max-attempts` / `delay-ms` and `apicurio.registry.retry-count`; confirm INFO log shows the configured values at client create
- [ ] Stop Apicurio briefly during auto-register / schema resolve; confirm retries occur and the task recovers when the registry returns (instead of failing after ~2s of default HTTP retries)
- [ ] Confirm non-retriable errors still fail without spinning


Made with [Cursor](https://cursor.com)