### PR TITLE
fix(ui): reset PleaseWait modal when delete/action requests fail

### DIFF
--- a/ui/ui-app/src/app/pages/artifact/ArtifactPage.tsx
+++ b/ui/ui-app/src/app/pages/artifact/ArtifactPage.tsx
@@ -3,7 +3,7 @@ import "./ArtifactPage.css";
 import { LoaderGuard, newLoaderGuard } from "@utils/loader.utils.ts";
 import { Breadcrumb, BreadcrumbItem, PageSection, Tab, Tabs } from "@patternfly/react-core";
 import { Link, useMatch, useParams } from "react-router";
-import { EXPLORE_PAGE_IDX, PageDataLoader, PageError, PageErrorHandler, PageProperties, toPageError } from "@app/pages";
+import { EXPLORE_PAGE_IDX, handleMutatingActionError, PageDataLoader, PageError, PageErrorHandler, PageProperties, toPageError } from "@app/pages";
 import {
     ChangeOwnerModal,
     ConfirmDeleteModal,
@@ -192,7 +192,7 @@ export const ArtifactPage: FunctionComponent<PageProperties> = () => {
             pleaseWait(false, "");
             appNavigation.navigateTo("/explore");
         }).catch(error => {
-            setPageError(toPageError(error, "Error deleting an artifact."));
+            handleMutatingActionError(error, "Error deleting an artifact.", setPageError, () => pleaseWait(false));
         });
     };
 
@@ -262,7 +262,7 @@ export const ArtifactPage: FunctionComponent<PageProperties> = () => {
                 versionDeleteSuccessCallback();
             }
         }).catch(error => {
-            setPageError(toPageError(error, "Error deleting a version."));
+            handleMutatingActionError(error, "Error deleting a version.", setPageError, () => pleaseWait(false));
         });
     };
 
@@ -287,8 +287,7 @@ export const ArtifactPage: FunctionComponent<PageProperties> = () => {
             const bid: string = encodeURIComponent(branchId);
             appNavigation.navigateTo(`/explore/${gid}/${aid}/branches/${bid}/versions`);
         }).catch(error => {
-            pleaseWait(false);
-            setPageError(toPageError(error, "Error adding a version to a branch."));
+            handleMutatingActionError(error, "Error adding a version to a branch.", setPageError, () => pleaseWait(false));
         });
     };
 
@@ -321,7 +320,7 @@ export const ArtifactPage: FunctionComponent<PageProperties> = () => {
                 branchDeleteSuccessCallback();
             }
         }).catch(error => {
-            setPageError(toPageError(error, "Error deleting a branch."));
+            handleMutatingActionError(error, "Error deleting a branch.", setPageError, () => pleaseWait(false));
         });
     };
 

--- a/ui/ui-app/src/app/pages/branch/BranchPage.tsx
+++ b/ui/ui-app/src/app/pages/branch/BranchPage.tsx
@@ -5,6 +5,7 @@ import { Breadcrumb, BreadcrumbItem, PageSection,  } from "@patternfly/react-cor
 import { Link, useParams } from "react-router";
 import {
     EXPLORE_PAGE_IDX,
+    handleMutatingActionError,
     PageDataLoader,
     PageError,
     PageErrorHandler,
@@ -86,7 +87,7 @@ export const BranchPage: FunctionComponent<PageProperties> = () => {
             const aid: string = encodeURIComponent(artifactId as string);
             appNavigation.navigateTo(`/explore/${gid}/${aid}/branches`);
         }).catch(error => {
-            setPageError(toPageError(error, "Error deleting a version."));
+            handleMutatingActionError(error, "Error deleting a branch.", setPageError, () => pleaseWait(false));
         });
     };
 

--- a/ui/ui-app/src/app/pages/explore/ExplorePage.tsx
+++ b/ui/ui-app/src/app/pages/explore/ExplorePage.tsx
@@ -7,6 +7,7 @@ import {
     ExplorePageEmptyState,
     ExplorePageToolbar,
     ExplorePageToolbarFilterCriteria, ImportModal,
+    handleMutatingActionError,
     PageDataLoader,
     PageError,
     PageErrorHandler,
@@ -230,7 +231,7 @@ export const ExplorePage: FunctionComponent<ExplorePageProps> = () => {
                     search(criteria, resetPaging);
                 }, 1500);
             }).catch(error => {
-                setPageError(toPageError(error, "Error importing multiple artifacts"));
+                handleMutatingActionError(error, "Error importing multiple artifacts", setPageError, () => setImporting(false));
             });
         }
     };
@@ -259,7 +260,7 @@ export const ExplorePage: FunctionComponent<ExplorePageProps> = () => {
             setPaging(resetPaging);
             search(criteria, resetPaging);
         }).catch(error => {
-            setPageError(toPageError(error, "Error deleting group."));
+            handleMutatingActionError(error, "Error deleting group.", setPageError, () => pleaseWait(false));
         });
     };
 

--- a/ui/ui-app/src/app/pages/group/GroupPage.tsx
+++ b/ui/ui-app/src/app/pages/group/GroupPage.tsx
@@ -7,6 +7,7 @@ import {
     EXPLORE_PAGE_IDX,
     GroupOverviewTabContent,
     GroupPageHeader, GroupRulesTabContent,
+    handleMutatingActionError,
     PageDataLoader,
     PageError,
     PageErrorHandler,
@@ -122,7 +123,7 @@ export const GroupPage: FunctionComponent<PageProperties> = () => {
             pleaseWait(false);
             appNavigation.navigateTo("/explore");
         }).catch(error => {
-            setPageError(toPageError(error, "Error deleting group."));
+            handleMutatingActionError(error, "Error deleting group.", setPageError, () => pleaseWait(false));
         });
     };
 
@@ -134,6 +135,8 @@ export const GroupPage: FunctionComponent<PageProperties> = () => {
             if (artifactDeleteSuccessCallback) {
                 artifactDeleteSuccessCallback();
             }
+        }).catch(error => {
+            handleMutatingActionError(error, "Error deleting artifact.", setPageError, () => pleaseWait(false));
         });
     };
 

--- a/ui/ui-app/src/app/pages/handleMutatingActionError.test.ts
+++ b/ui/ui-app/src/app/pages/handleMutatingActionError.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleMutatingActionError } from "./handleMutatingActionError";
+import { PageErrorType } from "./PageErrorType";
+
+describe("handleMutatingActionError", () => {
+    it("clears the wait overlay and sets a page error", () => {
+        const clearWait = vi.fn();
+        const setPageError = vi.fn();
+        const error = { status: 500, detail: "boom" };
+
+        handleMutatingActionError(error, "Error deleting an artifact.", setPageError, clearWait);
+
+        expect(clearWait).toHaveBeenCalledTimes(1);
+        expect(setPageError).toHaveBeenCalledTimes(1);
+        expect(setPageError).toHaveBeenCalledWith({
+            error,
+            errorMessage: "Error deleting an artifact.",
+            type: PageErrorType.Server
+        });
+        expect(clearWait.mock.invocationCallOrder[0]).toBeLessThan(setPageError.mock.invocationCallOrder[0]);
+    });
+
+    it("still sets the page error when no clearWait callback is provided", () => {
+        const setPageError = vi.fn();
+
+        handleMutatingActionError({ status: 400 }, "Error deleting a version.", setPageError);
+
+        expect(setPageError).toHaveBeenCalledWith({
+            error: { status: 400 },
+            errorMessage: "Error deleting a version.",
+            type: PageErrorType.Server
+        });
+    });
+});

--- a/ui/ui-app/src/app/pages/handleMutatingActionError.ts
+++ b/ui/ui-app/src/app/pages/handleMutatingActionError.ts
@@ -1,0 +1,18 @@
+import { PageError } from "@app/pages/PageError.ts";
+import { toPageError } from "@app/pages/toPageError.ts";
+
+export type ClearWaitFn = () => void;
+
+/**
+ * Clears a blocking wait/progress overlay and records a page-level error.
+ * Use in mutating-action `.catch` handlers so a failed request cannot leave the modal stuck.
+ */
+export const handleMutatingActionError = (
+    error: any,
+    errorMessage: string,
+    setPageError: (pageError: PageError) => void,
+    clearWait?: ClearWaitFn
+): void => {
+    clearWait?.();
+    setPageError(toPageError(error, errorMessage));
+};

--- a/ui/ui-app/src/app/pages/index.ts
+++ b/ui/ui-app/src/app/pages/index.ts
@@ -21,3 +21,4 @@ export * from "./PageErrorType";
 export * from "./PageProperties";
 export * from "./Pages";
 export * from "./toPageError";
+export * from "./handleMutatingActionError";

--- a/ui/ui-app/src/app/pages/roles/RolesPage.tsx
+++ b/ui/ui-app/src/app/pages/roles/RolesPage.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent, useEffect, useState } from "react";
 import "./RolesPage.css";
 import { PageSection, PageSectionVariants } from "@patternfly/react-core";
 import {
+    handleMutatingActionError,
     PageDataLoader,
     PageError,
     PageErrorHandler,
@@ -86,7 +87,7 @@ export const RolesPage: FunctionComponent<PageProperties> = () => {
             pleaseWait(false, "");
             setRoles([...currentRoleMappings]);
         }).catch(error => {
-            setPageError(toPageError(error, "Error updating access."));
+            handleMutatingActionError(error, "Error updating access.", setPageError, () => pleaseWait(false, ""));
         });
     };
 
@@ -105,7 +106,7 @@ export const RolesPage: FunctionComponent<PageProperties> = () => {
                     // and we should instead update.
                     updateRoleMapping(principal, role);
                 } else {
-                    setPageError(toPageError(error, "Error granting access."));
+                    handleMutatingActionError(error, "Error granting access.", setPageError, () => pleaseWait(false, ""));
                 }
             });
         }
@@ -117,7 +118,7 @@ export const RolesPage: FunctionComponent<PageProperties> = () => {
             pleaseWait(false, "");
             removeMapping(role.principalId!);
         }).catch(error => {
-            setPageError(toPageError(error, "Error revoking access."));
+            handleMutatingActionError(error, "Error revoking access.", setPageError, () => pleaseWait(false, ""));
         });
     };
 

--- a/ui/ui-app/src/app/pages/version/VersionPage.tsx
+++ b/ui/ui-app/src/app/pages/version/VersionPage.tsx
@@ -7,6 +7,7 @@ import {
     ContentTabContent,
     DocumentationTabContent,
     EXPLORE_PAGE_IDX,
+    handleMutatingActionError,
     PageDataLoader,
     PageError,
     PageErrorHandler,
@@ -274,7 +275,7 @@ export const VersionPage: FunctionComponent<PageProperties> = () => {
             const aid: string = encodeURIComponent(artifactId as string);
             appNavigation.navigateTo(`/explore/${gid}/${aid}`);
         }).catch(error => {
-            setPageError(toPageError(error, "Error deleting a version."));
+            handleMutatingActionError(error, "Error deleting a version.", setPageError, () => pleaseWait(false));
         });
     };
 


### PR DESCRIPTION
## Summary
- Fixes #9408: failed delete/action requests no longer leave the blocking **Please wait** modal stuck open.
- Adds shared `handleMutatingActionError` next to `toPageError` and uses it on mutating-action failure paths so clearing the wait overlay and setting the page error happen in one place.
- Sweep of `pleaseWait(true` in ui-app also fixed RolesPage catch handlers and Explore ZIP import (`ProgressModal` / `setImporting(false)` on failure).
- Corrects BranchPage delete error copy from "Error deleting a version." to "Error deleting a branch."
- Helper unit tests added. Page-level harness/regression test tracked in #9584 (manual checklist left unchecked until exercised).

## Test plan
- [ ] On Artifact page, trigger a failed delete artifact/version/branch and confirm Please wait closes and the page remains usable
- [ ] On Version page, trigger a failed delete version and confirm the modal closes
- [ ] On Explore / Group page, trigger a failed delete group (and artifact delete on Group) and confirm the modal closes
- [ ] On Branch page, trigger a failed delete branch and confirm the modal closes
- [ ] On Explore, force a failed ZIP import and confirm the import progress modal closes
- [ ] On Roles/Access page, force a failed grant/update/revoke and confirm Please wait closes
- [ ] Confirm successful deletes still close the modal and navigate as before
- [x] `npx vitest run src/app/pages/handleMutatingActionError.test.ts` in `ui/ui-app`
