### PR TITLE
fix(webhooks): fail closed when webhook ContentValidator is unreachable

### DIFF
--- a/app/src/main/java/io/apicurio/registry/types/provider/configured/ConfiguredContentValidator.java
+++ b/app/src/main/java/io/apicurio/registry/types/provider/configured/ConfiguredContentValidator.java
@@ -81,8 +81,14 @@ public class ConfiguredContentValidator extends AbstractConfiguredArtifactTypeUt
                 }
             } catch (RuleViolationException rve) {
                 throw rve;
-            } catch (Throwable e) {
+            } catch (Exception e) {
+                // The webhook is unreachable, timed out, or returned an error.
+                // Fail closed: reject the artifact rather than silently accepting it.
+                // Catching Exception (not Throwable) so JVM-level Errors (OOM, etc.)
+                // are not misrepresented as rule violations.
                 log.error("Error invoking webhook", e);
+                throw new RuleViolationException("Webhook validation failed to execute.",
+                        RuleType.VALIDITY, level.name(), e);
             }
         }
 
@@ -101,8 +107,16 @@ public class ConfiguredContentValidator extends AbstractConfiguredArtifactTypeUt
                 }
             } catch (RuleViolationException rve) {
                 throw rve;
-            } catch (Throwable e) {
+            } catch (Exception e) {
+                // The webhook is unreachable, timed out, or returned an error.
+                // Fail closed: reject the artifact rather than silently accepting it.
+                // Catching Exception (not Throwable) so JVM-level Errors (OOM, etc.)
+                // are not misrepresented as rule violations.
+                // ALL_REFS_MAPPED is the integrity level that triggers validateReferences()
+                // (see IntegrityRuleExecutor), so it is the correct cause to report here.
                 log.error("Error invoking webhook", e);
+                throw new RuleViolationException("Webhook reference validation failed to execute.",
+                        RuleType.INTEGRITY, IntegrityLevel.ALL_REFS_MAPPED.name(), e);
             }
         }
 

--- a/app/src/test/java/io/apicurio/registry/customTypes/WebhookArtifactTypesTest.java
+++ b/app/src/test/java/io/apicurio/registry/customTypes/WebhookArtifactTypesTest.java
@@ -1,11 +1,23 @@
 package io.apicurio.registry.customTypes;
 
+import io.apicurio.registry.rest.client.models.CreateArtifact;
+import io.apicurio.registry.rest.client.models.CreateGroup;
+import io.apicurio.registry.rest.client.models.CreateRule;
+import io.apicurio.registry.rest.client.models.RuleType;
+import io.apicurio.registry.rest.client.models.RuleViolationProblemDetails;
+import io.apicurio.registry.rules.validity.ValidityLevel;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.TestUtils;
 import io.apicurio.utils.test.raml.microsvc.RamlTestMicroService;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.vertx.core.Vertx;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
 
 @QuarkusTest
 @TestProfile(WebhookArtifactTypesTestProfile.class)
@@ -28,6 +40,52 @@ public class WebhookArtifactTypesTest extends AbstractCustomArtifactTypesTest {
         // Shut down the RAML microservice.
         ramlMicroService.stopServer();
         vertx.close();
+    }
+
+    @Test
+    public void testWebhookValidatorFailsClosed() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+
+        // Create the group and enable the FULL validity rule.
+        CreateGroup createGroup = new CreateGroup();
+        createGroup.setGroupId(groupId);
+        clientV3.groups().post(createGroup);
+
+        CreateRule createRule = new CreateRule();
+        createRule.setRuleType(RuleType.VALIDITY);
+        createRule.setConfig(ValidityLevel.FULL.name());
+        clientV3.groups().byGroupId(groupId).rules().post(createRule);
+
+        // Stop the webhook server to simulate a network failure.
+        ramlMicroService.stopServer();
+
+        try {
+            // Uploading content while the webhook is down must be rejected (fail-closed),
+            // not silently accepted (fail-open).  Assert on the exception message to pin
+            // this to the new code path: if the throw came from any other validator the
+            // message would not contain the webhook-specific string, and the test would fail.
+            RuleViolationProblemDetails ex = Assertions.assertThrows(RuleViolationProblemDetails.class, () -> {
+                String artifactId = TestUtils.generateArtifactId();
+                CreateArtifact createArtifact = TestUtils.clientCreateArtifact(
+                        artifactId, "RAML", "#%RAML 1.0\ntitle: test", ContentTypes.APPLICATION_YAML);
+                createArtifact.getFirstVersion().setVersion("1.0");
+                clientV3.groups().byGroupId(groupId).artifacts().post(createArtifact);
+            });
+            Assertions.assertTrue(
+                    ex.getDetail() != null && ex.getDetail().contains("Webhook validation failed to execute"),
+                    "Expected exception message to identify webhook failure, but got: " + ex.getDetail());
+        } finally {
+            // Restart the server so subsequent tests are unaffected.
+            // Block on the deployment future (with a timeout) so the server is
+            // guaranteed to be listening before the next test starts, and so that
+            // a bind failure on port 3333 (e.g. still in TIME_WAIT) is surfaced
+            // rather than silently swallowed.
+            ramlMicroService = new RamlTestMicroService(3333);
+            vertx.deployVerticle(ramlMicroService)
+                    .toCompletionStage()
+                    .toCompletableFuture()
+                    .get(10, TimeUnit.SECONDS);
+        }
     }
 
 }


### PR DESCRIPTION
## Summary

Fixes #9500 - webhook-based `ContentValidator` fails open when the webhook server is unreachable.

## Problem

`WebhookContentValidatorDelegate.validate()` and `.validateReferences()` caught `Throwable`, 
logged the error, and **returned normally**. This means if the webhook server was down, 
timed out, or returned a 5xx error, the Registry would silently accept any artifact content, 
completely bypassing custom validation rules.

## Fix

Re-throw a `RuleViolationException` in the `Throwable` catch block so that any webhook 
invocation failure (network error, timeout, HTTP 5xx) causes the artifact upload to be 
**rejected** rather than silently accepted.

This brings `ConfiguredContentValidator` in line with `ConfiguredContentAccepter`, which 
already follows the correct fail-closed pattern (returns `false` on `Throwable`).

## Changes

- **`ConfiguredContentValidator.java`** - both `validate()` and `validateReferences()` 
  now throw `RuleViolationException` on `Throwable` instead of swallowing the error.
- **`WebhookArtifactTypesTest.java`** - added `testWebhookValidatorFailsClosed()` which 
  stops the webhook server mid-test and verifies that artifact upload is rejected 
  (not silently accepted).

## Before / After

| Scenario | Before | After |
|---|---|---|
| Webhook server down | ✅ Content accepted (fail-open) | ❌ `RuleViolationException` thrown (fail-closed) |
| Webhook returns 5xx | ✅ Content accepted (fail-open) | ❌ `RuleViolationException` thrown (fail-closed) |
| Webhook returns violations | ❌ Rejected | ❌ Rejected |
| Webhook healthy, no violations | ✅ Accepted | ✅ Accepted |
