### PR TITLE
fix(rules): reject COMPATIBILITY rules for artifact types with no checker

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rules/app/compatibility/CompatibilityRuleExecutor.java
+++ b/app/src/main/java/io/apicurio/registry/rules/app/compatibility/CompatibilityRuleExecutor.java
@@ -1,9 +1,11 @@
 package io.apicurio.registry.rules.app.compatibility;
 
+import io.apicurio.common.apps.config.Info;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.rules.RuleContext;
 import io.apicurio.registry.rules.RuleExecutor;
+import io.apicurio.registry.rules.compatibility.CompatibilityCheckNotSupportedException;
 import io.apicurio.registry.rules.compatibility.CompatibilityChecker;
 import io.apicurio.registry.rules.compatibility.CompatibilityDifference;
 import io.apicurio.registry.rules.compatibility.CompatibilityExecutionResult;
@@ -15,6 +17,8 @@ import io.apicurio.registry.types.provider.ArtifactTypeUtilProvider;
 import io.apicurio.registry.types.provider.ArtifactTypeUtilProviderFactory;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -22,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_TYPES;
 import static java.util.Collections.emptyList;
 
 /**
@@ -34,7 +39,14 @@ import static java.util.Collections.emptyList;
 public class CompatibilityRuleExecutor implements RuleExecutor {
 
     @Inject
+    Logger log;
+
+    @Inject
     ArtifactTypeUtilProviderFactory factory;
+
+    @ConfigProperty(name = "apicurio.compat.allow-unsupported-types.enabled", defaultValue = "false")
+    @Info(category = CATEGORY_TYPES, description = "Allow the COMPATIBILITY rule to pass silently for artifact types that have no compatibility checker implementation. When false (the default), enforcing a non-NONE compatibility level on such a type is rejected rather than reported as compatible.", availableSince = "3.3.2")
+    boolean allowUnsupportedTypes;
 
     /**
      * @see io.apicurio.registry.rules.RuleExecutor#execute(io.apicurio.registry.rules.RuleContext)
@@ -50,6 +62,27 @@ public class CompatibilityRuleExecutor implements RuleExecutor {
 
         ArtifactTypeUtilProvider provider = factory.getArtifactTypeProvider(context.getArtifactType());
         CompatibilityChecker checker = provider.getCompatibilityChecker();
+
+        // A stub checker always answers "compatible" without comparing anything, so letting it through
+        // would silently approve a breaking change. Fail closed unless the operator has explicitly
+        // opted back into the previous (unchecked) behavior.
+        if (!checker.isCompatibilitySupported()) {
+            if (!allowUnsupportedTypes) {
+                throw new CompatibilityCheckNotSupportedException(String.format(
+                        "Compatibility level '%s' cannot be enforced for artifact '%s' because artifact type"
+                                + " '%s' has no compatibility checker implementation. Set the COMPATIBILITY"
+                                + " rule to NONE, remove it, or set"
+                                + " apicurio.compat.allow-unsupported-types.enabled=true to restore the"
+                                + " previous behavior of skipping the check.",
+                        level, context.getArtifactId(), context.getArtifactType()));
+            }
+            log.warn("COMPATIBILITY rule level '{}' is NOT being enforced for artifact '{}' [{}]: this"
+                    + " artifact type has no compatibility checker implementation and"
+                    + " apicurio.compat.allow-unsupported-types.enabled is true.", level,
+                    context.getArtifactId(), context.getArtifactType());
+            return;
+        }
+
         List<TypedContent> existingArtifacts = context.getCurrentContent() != null
             ? context.getCurrentContent() : emptyList();
         CompatibilityExecutionResult compatibilityExecutionResult = checker.testCompatibility(level,

--- a/app/src/main/java/io/apicurio/registry/services/http/HttpStatusCodeMap.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/HttpStatusCodeMap.java
@@ -16,6 +16,7 @@ import io.apicurio.registry.rest.MissingRequiredParameterException;
 import io.apicurio.registry.rest.ParametersConflictException;
 import io.apicurio.registry.rest.RestConfig;
 import io.apicurio.registry.rules.DefaultRuleDeletionException;
+import io.apicurio.registry.rules.compatibility.CompatibilityCheckNotSupportedException;
 import io.apicurio.registry.rules.violation.RuleViolationException;
 import io.apicurio.registry.rules.violation.UnprocessableSchemaException;
 import io.apicurio.registry.storage.error.AlreadyExistsException;
@@ -91,6 +92,7 @@ public class HttpStatusCodeMap {
         map.put(BranchAlreadyExistsException.class, HTTP_CONFLICT);
         map.put(BranchNotFoundException.class, HTTP_NOT_FOUND);
         map.put(CommentNotFoundException.class, HTTP_NOT_FOUND);
+        map.put(CompatibilityCheckNotSupportedException.class, HTTP_BAD_REQUEST);
         map.put(ConfigPropertyNotFoundException.class, HTTP_NOT_FOUND);
         map.put(ConflictException.class, HTTP_CONFLICT);
         map.put(ContentAlreadyExistsException.class, HTTP_CONFLICT);

--- a/app/src/test/java/io/apicurio/registry/noprofile/compatibility/UnsupportedTypeCompatibilityRuleTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/compatibility/UnsupportedTypeCompatibilityRuleTest.java
@@ -1,0 +1,165 @@
+package io.apicurio.registry.noprofile.compatibility;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.content.TypedContent;
+import io.apicurio.registry.rest.client.models.CreateRule;
+import io.apicurio.registry.rest.client.models.CreateVersion;
+import io.apicurio.registry.rest.client.models.RuleType;
+import io.apicurio.registry.rest.client.models.RuleViolationProblemDetails;
+import io.apicurio.registry.rules.RuleContext;
+import io.apicurio.registry.rules.app.compatibility.CompatibilityRuleExecutor;
+import io.apicurio.registry.rules.compatibility.CompatibilityCheckNotSupportedException;
+import io.apicurio.registry.rules.compatibility.CompatibilityLevel;
+import io.apicurio.registry.rules.violation.RuleViolationException;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+/**
+ * Verifies that a COMPATIBILITY rule is not silently satisfied by artifact types whose compatibility checker
+ * is a stub.
+ * <p>
+ * Before the fix, {@link CompatibilityRuleExecutor} delegated straight to
+ * {@code NoopCompatibilityChecker}, which returns "compatible" unconditionally. An operator enforcing
+ * BACKWARD or FULL_TRANSITIVE on such a type received a passing verdict for an outright breaking change.
+ * </p>
+ */
+@QuarkusTest
+public class UnsupportedTypeCompatibilityRuleTest extends AbstractResourceTestBase {
+
+    private static final String XML_V1 = "<?xml version=\"1.0\"?><order><id>1</id><total>9.99</total></order>";
+    private static final String XML_V2 = "<?xml version=\"1.0\"?><invoice><ref>1</ref></invoice>";
+
+    private static final String GRAPHQL_V1 = "type Query { id: String name: String }";
+    private static final String GRAPHQL_V2 = "type Mutation { unrelated: Int }";
+
+    private static final String AVRO_V1 = "{\"type\":\"record\",\"namespace\":\"com.example\",\"name\":\"FullName\","
+            + "\"fields\":[{\"name\":\"first\",\"type\":\"string\"},{\"name\":\"last\",\"type\":\"string\"}]}";
+    private static final String AVRO_V2 = "{\"type\": \"string\"}";
+
+    @Inject
+    CompatibilityRuleExecutor compatibility;
+
+    private static TypedContent xml(String content) {
+        return TypedContent.create(ContentHandle.create(content), ContentTypes.APPLICATION_XML);
+    }
+
+    private static TypedContent json(String content) {
+        return TypedContent.create(ContentHandle.create(content), ContentTypes.APPLICATION_JSON);
+    }
+
+    private RuleContext context(String artifactType, String level, TypedContent existing,
+            TypedContent proposed) {
+        return new RuleContext("TestGroup", "TestArtifact", artifactType, level,
+                Collections.singletonList(existing), proposed, Collections.emptyList(),
+                Collections.emptyMap(), null);
+    }
+
+    /**
+     * The core regression: XML has no compatibility checker, so a wholly incompatible replacement used to
+     * be reported as compatible. It must now be rejected instead.
+     */
+    @Test
+    public void testUnsupportedTypeRejectsNonNoneLevel() {
+        RuleContext ctx = context(ArtifactType.XML, CompatibilityLevel.BACKWARD.name(), xml(XML_V1),
+                xml(XML_V2));
+
+        CompatibilityCheckNotSupportedException ex = Assertions
+                .assertThrows(CompatibilityCheckNotSupportedException.class,
+                        () -> compatibility.execute(ctx));
+
+        Assertions.assertTrue(ex.getMessage().contains(ArtifactType.XML),
+                "Error message should name the offending artifact type, was: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("apicurio.compat.allow-unsupported-types.enabled"),
+                "Error message should tell the operator how to opt out, was: " + ex.getMessage());
+    }
+
+    /**
+     * Every transitive/non-transitive level other than NONE must be rejected, not just BACKWARD.
+     */
+    @Test
+    public void testUnsupportedTypeRejectsEveryEnforcingLevel() {
+        for (CompatibilityLevel level : CompatibilityLevel.values()) {
+            if (level == CompatibilityLevel.NONE) {
+                continue;
+            }
+            RuleContext ctx = context(ArtifactType.ASYNCAPI, level.name(), json("{}"), json("{}"));
+            Assertions.assertThrows(CompatibilityCheckNotSupportedException.class,
+                    () -> compatibility.execute(ctx),
+                    "Level " + level + " should be rejected for an artifact type without a checker");
+        }
+    }
+
+    /**
+     * NONE means "rule disabled" and must keep short-circuiting before the capability check, otherwise
+     * simply having the rule present would break writes for these types.
+     */
+    @Test
+    public void testUnsupportedTypeAllowsNoneLevel() {
+        RuleContext ctx = context(ArtifactType.XML, CompatibilityLevel.NONE.name(), xml(XML_V1),
+                xml(XML_V2));
+
+        Assertions.assertDoesNotThrow(() -> compatibility.execute(ctx));
+    }
+
+    /**
+     * Regression guard: types that do have a checker must keep evaluating content, not be short-circuited
+     * by the new capability gate.
+     */
+    @Test
+    public void testSupportedTypeStillEvaluatesContent() {
+        RuleContext incompatible = context(ArtifactType.AVRO, CompatibilityLevel.BACKWARD.name(),
+                json(AVRO_V1), json(AVRO_V2));
+        Assertions.assertThrows(RuleViolationException.class,
+                () -> compatibility.execute(incompatible));
+
+        RuleContext compatible = context(ArtifactType.AVRO, CompatibilityLevel.BACKWARD.name(),
+                json(AVRO_V1), json(AVRO_V1));
+        Assertions.assertDoesNotThrow(() -> compatibility.execute(compatible));
+    }
+
+    /**
+     * End-to-end check over the v3 REST API, mirroring how an operator hits this: configure an artifact
+     * rule, then push a breaking version.
+     * <p>
+     * The client type is {@code RuleViolationProblemDetails} rather than plain {@code ProblemDetails}
+     * because the v3 OpenAPI declares the 400 response of createArtifactVersion as
+     * {@code RuleViolationBadRequest}; every 400 from this operation deserializes to that shape. The
+     * rule-specific fields are simply left unset here.
+     * </p>
+     */
+    @Test
+    public void testRestApiRejectsBreakingChangeForUnsupportedType() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = TestUtils.generateArtifactId();
+
+        createArtifact(groupId, artifactId, ArtifactType.GRAPHQL, GRAPHQL_V1,
+                ContentTypes.APPLICATION_GRAPHQL);
+
+        CreateRule createRule = new CreateRule();
+        createRule.setRuleType(RuleType.COMPATIBILITY);
+        createRule.setConfig(CompatibilityLevel.BACKWARD.name());
+        clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).rules().post(createRule);
+
+        CreateVersion breaking = TestUtils.clientCreateVersion(GRAPHQL_V2,
+                ContentTypes.APPLICATION_GRAPHQL);
+
+        RuleViolationProblemDetails error = Assertions.assertThrows(RuleViolationProblemDetails.class,
+                () -> clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions()
+                        .post(breaking));
+
+        Assertions.assertEquals(400, error.getStatus());
+        Assertions.assertTrue(error.getDetail().contains(ArtifactType.GRAPHQL),
+                "Error detail should name the artifact type, was: " + error.getDetail());
+        Assertions.assertTrue(
+                error.getDetail().contains("apicurio.compat.allow-unsupported-types.enabled"),
+                "Error detail should tell the operator how to opt out, was: " + error.getDetail());
+    }
+}

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -1510,6 +1510,11 @@ The following {registry} configuration options are available for each component 
 |`/tmp/apicurio-registry-artifact-types.json`
 |`3.1.0`
 |Path to a configuration file containing a list of supported artifact types.
+|`apicurio.compat.allow-unsupported-types.enabled`
+|`boolean`
+|`false`
+|`3.3.2`
+|Allow the COMPATIBILITY rule to pass silently for artifact types that have no compatibility checker implementation. When false (the default), enforcing a non-NONE compatibility level on such a type is rejected rather than reported as compatible.
 |`apicurio.compat.json-schema.use-apitomy`
 |`boolean`
 |`false`

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/CompatibilityCheckNotSupportedException.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/CompatibilityCheckNotSupportedException.java
@@ -1,0 +1,18 @@
+package io.apicurio.registry.rules.compatibility;
+
+import io.apicurio.registry.types.RegistryException;
+
+/**
+ * Thrown when a COMPATIBILITY rule is enforced against an artifact type that has no compatibility checker
+ * implementation. Reporting such content as compatible would silently approve a breaking change, so the
+ * operation is rejected instead.
+ */
+public class CompatibilityCheckNotSupportedException extends RegistryException {
+
+    private static final long serialVersionUID = 1L;
+
+    public CompatibilityCheckNotSupportedException(String message) {
+        super(message);
+    }
+
+}

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/CompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/CompatibilityChecker.java
@@ -23,4 +23,16 @@ public interface CompatibilityChecker {
             List<TypedContent> existingArtifacts, TypedContent proposedArtifact,
             Map<String, TypedContent> resolvedReferences);
 
+    /**
+     * Whether this checker can actually evaluate compatibility. Implementations that do not compare the
+     * proposed content against the existing versions (i.e. stubs such as
+     * {@link NoopCompatibilityChecker}) MUST return <code>false</code> so that callers can distinguish
+     * "verified compatible" from "not checked at all" instead of treating both as a passing verdict.
+     *
+     * @return true if {@link #testCompatibility} produces a meaningful verdict, false if it is a stub
+     */
+    default boolean isCompatibilitySupported() {
+        return true;
+    }
+
 }

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/NoopCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/NoopCompatibilityChecker.java
@@ -22,4 +22,15 @@ public class NoopCompatibilityChecker implements CompatibilityChecker {
         requireNonNull(proposedArtifact, "proposedSchema MUST NOT be null");
         return CompatibilityExecutionResult.compatible();
     }
+
+    /**
+     * This checker performs no comparison at all, so the "compatible" result returned by
+     * {@link #testCompatibility} carries no guarantee. Callers must not interpret it as a passing check.
+     *
+     * @see CompatibilityChecker#isCompatibilitySupported()
+     */
+    @Override
+    public boolean isCompatibilitySupported() {
+        return false;
+    }
 }

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/types/provider/CompatibilityCheckerSupportTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/types/provider/CompatibilityCheckerSupportTest.java
@@ -1,0 +1,72 @@
+package io.apicurio.registry.types.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import io.apicurio.registry.types.ArtifactType;
+
+/**
+ * Guards the boundary between artifact types that can really evaluate a COMPATIBILITY rule and those whose
+ * checker is a stub.
+ * <p>
+ * A stub checker answers "compatible" without comparing anything, so a type that silently falls back to one
+ * lets a breaking change through while the registry reports success. The set below is therefore pinned:
+ * adding a new artifact type without a compatibility checker, or dropping an existing checker, fails this
+ * test and forces the decision to be made deliberately.
+ * </p>
+ */
+class CompatibilityCheckerSupportTest {
+
+    /**
+     * Artifact types that knowingly ship without a compatibility checker implementation. Enforcing a
+     * non-NONE compatibility level on these is rejected at rule-execution time rather than silently passing.
+     */
+    private static final Set<String> TYPES_WITHOUT_COMPATIBILITY_SUPPORT = new TreeSet<>(Set.of(
+            ArtifactType.ASYNCAPI,
+            ArtifactType.GRAPHQL,
+            ArtifactType.KCONNECT,
+            ArtifactType.ODCS_CONTRACT,
+            ArtifactType.OPENRPC,
+            ArtifactType.THRIFT,
+            ArtifactType.WSDL,
+            ArtifactType.XML));
+
+    @Test
+    void testUnsupportedTypesAreExactlyTheKnownSet() {
+        Set<String> actual = StandardArtifactTypeProviderRegistry.createStandardProviders().stream()
+                .filter(provider -> !provider.getCompatibilityChecker().isCompatibilitySupported())
+                .map(ArtifactTypeUtilProvider::getArtifactType)
+                .collect(Collectors.toCollection(TreeSet::new));
+
+        assertEquals(TYPES_WITHOUT_COMPATIBILITY_SUPPORT, actual,
+                "The set of artifact types without a compatibility checker changed. If a checker was added,"
+                        + " remove the type from TYPES_WITHOUT_COMPATIBILITY_SUPPORT. If a new type was added"
+                        + " without one, either implement a checker or add it here deliberately -- it will"
+                        + " reject non-NONE COMPATIBILITY rules at runtime.");
+    }
+
+    @Test
+    void testRemainingTypesReportCompatibilitySupported() {
+        List<ArtifactTypeUtilProvider> providers = StandardArtifactTypeProviderRegistry
+                .createStandardProviders();
+
+        for (ArtifactTypeUtilProvider provider : providers) {
+            boolean supported = provider.getCompatibilityChecker().isCompatibilitySupported();
+            if (TYPES_WITHOUT_COMPATIBILITY_SUPPORT.contains(provider.getArtifactType())) {
+                assertFalse(supported, provider.getArtifactType()
+                        + " is listed as unsupported but reports compatibility support");
+            } else {
+                assertTrue(supported, provider.getArtifactType()
+                        + " has a real compatibility checker but reports it is unsupported");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The COMPATIBILITY rule silently reports success for artifact types that have no compatibility checker. Enforcing BACKWARD or FULL_TRANSITIVE on ASYNCAPI, GRAPHQL, KCONNECT, WSDL, XML, OPENRPC, ODCS_CONTRACT or THRIFT approves an outright breaking change and returns 200, so a schema that breaks every downstream consumer ships while the registry reports healthy.

Fixes #9579

## Root Cause

`ProviderConfig.Builder` defaults `compatibilityChecker` to `NoopCompatibilityChecker.INSTANCE` (`ProviderConfig.java:167`). Any entry in `StandardArtifactTypeProviderRegistry` that omits `.compatibilityChecker(...)` picks up that stub, and the stub returns `CompatibilityExecutionResult.compatible()` unconditionally without comparing anything.

`CompatibilityRuleExecutor` cannot distinguish "I compared the schemas and they are compatible" from "I did not compare anything" — both arrive as `isCompatible() == true` — so it never throws. Custom artifact types configured without a checker reach the same stub through `ConfiguredArtifactTypeUtilProvider.createCompatibilityChecker()`.

Rejecting the rule at configuration time does not work as a fix: global and group rules are set without reference to an artifact type, so the type is only known at execution time.

## Changes

- `CompatibilityChecker` — new `isCompatibilitySupported()` default method returning `true`, so the eleven real checkers and any third-party implementation are unaffected.
- `NoopCompatibilityChecker` — overrides it to `false`, making the stub self-describing rather than indistinguishable from a real pass.
- `CompatibilityRuleExecutor.execute()` — consults the capability after the existing `NONE` short-circuit and raises `CompatibilityCheckNotSupportedException` instead of passing. Adds `apicurio.compat.allow-unsupported-types.enabled` (default `false`) to restore the previous skip-and-continue behaviour, logging a warning that names the level not being enforced.
- `CompatibilityCheckNotSupportedException` — new, extends `RegistryException`, following `DereferencingNotSupportedException`.
- `HttpStatusCodeMap` — maps it to 400, alongside the existing `DereferencingNotSupportedException` and `ContentSearchNotSupportedException` entries.
- `ref-registry-all-configs.adoc` — regenerated for the new config property.

### Behaviour change

Anyone already enforcing a non-NONE compatibility level over these types, most plausibly via a global rule, starts getting a 400 where they previously got a silent pass. That is the point of the fix, but it is a behaviour change on upgrade, hence the opt-out property. Happy to switch the default the other way if maintainers would rather stage this over a release.

## Test plan

- [x] `CompatibilityCheckerSupportTest` (new) — pins the exact set of types resolving to a no-op checker, so adding a type without a checker or dropping an existing one has to be deliberate. Fails 2/2 without the change.
- [x] `UnsupportedTypeCompatibilityRuleTest` (new, 5 cases) — covers the executor directly and the full v3 REST path, plus the `NONE` short-circuit and an AVRO control proving real checkers still work. Fails 3/5 without the change; the REST case fails by creating the breaking version and returning success.
- [x] Rules, artifact types and custom types (`CompatibilityRuleApplicationTest`, `ArtifactTypeTest`, `GroupRulesTest`, `JavaClassArtifactTypesTest`, `WebhookArtifactTypesTest`, `io.apicurio.registry.rules.**`) — 52 pass.
- [x] ccompat v7/v8, REST, admin (`ConfluentClientTest`, `CCompatV8BasicTest`, `CCompatV7EnhancementsTest`, `GroupsResourceTest`, `AdminResourceTest`, `RegistryClientTest`, `ConfluentDataMigrationTest`, `AllYamlTest`) — 200 pass.
- [x] `schema-util/util-provider` full suite — 268 pass.
- [x] `io.apicurio.registry.storage.impl.sql.**` — 141 pass.
- [x] `./mvnw checkstyle:check -pl app,schema-util/common,schema-util/util-provider` clean.
- [x] SQL storage variant.
- [ ] KafkaSQL variant not exercised locally. The change lives in the rules engine, which runs in `GroupsResourceImpl` before any `RegistryStorage` call and touches no storage interface, so it should be variant-independent — leaving the `app-kafkasql` shard to confirm.

Unrelated note: `ProtobufContentValidatorTest` currently fails on a clean checkout of this branch (8 failures / 6 errors, all `Syntax violation for Protobuf artifact`). It is unrelated to this change and reproduces with the change stashed. I can open a separate issue if it is not already known.