### PR TITLE
test(mcp): add compatibility test for input schema

### DIFF
--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
@@ -24,6 +24,8 @@ public class McpToolCompatibilityChecker
         extends AbstractCompatibilityChecker<McpToolCompatibilityDifference> {
 
     private static final ObjectMapper mapper = new ObjectMapper();
+    private static final String INPUT_SCHEMA = "inputSchema";
+    private static final String PROPERTIES = "properties";
 
     @Override
     protected Set<McpToolCompatibilityDifference> isBackwardsCompatibleWith(String existing,
@@ -73,16 +75,16 @@ public class McpToolCompatibilityChecker
 
     private void checkPropertyTypeChanges(JsonNode existing, JsonNode proposed,
         Set<McpToolCompatibilityDifference> differences) {
-    JsonNode existingSchema = existing.get("inputSchema");
-    JsonNode proposedSchema = proposed.get("inputSchema");
+    JsonNode existingSchema = existing.get(INPUT_SCHEMA);
+    JsonNode proposedSchema = proposed.get(INPUT_SCHEMA);
 
     if (existingSchema == null || proposedSchema == null
             || !existingSchema.isObject() || !proposedSchema.isObject()) {
         return;
     }
 
-    JsonNode existingProps = existingSchema.get("properties");
-    JsonNode proposedProps = proposedSchema.get("properties");
+    JsonNode existingProps = existingSchema.get(PROPERTIES);
+    JsonNode proposedProps = proposedSchema.get(PROPERTIES);
 
     if (existingProps == null || proposedProps == null
             || !existingProps.isObject() || !proposedProps.isObject()) {
@@ -156,7 +158,7 @@ public class McpToolCompatibilityChecker
     }
 
     private String getInputSchemaType(JsonNode node) {
-        JsonNode inputSchema = node.get("inputSchema");
+        JsonNode inputSchema = node.get(INPUT_SCHEMA);
         if (inputSchema != null && inputSchema.isObject()) {
             JsonNode type = inputSchema.get("type");
             if (type != null && type.isTextual()) {
@@ -168,9 +170,9 @@ public class McpToolCompatibilityChecker
 
     private Set<String> extractPropertyNames(JsonNode node) {
         Set<String> properties = new HashSet<>();
-        JsonNode inputSchema = node.get("inputSchema");
+        JsonNode inputSchema = node.get(INPUT_SCHEMA);
         if (inputSchema != null && inputSchema.isObject()) {
-            JsonNode props = inputSchema.get("properties");
+            JsonNode props = inputSchema.get(PROPERTIES);
             if (props != null && props.isObject()) {
                 Iterator<String> fieldNames = props.fieldNames();
                 while (fieldNames.hasNext()) {
@@ -183,7 +185,7 @@ public class McpToolCompatibilityChecker
 
     private Set<String> extractRequiredParams(JsonNode node) {
         Set<String> required = new HashSet<>();
-        JsonNode inputSchema = node.get("inputSchema");
+        JsonNode inputSchema = node.get(INPUT_SCHEMA);
         if (inputSchema != null && inputSchema.isObject()) {
             JsonNode requiredNode = inputSchema.get("required");
             if (requiredNode != null && requiredNode.isArray()) {

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
@@ -37,7 +37,10 @@ public class McpToolCompatibilityChecker
             // Check inputSchema type changes
             checkInputSchemaTypeChange(existingNode, proposedNode, differences);
 
-            // Check removed properties
+// Check property type changes
+            checkPropertyTypeChanges(existingNode, proposedNode, differences);
+
+// Check removed properties
             checkPropertyRemovals(existingNode, proposedNode, differences);
 
             // Check added required parameters
@@ -67,6 +70,48 @@ public class McpToolCompatibilityChecker
                             + "'"));
         }
     }
+
+    private void checkPropertyTypeChanges(JsonNode existing, JsonNode proposed,
+        Set<McpToolCompatibilityDifference> differences) {
+    JsonNode existingSchema = existing.get("inputSchema");
+    JsonNode proposedSchema = proposed.get("inputSchema");
+
+    if (existingSchema == null || proposedSchema == null
+            || !existingSchema.isObject() || !proposedSchema.isObject()) {
+        return;
+    }
+
+    JsonNode existingProps = existingSchema.get("properties");
+    JsonNode proposedProps = proposedSchema.get("properties");
+
+    if (existingProps == null || proposedProps == null
+            || !existingProps.isObject() || !proposedProps.isObject()) {
+        return;
+    }
+
+    Iterator<String> fieldNames = existingProps.fieldNames();
+    while (fieldNames.hasNext()) {
+        String property = fieldNames.next();
+
+        if (!proposedProps.has(property)) {
+            continue;
+        }
+
+        JsonNode existingProperty = existingProps.get(property);
+        JsonNode proposedProperty = proposedProps.get(property);
+
+        JsonNode existingType = existingProperty.get("type");
+        JsonNode proposedType = proposedProperty.get("type");
+
+        if (existingType != null && proposedType != null
+                && !existingType.asText().equals(proposedType.asText())) {
+            differences.add(new McpToolCompatibilityDifference(
+                    McpToolCompatibilityDifference.Type.PROPERTY_TYPE_CHANGED,
+                    "Input property '" + property + "' type changed from '"
+                            + existingType.asText() + "' to '" + proposedType.asText() + "'"));
+        }
+    }
+}
 
     private void checkPropertyRemovals(JsonNode existing, JsonNode proposed,
             Set<McpToolCompatibilityDifference> differences) {

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
@@ -18,6 +18,7 @@ import java.util.Set;
  * - Adding required parameters: Backward incompatible
  * - Removing required parameters: Backward incompatible
  * - Changing inputSchema type: Backward incompatible
+ * - Changing input property type: Backward incompatible
  * - Changing name, title, description, annotations: Always compatible
  */
 public class McpToolCompatibilityChecker
@@ -26,6 +27,7 @@ public class McpToolCompatibilityChecker
     private static final ObjectMapper mapper = new ObjectMapper();
     private static final String INPUT_SCHEMA = "inputSchema";
     private static final String PROPERTIES = "properties";
+    private static final String TYPE = "type";
 
     @Override
     protected Set<McpToolCompatibilityDifference> isBackwardsCompatibleWith(String existing,
@@ -39,10 +41,10 @@ public class McpToolCompatibilityChecker
             // Check inputSchema type changes
             checkInputSchemaTypeChange(existingNode, proposedNode, differences);
 
-// Check property type changes
+            // Check property type changes
             checkPropertyTypeChanges(existingNode, proposedNode, differences);
 
-// Check removed properties
+            // Check removed properties
             checkPropertyRemovals(existingNode, proposedNode, differences);
 
             // Check added required parameters
@@ -74,46 +76,52 @@ public class McpToolCompatibilityChecker
     }
 
     private void checkPropertyTypeChanges(JsonNode existing, JsonNode proposed,
-        Set<McpToolCompatibilityDifference> differences) {
-    JsonNode existingSchema = existing.get(INPUT_SCHEMA);
-    JsonNode proposedSchema = proposed.get(INPUT_SCHEMA);
+            Set<McpToolCompatibilityDifference> differences) {
+        JsonNode existingSchema = existing.get(INPUT_SCHEMA);
+        JsonNode proposedSchema = proposed.get(INPUT_SCHEMA);
 
-    if (existingSchema == null || proposedSchema == null
-            || !existingSchema.isObject() || !proposedSchema.isObject()) {
-        return;
-    }
-
-    JsonNode existingProps = existingSchema.get(PROPERTIES);
-    JsonNode proposedProps = proposedSchema.get(PROPERTIES);
-
-    if (existingProps == null || proposedProps == null
-            || !existingProps.isObject() || !proposedProps.isObject()) {
-        return;
-    }
-
-    Iterator<String> fieldNames = existingProps.fieldNames();
-    while (fieldNames.hasNext()) {
-        String property = fieldNames.next();
-
-        if (!proposedProps.has(property)) {
-            continue;
+        if (existingSchema == null || proposedSchema == null
+                || !existingSchema.isObject() || !proposedSchema.isObject()) {
+            return;
         }
 
-        JsonNode existingProperty = existingProps.get(property);
-        JsonNode proposedProperty = proposedProps.get(property);
+        JsonNode existingProps = existingSchema.get(PROPERTIES);
+        JsonNode proposedProps = proposedSchema.get(PROPERTIES);
 
-        JsonNode existingType = existingProperty.get("type");
-        JsonNode proposedType = proposedProperty.get("type");
+        if (existingProps == null || proposedProps == null
+                || !existingProps.isObject() || !proposedProps.isObject()) {
+            return;
+        }
 
-        if (existingType != null && proposedType != null
-                && !existingType.asText().equals(proposedType.asText())) {
-            differences.add(new McpToolCompatibilityDifference(
-                    McpToolCompatibilityDifference.Type.PROPERTY_TYPE_CHANGED,
-                    "Input property '" + property + "' type changed from '"
-                            + existingType.asText() + "' to '" + proposedType.asText() + "'"));
+        Iterator<String> fieldNames = existingProps.fieldNames();
+
+        while (fieldNames.hasNext()) {
+            String property = fieldNames.next();
+
+            if (!proposedProps.has(property)) {
+                continue;
+            }
+
+            JsonNode existingProperty = existingProps.get(property);
+            JsonNode proposedProperty = proposedProps.get(property);
+
+            JsonNode existingType = existingProperty.get(TYPE);
+            JsonNode proposedType = proposedProperty.get(TYPE);
+
+            if (existingType == null && proposedType == null) {
+                continue;
+            }
+
+            if (existingType == null || proposedType == null
+                    || !existingType.equals(proposedType)) {
+                differences.add(new McpToolCompatibilityDifference(
+                        McpToolCompatibilityDifference.Type.PROPERTY_TYPE_CHANGED,
+                        "Input property '" + property + "' type changed from '"
+                                + String.valueOf(existingType) + "' to '"
+                                + String.valueOf(proposedType) + "'"));
+            }
         }
     }
-}
 
     private void checkPropertyRemovals(JsonNode existing, JsonNode proposed,
             Set<McpToolCompatibilityDifference> differences) {
@@ -159,35 +167,44 @@ public class McpToolCompatibilityChecker
 
     private String getInputSchemaType(JsonNode node) {
         JsonNode inputSchema = node.get(INPUT_SCHEMA);
+
         if (inputSchema != null && inputSchema.isObject()) {
-            JsonNode type = inputSchema.get("type");
+            JsonNode type = inputSchema.get(TYPE);
+
             if (type != null && type.isTextual()) {
                 return type.asText();
             }
         }
+
         return null;
     }
 
     private Set<String> extractPropertyNames(JsonNode node) {
         Set<String> properties = new HashSet<>();
         JsonNode inputSchema = node.get(INPUT_SCHEMA);
+
         if (inputSchema != null && inputSchema.isObject()) {
             JsonNode props = inputSchema.get(PROPERTIES);
+
             if (props != null && props.isObject()) {
                 Iterator<String> fieldNames = props.fieldNames();
+
                 while (fieldNames.hasNext()) {
                     properties.add(fieldNames.next());
                 }
             }
         }
+
         return properties;
     }
 
     private Set<String> extractRequiredParams(JsonNode node) {
         Set<String> required = new HashSet<>();
         JsonNode inputSchema = node.get(INPUT_SCHEMA);
+
         if (inputSchema != null && inputSchema.isObject()) {
             JsonNode requiredNode = inputSchema.get("required");
+
             if (requiredNode != null && requiredNode.isArray()) {
                 for (JsonNode item : requiredNode) {
                     if (item.isTextual()) {
@@ -196,6 +213,7 @@ public class McpToolCompatibilityChecker
                 }
             }
         }
+
         return required;
     }
 

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityDifference.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityDifference.java
@@ -10,11 +10,12 @@ import java.util.Objects;
 public class McpToolCompatibilityDifference implements CompatibilityDifference {
 
     public enum Type {
-        REQUIRED_PARAM_ADDED("inputSchema/required"),
-        REQUIRED_PARAM_REMOVED("inputSchema/required"),
-        INPUT_SCHEMA_TYPE_CHANGED("inputSchema/type"),
-        PROPERTY_REMOVED("inputSchema/properties"),
-        PARSE_ERROR("document");
+    REQUIRED_PARAM_ADDED("inputSchema/required"),
+    REQUIRED_PARAM_REMOVED("inputSchema/required"),
+    INPUT_SCHEMA_TYPE_CHANGED("inputSchema/type"),
+    PROPERTY_TYPE_CHANGED("inputSchema/properties"),
+    PROPERTY_REMOVED("inputSchema/properties"),
+    PARSE_ERROR("document");
 
         private final String context;
 

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
@@ -373,4 +373,73 @@ class McpToolCompatibilityCheckerTest {
         assertTrue(result.isCompatible(),
                 "Adding a valid inputSchema should be compatible");
     }
+
+    @Test
+    void testBackwardIncompatibleChangingInputSchemaPropertyType() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        }
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "integer" }
+                        }
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Changing an inputSchema property type should be backward incompatible");
+    }
+
+    @Test
+    void testBackwardIncompatibleAddingRequiredInputParameter() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        }
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Adding a required input parameter should be backward incompatible");
+    }
 }

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
@@ -408,15 +408,50 @@ class McpToolCompatibilityCheckerTest {
                 "Changing an inputSchema property type should be backward incompatible");
     }
 
+
     @Test
-    void testBackwardIncompatibleAddingRequiredInputParameter() {
+    void testBackwardIncompatibleChangingInputSchemaPropertyUnionType() {
         String existing = """
                 {
                     "name": "test_tool",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
-                            "query": { "type": "string" }
+                            "query": { "type": ["integer", "null"] }
+                        }
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": ["string"] }
+                        }
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Changing an inputSchema property union type should be backward incompatible");
+    }
+
+    @Test
+    void testBackwardIncompatibleAddingInputSchemaPropertyTypeConstraint() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": {}
                         }
                     }
                 }
@@ -429,8 +464,7 @@ class McpToolCompatibilityCheckerTest {
                         "type": "object",
                         "properties": {
                             "query": { "type": "string" }
-                        },
-                        "required": ["query"]
+                        }
                     }
                 }
                 """;
@@ -440,6 +474,6 @@ class McpToolCompatibilityCheckerTest {
                 createMcpTool(proposed), Map.of());
 
         assertFalse(result.isCompatible(),
-                "Adding a required input parameter should be backward incompatible");
+                "Adding an inputSchema property type constraint should be backward incompatible");
     }
 }

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
@@ -344,4 +344,33 @@ class McpToolCompatibilityCheckerTest {
 
         assertTrue(result.isCompatible(), "Identical schema with description change should be fully compatible");
     }
+
+
+    @Test
+    void testBackwardCompatibleAddingInputSchema() {
+        String existing = """
+                {
+                    "name": "test_tool"
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        }
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertTrue(result.isCompatible(),
+                "Adding a valid inputSchema should be compatible");
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Adds a compatibility test covering the case where an MCP tool gains a valid `inputSchema`.

## Testing

- `McpToolCompatibilityCheckerTest`: 10 tests passed
- Checkstyle: 0 violations
- Build: SUCCESS