### PR TITLE
fix(ui): rework artifact reference validation to align with backend rules

### DIFF
--- a/ui/ui-app/src/app/components/modals/CreateArtifactModal.tsx
+++ b/ui/ui-app/src/app/components/modals/CreateArtifactModal.tsx
@@ -38,7 +38,9 @@ import { listToLabels } from "@utils/labels.utils.ts";
 import { detectContentType, detectVersionInContent } from "@utils/content.utils.ts";
 
 
-export type ValidType = "default" | "success" | "error";
+import { checkIdValid, checkVersionValid, validateField, validateVersionField, ValidType } from "@utils/validation.utils.ts";
+
+export type { ValidType };
 
 export type Validities = {
     groupId?: ValidType;
@@ -49,35 +51,6 @@ export type Validities = {
     versionNumber?: ValidType;
     versionName?: ValidType;
     versionDescription?: ValidType;
-};
-
-const checkIdValid = (id: string | undefined | null): boolean => {
-    if (!id) {
-        //id is optional, server can generate it
-        return true;
-    } else {
-        // character % breaks the ui
-        const isAscii = (str: string) => {
-            for (let i = 0; i < str.length; i++){
-                if (str.charCodeAt(i) > 127){
-                    return false;
-                }
-            }
-            return true;
-        };
-        return id.indexOf("%") == -1 && isAscii(id);
-    }
-};
-
-const validateField = (value: string | undefined | null): ValidType => {
-    const isValid: boolean = checkIdValid(value);
-    if (!isValid) {
-        return "error";
-    }
-    if (value === undefined || value === null || value === "") {
-        return "default";
-    }
-    return "success";
 };
 
 
@@ -361,7 +334,8 @@ export const CreateArtifactModal: FunctionComponent<CreateArtifactModalProps> = 
     useEffect(() => {
         setValidities({
             groupId: validateField(groupId),
-            artifactId: validateField(data.artifactId)
+            artifactId: validateField(data.artifactId),
+            versionNumber: validateVersionField(data.firstVersion?.version)
         });
     }, [groupId, data]);
 
@@ -371,9 +345,10 @@ export const CreateArtifactModal: FunctionComponent<CreateArtifactModalProps> = 
 
     const isGroupIdValid: boolean = validities.groupId !== "error";
     const isArtifactIdValid: boolean = validities.artifactId !== "error";
+    const isVersionNumberValid: boolean = validities.versionNumber !== "error";
     const isCoordinates1Valid: boolean = isGroupIdValid && isArtifactIdValid;
     const areReferencesValid: boolean = isReferencesValid(versionReferences);
-    const isValid: boolean = isCoordinates1Valid && areReferencesValid;
+    const isValid: boolean = isCoordinates1Valid && isVersionNumberValid && areReferencesValid;
 
     const coordinatesStepFooter: Partial<WizardFooterProps> = {
         nextButtonProps: {
@@ -568,9 +543,16 @@ export const CreateArtifactModal: FunctionComponent<CreateArtifactModalProps> = 
                                 value={data.firstVersion?.version || ""}
                                 placeholder="1.0.0 (optional) will be generated if left blank"
                                 onChange={(_evt, value) => setVersionNumber(value)}
-                                // validated={groupValidated()}
+                                validated={validities.versionNumber}
                             />
-                            <If condition={autoDetectedVersion !== undefined && data.firstVersion?.version === autoDetectedVersion}>
+                            <If condition={!isVersionNumberValid}>
+                                <FormHelperText>
+                                    <HelperText>
+                                        <HelperTextItem variant="error" icon={ <ExclamationCircleIcon /> }>Only alphanumeric characters, dots, underscores, hyphens, and plus signs are allowed (max 256 characters)</HelperTextItem>
+                                    </HelperText>
+                                </FormHelperText>
+                            </If>
+                            <If condition={isVersionNumberValid && autoDetectedVersion !== undefined && data.firstVersion?.version === autoDetectedVersion}>
                                 <FormHelperText>
                                     <HelperText>
                                         <HelperTextItem>Version detected from the content.</HelperTextItem>

--- a/ui/ui-app/src/app/components/modals/ReferencesFormGroup.tsx
+++ b/ui/ui-app/src/app/components/modals/ReferencesFormGroup.tsx
@@ -11,22 +11,39 @@ export type ArtifactReferenceFormItem = {
     name: string;
 };
 
-type ValidType = "default" | "success" | "error";
+import { checkIdValid, checkVersionValid, ValidType } from "@utils/validation.utils.ts";
 
-const validateRefField = (value: string): ValidType => {
-    if (value === "") {
+export type ArtifactReferenceFormItem = {
+    groupId: string;
+    artifactId: string;
+    version: string;
+    name: string;
+};
+
+const validateRefIdField = (value: string): ValidType => {
+    if (value === "" || !checkIdValid(value)) {
+        return "error";
+    }
+    return "success";
+};
+
+const validateRefVersionField = (value: string): ValidType => {
+    if (value === "" || !checkVersionValid(value)) {
         return "error";
     }
     return "success";
 };
 
 /**
- * Returns true if all reference rows have all four fields populated.
+ * Returns true if all reference rows have valid populated fields.
  * Returns true if there are no references (empty list is valid).
  */
 export const isReferencesValid = (items: ArtifactReferenceFormItem[]): boolean => {
     return items.every(item =>
-        item.name !== "" && item.groupId !== "" && item.artifactId !== "" && item.version !== ""
+        item.name !== "" && checkIdValid(item.name) &&
+        item.groupId !== "" && checkIdValid(item.groupId) &&
+        item.artifactId !== "" && checkIdValid(item.artifactId) &&
+        item.version !== "" && checkVersionValid(item.version)
     );
 };
 
@@ -101,7 +118,7 @@ export const ReferencesFormGroup: FunctionComponent<ReferencesFormGroupProps> = 
                                         data-testid={`references-form-name-${idx}`}
                                         name={`form-ref-name-${idx}`}
                                         value={ref.name}
-                                        validated={validateRefField(ref.name)}
+                                        validated={validateRefIdField(ref.name)}
                                         onChange={(_event, newVal) => {
                                             ref.name = newVal;
                                             onChange([...references]);
@@ -120,7 +137,7 @@ export const ReferencesFormGroup: FunctionComponent<ReferencesFormGroupProps> = 
                                         data-testid={`references-form-group-id-${idx}`}
                                         name={`form-ref-group-${idx}`}
                                         value={ref.groupId}
-                                        validated={validateRefField(ref.groupId)}
+                                        validated={validateRefIdField(ref.groupId)}
                                         onChange={(_event, newVal) => {
                                             ref.groupId = newVal;
                                             onChange([...references]);
@@ -139,7 +156,7 @@ export const ReferencesFormGroup: FunctionComponent<ReferencesFormGroupProps> = 
                                         data-testid={`references-form-artifact-id-${idx}`}
                                         name={`form-ref-artifact-${idx}`}
                                         value={ref.artifactId}
-                                        validated={validateRefField(ref.artifactId)}
+                                        validated={validateRefIdField(ref.artifactId)}
                                         onChange={(_event, newVal) => {
                                             ref.artifactId = newVal;
                                             onChange([...references]);
@@ -159,7 +176,7 @@ export const ReferencesFormGroup: FunctionComponent<ReferencesFormGroupProps> = 
                                             data-testid={`references-form-version-${idx}`}
                                             name={`form-ref-version-${idx}`}
                                             value={ref.version}
-                                            validated={validateRefField(ref.version)}
+                                            validated={validateRefVersionField(ref.version)}
                                             onChange={(_event, newVal) => {
                                                 ref.version = newVal;
                                                 onChange([...references]);

--- a/ui/ui-app/src/app/pages/agents/components/modals/CreateAgentModal.tsx
+++ b/ui/ui-app/src/app/pages/agents/components/modals/CreateAgentModal.tsx
@@ -18,11 +18,12 @@ import { Modal } from "@patternfly/react-core/deprecated";
 import { ExclamationCircleIcon } from "@patternfly/react-icons";
 import { AgentCard, AgentCardEditor } from "@app/components/agentCard";
 import { CreateArtifact } from "@sdk/lib/generated-client/models";
-import { checkIdValid, validateField, ValidType } from "@utils/validation.utils.ts";
+import { checkIdValid, checkVersionValid, validateField, validateVersionField, ValidType } from "@utils/validation.utils.ts";
 
 type Validities = {
     groupId?: ValidType;
     artifactId?: ValidType;
+    version?: ValidType;
 };
 
 const EMPTY_AGENT_CARD: AgentCard = {
@@ -92,7 +93,7 @@ export const CreateAgentModal: FunctionComponent<CreateAgentModalProps> = (props
     };
 
     const isCoordinatesStepValid = (): boolean => {
-        return checkIdValid(groupId) && checkIdValid(artifactId);
+        return checkIdValid(groupId) && checkIdValid(artifactId) && checkVersionValid(version);
     };
 
     const isContentStepValid = (): boolean => {
@@ -205,11 +206,22 @@ export const CreateAgentModal: FunctionComponent<CreateAgentModalProps> = (props
                                         name="version"
                                         placeholder="1.0.0"
                                         value={version}
-                                        onChange={(_event, value) => setVersion(value)}
+                                        validated={validities.version}
+                                        onChange={(_event, value) => {
+                                            setVersion(value);
+                                            setValidities({ ...validities, version: validateVersionField(value) });
+                                        }}
                                     />
                                     <FormHelperText>
                                         <HelperText>
-                                            <HelperTextItem>The initial version number.</HelperTextItem>
+                                            <HelperTextItem
+                                                variant={validities.version}
+                                                icon={validities.version === "error" ? <ExclamationCircleIcon /> : undefined}
+                                            >
+                                                {validities.version === "error"
+                                                    ? "Only alphanumeric characters, dots, underscores, hyphens, and plus signs are allowed (max 256 characters)."
+                                                    : "The initial version number."}
+                                            </HelperTextItem>
                                         </HelperText>
                                     </FormHelperText>
                                 </FormGroup>

--- a/ui/ui-app/src/app/pages/drafts/components/modals/CreateDraftModal.tsx
+++ b/ui/ui-app/src/app/pages/drafts/components/modals/CreateDraftModal.tsx
@@ -44,7 +44,7 @@ import {
 } from "@app/components";
 
 
-type ValidType = "default" | "success" | "error";
+import { checkIdValid, checkVersionValid, validateField, validateVersionField, ValidType } from "@utils/validation.utils.ts";
 
 type Validities = {
     groupId?: ValidType;
@@ -54,35 +54,6 @@ type Validities = {
     content?: ValidType;
     name?: ValidType;
     description?: ValidType;
-};
-
-const checkIdValid = (id: string | undefined | null): boolean => {
-    if (!id) {
-        //id is optional, server can generate it
-        return true;
-    } else {
-        // character % breaks the ui
-        const isAscii = (str: string) => {
-            for (let i = 0; i < str.length; i++){
-                if (str.charCodeAt(i) > 127){
-                    return false;
-                }
-            }
-            return true;
-        };
-        return id.indexOf("%") == -1 && isAscii(id);
-    }
-};
-
-const validateField = (value: string | undefined | null): ValidType => {
-    const isValid: boolean = checkIdValid(value);
-    if (!isValid) {
-        return "error";
-    }
-    if (value === undefined || value === null || value === "") {
-        return "default";
-    }
-    return "success";
 };
 
 const validateContent = (content: string | undefined | null): ValidType => {
@@ -340,6 +311,7 @@ export const CreateDraftModal: FunctionComponent<CreateDraftModalProps> = (props
         setValidities({
             groupId: validateField(data.groupId),
             draftId: validateField(data.draftId),
+            version: validateVersionField(data.version),
             content: validateContent(data.content)
         });
     }, [data]);
@@ -347,8 +319,9 @@ export const CreateDraftModal: FunctionComponent<CreateDraftModalProps> = (props
     useEffect(() => {
         const isGroupIdValid: boolean = validateField(data.groupId) !== "error";
         const isDraftIdValid: boolean = validateField(data.draftId) !== "error";
+        const isVersionValid: boolean = validateVersionField(data.version) !== "error";
 
-        if (data.draftId && data.draftId.length > 0 && data.version && data.version.length > 0 && isGroupIdValid && isDraftIdValid) {
+        if (data.draftId && data.draftId.length > 0 && data.version && data.version.length > 0 && isGroupIdValid && isDraftIdValid && isVersionValid) {
             setIsCoordinatesAvailable(false);
             setIsValidatingCoordinates(true);
             // Debounce the validation logic because it hits the REST API each time.
@@ -361,7 +334,8 @@ export const CreateDraftModal: FunctionComponent<CreateDraftModalProps> = (props
 
     const isGroupIdValid: boolean = validities.groupId !== "error";
     const isDraftIdValid: boolean = validities.draftId !== "error";
-    const isCoordinatesValid: boolean = isGroupIdValid && isDraftIdValid;
+    const isVersionValid: boolean = validities.version !== "error";
+    const isCoordinatesValid: boolean = isGroupIdValid && isDraftIdValid && isVersionValid;
     const isContentValid: boolean = validities.content === "success";
     const areReferencesValid: boolean = isReferencesValid(versionReferences);
     const isValid: boolean = isCoordinatesValid && isContentValid && isCoordinatesAvailable && areReferencesValid;
@@ -464,8 +438,15 @@ export const CreateDraftModal: FunctionComponent<CreateDraftModalProps> = (props
                                 value={data.version || ""}
                                 placeholder="1.0.0 (optional) will be generated if left blank"
                                 onChange={(_evt, value) => setVersionNumber(value)}
-                                // validated={groupValidated()}
+                                validated={validities.version}
                             />
+                            <If condition={validities.version === "error"}>
+                                <FormHelperText>
+                                    <HelperText>
+                                        <HelperTextItem variant="error" icon={ <ExclamationCircleIcon /> }>Only alphanumeric characters, dots, underscores, hyphens, and plus signs are allowed (max 256 characters)</HelperTextItem>
+                                    </HelperText>
+                                </FormHelperText>
+                            </If>
                         </FormGroup>
                         <If condition={isValidatingCoordinates}>
                             <FormGroup>

--- a/ui/ui-app/src/app/pages/drafts/components/modals/NewDraftFromModal.tsx
+++ b/ui/ui-app/src/app/pages/drafts/components/modals/NewDraftFromModal.tsx
@@ -19,41 +19,12 @@ import { If } from "@apitomy/common-ui-components";
 import { ExclamationCircleIcon } from "@patternfly/react-icons";
 import { VersionMetaData } from "@sdk/lib/generated-client/models";
 
-type ValidType = "default" | "success" | "error";
+import { checkIdValid, checkVersionValid, validateField, validateVersionField, ValidType } from "@utils/validation.utils.ts";
 
 type Validities = {
     groupId?: ValidType;
     draftId?: ValidType;
     version?: ValidType;
-};
-
-const checkIdValid = (id: string | undefined | null): boolean => {
-    if (!id) {
-        //id is optional, server can generate it
-        return true;
-    } else {
-        // character % breaks the ui
-        const isAscii = (str: string) => {
-            for (let i = 0; i < str.length; i++){
-                if (str.charCodeAt(i) > 127){
-                    return false;
-                }
-            }
-            return true;
-        };
-        return id.indexOf("%") == -1 && isAscii(id);
-    }
-};
-
-const validateField = (value: string | undefined | null): ValidType => {
-    const isValid: boolean = checkIdValid(value);
-    if (!isValid) {
-        return "error";
-    }
-    if (value === undefined || value === null || value === "") {
-        return "default";
-    }
-    return "success";
 };
 
 /**
@@ -135,15 +106,17 @@ export const NewDraftFromModal: FunctionComponent<NewDraftFromModalProps> = (pro
     useEffect(() => {
         setValidities({
             groupId: validateField(groupId),
-            draftId: validateField(draftId)
+            draftId: validateField(draftId),
+            version: validateVersionField(version)
         });
     }, [groupId, draftId, version]);
 
     useEffect(() => {
         const isGroupIdValid: boolean = validateField(groupId) !== "error";
         const isDraftIdValid: boolean = validateField(draftId) !== "error";
+        const isVersionValid: boolean = validateVersionField(version) !== "error";
 
-        if (draftId && draftId.length > 0 && version && version.length > 0 && isGroupIdValid && isDraftIdValid) {
+        if (draftId && draftId.length > 0 && version && version.length > 0 && isGroupIdValid && isDraftIdValid && isVersionValid) {
             setIsCoordinatesAvailable(false);
             setIsValidatingCoordinates(true);
             // Debounce the validation logic because it hits the REST API each time.
@@ -156,7 +129,8 @@ export const NewDraftFromModal: FunctionComponent<NewDraftFromModalProps> = (pro
 
     const isGroupIdValid: boolean = validities.groupId !== "error";
     const isDraftIdValid: boolean = validities.draftId !== "error";
-    const isCoordinatesValid: boolean = isGroupIdValid && isDraftIdValid;
+    const isVersionValid: boolean = validities.version !== "error";
+    const isCoordinatesValid: boolean = isGroupIdValid && isDraftIdValid && isVersionValid;
     const isValid: boolean = isCoordinatesValid && isCoordinatesAvailable;
 
     return (
@@ -232,6 +206,13 @@ export const NewDraftFromModal: FunctionComponent<NewDraftFromModalProps> = (pro
                         validated={validities.version}
                         onChange={(_evt, value) => setVersion(value)}
                     />
+                    <If condition={validities.version === "error"}>
+                        <FormHelperText>
+                            <HelperText>
+                                <HelperTextItem variant="error" icon={ <ExclamationCircleIcon /> }>Only alphanumeric characters, dots, underscores, hyphens, and plus signs are allowed (max 256 characters)</HelperTextItem>
+                            </HelperText>
+                        </FormHelperText>
+                    </If>
                 </FormGroup>
                 <If condition={isValidatingCoordinates}>
                     <FormGroup>

--- a/ui/ui-app/src/utils/validation.utils.test.ts
+++ b/ui/ui-app/src/utils/validation.utils.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { checkIdValid, checkVersionValid, validateField, validateVersionField } from "./validation.utils.ts";
+
+describe("validation.utils", () => {
+    describe("checkIdValid", () => {
+        it("accepts null, undefined, empty string", () => {
+            expect(checkIdValid(null)).toBe(true);
+            expect(checkIdValid(undefined)).toBe(true);
+            expect(checkIdValid("")).toBe(true);
+        });
+
+        it("accepts valid ASCII IDs without %", () => {
+            expect(checkIdValid("my-artifact")).toBe(true);
+            expect(checkIdValid("group.id.123")).toBe(true);
+            expect(checkIdValid("my-artifact(v2)")).toBe(true);
+            expect(checkIdValid("foo!~=;()*#&@")).toBe(true);
+            expect(checkIdValid("with spaces")).toBe(true);
+        });
+
+        it("rejects % character", () => {
+            expect(checkIdValid("artifact%1")).toBe(false);
+            expect(checkIdValid("1%2")).toBe(false);
+        });
+
+        it("rejects non-ASCII characters", () => {
+            expect(checkIdValid("artifact🔥")).toBe(false);
+            expect(checkIdValid("group-ñ")).toBe(false);
+        });
+
+        it("rejects IDs over 512 characters", () => {
+            const longId = "a".repeat(513);
+            expect(checkIdValid(longId)).toBe(false);
+            expect(checkIdValid("a".repeat(512))).toBe(true);
+        });
+    });
+
+    describe("checkVersionValid", () => {
+        it("accepts null, undefined, empty string", () => {
+            expect(checkVersionValid(null)).toBe(true);
+            expect(checkVersionValid(undefined)).toBe(true);
+            expect(checkVersionValid("")).toBe(true);
+        });
+
+        it("accepts valid version strings matching [a-zA-Z0-9._\\-+]{1,256}", () => {
+            expect(checkVersionValid("1.2.3")).toBe(true);
+            expect(checkVersionValid("2.0.23")).toBe(true);
+            expect(checkVersionValid("10.2.1")).toBe(true);
+            expect(checkVersionValid("1.2.3-beta.1")).toBe(true);
+            expect(checkVersionValid("1.2.3+build.5")).toBe(true);
+            expect(checkVersionValid("2.0.0-SNAPSHOT")).toBe(true);
+            expect(checkVersionValid("v1.0.0")).toBe(true);
+        });
+
+        it("rejects reserved or unsafe special characters, whitespace, non-ASCII", () => {
+            expect(checkVersionValid("1.0:rc1")).toBe(false); // reserved :
+            expect(checkVersionValid("1.0,rc1")).toBe(false); // reserved ,
+            expect(checkVersionValid("1%2")).toBe(false);
+            expect(checkVersionValid("1/2")).toBe(false);
+            expect(checkVersionValid("1\\2")).toBe(false);
+            expect(checkVersionValid("1#2")).toBe(false);
+            expect(checkVersionValid("1?2")).toBe(false);
+            expect(checkVersionValid("1@2")).toBe(false);
+            expect(checkVersionValid("1$2")).toBe(false);
+            expect(checkVersionValid("1^2")).toBe(false);
+            expect(checkVersionValid("1*2")).toBe(false);
+            expect(checkVersionValid("1(2)")).toBe(false);
+            expect(checkVersionValid("1 2")).toBe(false);
+            expect(checkVersionValid("1.0.0🔥")).toBe(false);
+        });
+
+        it("rejects version longer than 256 characters", () => {
+            expect(checkVersionValid("1".repeat(257))).toBe(false);
+            expect(checkVersionValid("1".repeat(256))).toBe(true);
+        });
+    });
+
+    describe("validateField", () => {
+        it("returns 'error' for invalid IDs", () => {
+            expect(validateField("1%2")).toBe("error");
+        });
+
+        it("returns 'default' for empty values", () => {
+            expect(validateField("")).toBe("default");
+            expect(validateField(undefined)).toBe("default");
+        });
+
+        it("returns 'success' for valid IDs", () => {
+            expect(validateField("valid-id")).toBe("success");
+        });
+    });
+
+    describe("validateVersionField", () => {
+        it("returns 'error' for invalid versions", () => {
+            expect(validateVersionField("1:2")).toBe("error");
+        });
+
+        it("returns 'default' for empty values", () => {
+            expect(validateVersionField("")).toBe("default");
+            expect(validateVersionField(undefined)).toBe("default");
+        });
+
+        it("returns 'success' for valid versions", () => {
+            expect(validateVersionField("1.0.0")).toBe("success");
+        });
+    });
+});

--- a/ui/ui-app/src/utils/validation.utils.ts
+++ b/ui/ui-app/src/utils/validation.utils.ts
@@ -1,8 +1,15 @@
 export type ValidType = "default" | "success" | "error";
 
+/**
+ * Validates group ID, artifact ID, or reference name against backend rules (ArtifactIdValidator.java):
+ * Any ASCII character except '%', max 512 characters.
+ */
 export const checkIdValid = (id: string | undefined | null): boolean => {
     if (!id) {
         return true;
+    }
+    if (id.length > 512) {
+        return false;
     }
     const isAscii = (str: string) => {
         for (let i = 0; i < str.length; i++) {
@@ -15,8 +22,30 @@ export const checkIdValid = (id: string | undefined | null): boolean => {
     return id.indexOf("%") === -1 && isAscii(id);
 };
 
+/**
+ * Validates version string against backend rules (VersionId.java):
+ * Regex: [a-zA-Z0-9._\-+]{1,256}
+ */
+export const checkVersionValid = (version: string | undefined | null): boolean => {
+    if (!version) {
+        return true;
+    }
+    const VERSION_REGEX = /^[a-zA-Z0-9._\-+]{1,256}$/;
+    return VERSION_REGEX.test(version);
+};
+
 export const validateField = (value: string | undefined | null): ValidType => {
     if (!checkIdValid(value)) {
+        return "error";
+    }
+    if (value === undefined || value === null || value === "") {
+        return "default";
+    }
+    return "success";
+};
+
+export const validateVersionField = (value: string | undefined | null): ValidType => {
+    if (!checkVersionValid(value)) {
         return "error";
     }
     if (value === undefined || value === null || value === "") {


### PR DESCRIPTION
Close - #9595 

## Summary
This PR reworks artifact reference validation in the UI (`ReferencesFormGroup` and modal components) to enforce strict validation rules on `groupId`, `artifactId`, `version`, and reference `name` fields in accordance with backend validation criteria (`ArtifactIdValidator.java` and `VersionId.java`).

## Changes
- **Validation Utilities (`ui/ui-app/src/utils/validation.utils.ts`)**:
  - Added `checkVersionValid` matching backend `VersionId` regex (`^[a-zA-Z0-9._\-+]{1,256}$`).
  - Added length limit check (max 512 characters) in `checkIdValid`.
  - Added `validateVersionField` for Form controls.

- **References Form Component (`ReferencesFormGroup.tsx`)**:
  - Replaced basic non-empty check with `validateRefIdField` and `validateRefVersionField`.
  - Updated `isReferencesValid` to validate format rules for all reference fields (`groupId`, `artifactId`, `version`, `name`).

- **Modals (`CreateArtifactModal`, `CreateDraftModal`, `NewDraftFromModal`, `CreateAgentModal`)**:
  - Standardized reference form field state and validation handling.

- **Unit Tests (`validation.utils.test.ts`)**:
  - Added comprehensive test coverage for `checkIdValid`, `checkVersionValid`, `validateField`, and `validateVersionField`.

##How to Test
1. Open the **Create Artifact** or **Create Draft** modal in the UI.
2. Add an Artifact Reference.
3. Verify that invalid characters (e.g. `%`, non-ASCII, spaces in version, or strings exceeding max lengths) trigger visual validation errors and prevent form submission.
4. Verify unit tests pass:
   ```bash
   npm --prefix ui/ui-app test
