### PR TITLE
fix(ui): use Optional for OIDC logout URL

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/SystemResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/SystemResourceImpl.java
@@ -105,9 +105,7 @@ public class SystemResourceImpl implements SystemResource {
             uiConfig.authOidcRedirectUri.ifPresent(uri -> options.put("redirectUri", uri));
             options.put("clientId", uiConfig.authOidcClientId);
             options.put("scope", uiConfig.scope);
-            if (!"f5".equals(uiConfig.authOidcLogoutUrl)) {
-                options.put("logoutUrl", uiConfig.authOidcLogoutUrl);
-            }
+            uiConfig.authOidcLogoutUrl.ifPresent(logoutUrl -> options.put("logoutUrl", logoutUrl));
             // Only include loadUserInfo if explicitly configured
             uiConfig.loadUserInfo.ifPresent(loadUserInfo -> options.put("loadUserInfo", String.valueOf(loadUserInfo)));
             // Only include useNonce if explicitly configured

--- a/app/src/main/java/io/apicurio/registry/ui/UserInterfaceConfigProperties.java
+++ b/app/src/main/java/io/apicurio/registry/ui/UserInterfaceConfigProperties.java
@@ -34,9 +34,9 @@ public class UserInterfaceConfigProperties {
     @ConfigProperty(name = "apicurio.ui.auth.oidc.client-id", defaultValue = "apicurio-registry-ui")
     @Info(category = CATEGORY_UI, description = "The OIDC clientId", availableSince = "3.0.0")
     public String authOidcClientId;
-    @ConfigProperty(name = "apicurio.ui.auth.oidc.logout-url", defaultValue = "f5")
+    @ConfigProperty(name = "apicurio.ui.auth.oidc.logout-url")
     @Info(category = CATEGORY_UI, description = "The OIDC logout URL", availableSince = "3.0.0")
-    public String authOidcLogoutUrl;
+    public Optional<String> authOidcLogoutUrl;
 
     @ConfigProperty(name = "apicurio.ui.features.read-only.enabled", defaultValue = "false")
     @Info(category = CATEGORY_UI, description = "Enabled to set the UI to read-only mode", availableSince = "3.0.0")

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SystemResourceLogoutUrlEmptyTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SystemResourceLogoutUrlEmptyTest.java
@@ -1,0 +1,24 @@
+package io.apicurio.registry.noprofile.rest.v3;
+
+import io.apicurio.registry.rest.v3.beans.UserInterfaceConfig;
+import io.apicurio.registry.rest.v3.impl.SystemResourceImpl;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@QuarkusTest
+@TestProfile(SystemResourceLogoutUrlEmptyTestProfile.class)
+public class SystemResourceLogoutUrlEmptyTest {
+
+    @Inject
+    SystemResourceImpl systemResource;
+
+    @Test
+    public void testLogoutUrlWhenEmptyString() {
+        UserInterfaceConfig config = systemResource.getUIConfig();
+        assertFalse(config.getAuth().getOptions().containsKey("logoutUrl"));
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SystemResourceLogoutUrlEmptyTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SystemResourceLogoutUrlEmptyTestProfile.java
@@ -1,0 +1,16 @@
+package io.apicurio.registry.noprofile.rest.v3;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+import java.util.Map;
+
+public class SystemResourceLogoutUrlEmptyTestProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "quarkus.oidc.tenant-enabled", "true",
+                "quarkus.oidc.auth-server-url", "https://example.com/realms/test",
+                "apicurio.ui.auth.oidc.client-id", "test-client",
+                "apicurio.ui.auth.oidc.logout-url", ""
+        );
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SystemResourceLogoutUrlSetTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SystemResourceLogoutUrlSetTest.java
@@ -1,0 +1,24 @@
+package io.apicurio.registry.noprofile.rest.v3;
+
+import io.apicurio.registry.rest.v3.beans.UserInterfaceConfig;
+import io.apicurio.registry.rest.v3.impl.SystemResourceImpl;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+@TestProfile(SystemResourceLogoutUrlSetTestProfile.class)
+public class SystemResourceLogoutUrlSetTest {
+
+    @Inject
+    SystemResourceImpl systemResource;
+
+    @Test
+    public void testLogoutUrlPresentWhenSet() {
+        UserInterfaceConfig config = systemResource.getUIConfig();
+        assertEquals("https://example.com/logout", config.getAuth().getOptions().get("logoutUrl"));
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SystemResourceLogoutUrlSetTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SystemResourceLogoutUrlSetTestProfile.java
@@ -1,0 +1,16 @@
+package io.apicurio.registry.noprofile.rest.v3;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+import java.util.Map;
+
+public class SystemResourceLogoutUrlSetTestProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "quarkus.oidc.tenant-enabled", "true",
+                "quarkus.oidc.auth-server-url", "https://example.com/realms/test",
+                "apicurio.ui.auth.oidc.client-id", "test-client",
+                "apicurio.ui.auth.oidc.logout-url", "https://example.com/logout"
+        );
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SystemResourceLogoutUrlUnsetTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SystemResourceLogoutUrlUnsetTest.java
@@ -1,0 +1,24 @@
+package io.apicurio.registry.noprofile.rest.v3;
+import io.apicurio.registry.rest.v3.beans.UserInterfaceConfig;
+import io.apicurio.registry.rest.v3.impl.SystemResourceImpl;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * @author kanu
+ **/
+@QuarkusTest
+@TestProfile(SystemResourceLogoutUrlUnsetTestProfile.class)
+public class SystemResourceLogoutUrlUnsetTest {
+    @Inject
+    SystemResourceImpl systemResource;
+    @Test
+    public void testLogoutUrlAbsentWhenUnset() {
+        UserInterfaceConfig config = systemResource.getUIConfig();
+        assertFalse(config.getAuth().getOptions().containsKey("logoutUrl"));
+    }
+
+}

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SystemResourceLogoutUrlUnsetTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/SystemResourceLogoutUrlUnsetTestProfile.java
@@ -1,0 +1,17 @@
+package io.apicurio.registry.noprofile.rest.v3;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Map;
+
+public class SystemResourceLogoutUrlUnsetTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "quarkus.oidc.tenant-enabled", "true",
+                "quarkus.oidc.auth-server-url", "https://example.com/realms/test",
+                "apicurio.ui.auth.oidc.client-id", "test-client"
+        );
+    }
+}

--- a/docs/modules/ROOT/pages/getting-started/assembly-config-reference.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-config-reference.adoc
@@ -1422,8 +1422,8 @@ The following {registry} configuration options are available for each component 
 |`3.1.6`
 |Whether to load user info from the OIDC userinfo endpoint. Defaults to true if not specified. Set to false for OIDC providers like Azure Entra ID where the userinfo endpoint has incompatible audience requirements.
 |`apicurio.ui.auth.oidc.logout-url`
-|`string`
-|`f5`
+|`optional<string>`
+|
 |`3.0.0`
 |The OIDC logout URL
 |`apicurio.ui.auth.oidc.redirect-uri`

--- a/docs/modules/ROOT/pages/getting-started/assembly-migrating-registry-v2-v3.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-migrating-registry-v2-v3.adoc
@@ -1649,7 +1649,7 @@ Configure the following properties on the `apicurio-registry` (API) container:
 
 | `apicurio.ui.auth.oidc.logout-url`
 | OAuth2/OIDC logout URL
-| `f5`
+|
 
 | `apicurio.ui.auth.oidc.scope`
 | OAuth2/OIDC scope

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -1599,8 +1599,8 @@ The following {registry} configuration options are available for each component 
 |`3.1.6`
 |Whether to load user info from the OIDC userinfo endpoint. Defaults to true if not specified. Set to false for OIDC providers like Azure Entra ID where the userinfo endpoint has incompatible audience requirements.
 |`apicurio.ui.auth.oidc.logout-url`
-|`string`
-|`f5`
+|`optional<string>`
+|
 |`3.0.0`
 |The OIDC logout URL
 |`apicurio.ui.auth.oidc.redirect-uri`


### PR DESCRIPTION
Fixes #9594 
The OIDC logout URL configuration currently uses `"f5"` as a magic default value to represent an unset configuration, this change replaces that approach with `Optional<String>consistent.
