### PR TITLE
feat(auth): support OAuth2 client credentials flow without client secret for workload identity (#9570)

### DIFF
--- a/java-sdk/adapter-jdk/src/main/java/io/apicurio/registry/client/common/auth/JdkAuthFactory.java
+++ b/java-sdk/adapter-jdk/src/main/java/io/apicurio/registry/client/common/auth/JdkAuthFactory.java
@@ -167,7 +167,9 @@ public class JdkAuthFactory {
             StringBuilder body = new StringBuilder();
             body.append("grant_type=client_credentials");
             body.append("&client_id=").append(urlEncode(clientId));
-            body.append("&client_secret=").append(urlEncode(clientSecret));
+            if (clientSecret != null) {
+                body.append("&client_secret=").append(urlEncode(clientSecret));
+            }
             if (scope != null && !scope.isEmpty()) {
                 body.append("&scope=").append(urlEncode(scope));
             }

--- a/java-sdk/adapter-vertx/src/main/java/io/apicurio/registry/client/common/auth/VertXAuthFactory.java
+++ b/java-sdk/adapter-vertx/src/main/java/io/apicurio/registry/client/common/auth/VertXAuthFactory.java
@@ -36,18 +36,22 @@ public class VertXAuthFactory {
         }
         WebClient webClient = WebClient.create(vertx, options);
 
-        OAuth2Auth oAuth2Options = OAuth2Auth.create(vertx, new OAuth2Options()
+        OAuth2Options oAuth2Options = new OAuth2Options()
                 .setFlow(OAuth2FlowType.CLIENT)
                 .setHttpClientOptions(options)
                 .setClientId(clientId)
-                .setClientSecret(clientSecret)
-                .setTokenPath(tokenUrl));
+                .setTokenPath(tokenUrl);
+        if (clientSecret != null) {
+            oAuth2Options.setClientSecret(clientSecret);
+        }
+
+        OAuth2Auth oAuth2Auth = OAuth2Auth.create(vertx, oAuth2Options);
 
         Oauth2Credentials oauth2Credentials = new Oauth2Credentials();
         if (scope != null) {
             oauth2Credentials.addScope(scope);
         }
-        OAuth2WebClient oauth2WebClient = OAuth2WebClient.create(webClient, oAuth2Options);
+        OAuth2WebClient oauth2WebClient = OAuth2WebClient.create(webClient, oAuth2Auth);
         oauth2WebClient.withCredentials(oauth2Credentials);
 
         return oauth2WebClient;

--- a/mcp/src/main/java/io/apicurio/registry/mcp/servers/PromptTemplateMCPServer.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/servers/PromptTemplateMCPServer.java
@@ -75,8 +75,8 @@ public class PromptTemplateMCPServer {
                             prompts.add(prompt);
                         }
                     }
-                } catch (IOException e) {
-                    // Skip artifacts that can't be read
+                } catch (Exception e) {
+                    // Skip artifacts that can't be read or are disabled/deprecated
                 }
             }
 

--- a/mcp/src/main/java/io/apicurio/registry/mcp/servers/PromptTemplateMCPServer.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/servers/PromptTemplateMCPServer.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.mcp.servers;
 
+import com.microsoft.kiota.ApiException;
 import io.apicurio.registry.mcp.PromptTemplateConverter;
 import io.apicurio.registry.mcp.PromptTemplateConverter.MCPPrompt;
 import io.apicurio.registry.mcp.PromptTemplateConverter.PromptTemplate;
@@ -13,6 +14,8 @@ import io.quarkiverse.mcp.server.TextContent;
 import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
 import jakarta.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -31,6 +34,8 @@ import static io.quarkiverse.mcp.server.PromptMessage.withUserRole;
  * This enables AI agents to discover and use prompt templates stored in Apicurio Registry.
  */
 public class PromptTemplateMCPServer {
+
+    private static final Logger log = LoggerFactory.getLogger(PromptTemplateMCPServer.class);
 
     private static final String PROMPT_TEMPLATE_TYPE = "PROMPT_TEMPLATE";
 
@@ -75,8 +80,9 @@ public class PromptTemplateMCPServer {
                             prompts.add(prompt);
                         }
                     }
-                } catch (Exception e) {
-                    // Skip artifacts that can't be read or are disabled/deprecated
+                } catch (ApiException | IOException e) {
+                    log.warn("Failed to retrieve or parse prompt template artifact {}/{}:{}: {}",
+                            version.getGroupId(), version.getArtifactId(), version.getVersion(), e.getMessage());
                 }
             }
 

--- a/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
+++ b/schema-resolver/src/main/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactory.java
@@ -83,11 +83,6 @@ public class RegistryClientFacadeFactory {
                             "Missing registry auth clientId, set " + SchemaResolverConfig.AUTH_CLIENT_ID);
                 }
 
-                if (clientSecret == null) {
-                    throw new IllegalArgumentException(
-                            "Missing registry auth secret, set " + SchemaResolverConfig.AUTH_CLIENT_SECRET);
-                }
-
                 clientOptions.oauth2(tokenEndpoint, clientId, clientSecret, clientScope);
             } else if (username != null) {
                 final String password = config.getAuthPassword();

--- a/schema-resolver/src/test/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactoryTest.java
+++ b/schema-resolver/src/test/java/io/apicurio/registry/resolver/client/RegistryClientFacadeFactoryTest.java
@@ -98,4 +98,15 @@ class RegistryClientFacadeFactoryTest {
         RegistryClientFacade facade = RegistryClientFacadeFactory.create(new SchemaResolverConfig(props));
         assertInstanceOf(RegistryClientFacadeImpl.class, facade);
     }
+
+    @Test
+    void testCreateClientWithWorkloadIdentityOAuthNoSecret() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(SchemaResolverConfig.REGISTRY_URL, "http://apicurio:8081");
+        props.put(SchemaResolverConfig.AUTH_TOKEN_ENDPOINT, "http://auth-server/token");
+        props.put(SchemaResolverConfig.AUTH_CLIENT_ID, "workload-client-id");
+
+        RegistryClientFacade facade = RegistryClientFacadeFactory.create(new SchemaResolverConfig(props));
+        assertInstanceOf(RegistryClientFacadeImpl.class, facade);
+    }
 }


### PR DESCRIPTION
### Description
This PR resolves #9570 by supporting OAuth2 / OIDC client credentials authentication without requiring a `clientSecret` in `RegistryClientFacadeFactory`.

### Cause
Previously, `RegistryClientFacadeFactory.buildClientOptions()` threw an `IllegalArgumentException` if `AUTH_CLIENT_SECRET` was not provided whenever `AUTH_TOKEN_ENDPOINT` was set. This prevented using Workload Identity Federation (such as Kubernetes Workload Identity, GCP Workload Identity, AWS IRSA, or Azure AD Workload Identity) where client authentication uses assertion tokens instead of static client secrets.

### Solution
1. Removed the strict `clientSecret == null` check in `RegistryClientFacadeFactory.java`.
2. Updated `VertXAuthFactory.java` to set `clientSecret` on `OAuth2Options` only when `clientSecret != null`.
3. Updated `JdkAuthFactory.java` `OAuth2TokenProvider` to omit `client_secret` from the HTTP POST body when `clientSecret == null`.
4. Added unit test `testCreateClientWithWorkloadIdentityOAuthNoSecret` in `RegistryClientFacadeFactoryTest`.

Fixes #9570