### PR TITLE
fix(gitops): load validation tasks from disk across replicas

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GitOpsValidationTaskManager.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GitOpsValidationTaskManager.java
@@ -140,9 +140,14 @@ public class GitOpsValidationTaskManager {
      * @return the task DTO, or null if not found or expired
      */
     public GitOpsValidateTask getTask(String taskId) {
-        var taskState = tasks.get(new ValidationTaskId(taskId));
+        var id = new ValidationTaskId(taskId);
+        var taskState = tasks.get(id);
         if (taskState == null) {
-            return null;
+            taskState = loadTaskStateFromDisk(id);
+            if (taskState == null) {
+                return null;
+            }
+            tasks.putIfAbsent(id, taskState);
         }
         return toDto(taskState);
     }
@@ -177,7 +182,8 @@ public class GitOpsValidationTaskManager {
      */
     void pollSidecarStatus(ValidationTaskState taskState) {
         ValidationTaskStatus currentState = taskState.getState();
-        if (currentState != ValidationTaskStatus.SUBMITTED && currentState != ValidationTaskStatus.FETCHING) {
+        if (currentState != ValidationTaskStatus.SUBMITTED
+                && currentState != ValidationTaskStatus.FETCHING) {
             return;
         }
 
@@ -187,7 +193,8 @@ public class GitOpsValidationTaskManager {
         }
 
         try {
-            var request = JsonObjectMapper.MAPPER.readValue(requestFile.toFile(), ValidationRequest.class);
+            var request = JsonObjectMapper.MAPPER.readValue(
+                    requestFile.toFile(), ValidationRequest.class);
 
             if (request.getApiVersion() != null
                     && !ValidationRequest.CURRENT_API_VERSION.equals(request.getApiVersion())) {
@@ -217,7 +224,8 @@ public class GitOpsValidationTaskManager {
                 }
             }
         } catch (IOException e) {
-            log.warn("[validate:{}] Failed to read sidecar status: {}", taskState.getTaskId(), e.getMessage());
+            log.warn("[validate:{}] Failed to read sidecar status: {}",
+                    taskState.getTaskId(), e.getMessage());
         }
     }
 
@@ -250,6 +258,7 @@ public class GitOpsValidationTaskManager {
                     failTask(taskState, "No commits found in checkout repository");
                     return;
                 }
+
                 var pollResult = tempRepo.collectFiles(head);
                 if (pollResult == null || pollResult.files().isEmpty()) {
                     failTask(taskState, "No files found in checkout");
@@ -280,6 +289,7 @@ public class GitOpsValidationTaskManager {
                                 err.setContext(e.context());
                                 return err;
                             }).toList();
+
                     completeTask(taskState, "failure",
                             processingResult.getGroupCount(),
                             processingResult.getArtifactCount(),
@@ -294,7 +304,8 @@ public class GitOpsValidationTaskManager {
                     taskState.getTaskId());
             taskState.setState(ValidationTaskStatus.SUBMITTED);
         } catch (Exception e) {
-            log.error("[validate:{}] Validation failed: {}", taskState.getTaskId(), e.getMessage(), e);
+            log.error("[validate:{}] Validation failed: {}",
+                    taskState.getTaskId(), e.getMessage(), e);
             failTask(taskState, "Validation error: " + e.getMessage());
         }
     }
@@ -330,6 +341,7 @@ public class GitOpsValidationTaskManager {
             if (activeTasks >= maxTasks) {
                 break;
             }
+
             if (taskState.getState() == ValidationTaskStatus.PENDING) {
                 writeRequestFile(taskState);
                 if (taskState.getState() != ValidationTaskStatus.FAILED) {
@@ -349,11 +361,13 @@ public class GitOpsValidationTaskManager {
         if (taskState.isCleaned()) {
             return;
         }
+
         ValidationTaskStatus state = taskState.getState();
         if (state == ValidationTaskStatus.COMPLETED || state == ValidationTaskStatus.FAILED) {
             if (cleanupFiles(taskState)) {
                 taskState.setCleaned(true);
-                log.debug("[validate:{}] Disk cleaned, result retained in memory", taskState.getTaskId());
+                log.debug("[validate:{}] Disk cleaned, result retained in memory",
+                        taskState.getTaskId());
             }
         }
     }
@@ -395,54 +409,85 @@ public class GitOpsValidationTaskManager {
      * Loads a task from an existing request file on the shared volume.
      * Called during startup to recover tasks that survived a restart.
      */
-    private void loadTaskFromFile(Path requestFile) {
+    private ValidationTaskState loadTaskStateFromDisk(ValidationTaskId id) {
+        Path requestFile = getRequestFilePath(id);
+
+        if (!Files.exists(requestFile)) {
+            return null;
+        }
+
         try {
-            var request = JsonObjectMapper.MAPPER.readValue(requestFile.toFile(), ValidationRequest.class);
+            var request = JsonObjectMapper.MAPPER.readValue(
+                    requestFile.toFile(), ValidationRequest.class);
 
             if (request.getApiVersion() != null
                     && !ValidationRequest.CURRENT_API_VERSION.equals(request.getApiVersion())) {
                 log.warn("Skipping validation request with unsupported apiVersion: {}",
                         request.getApiVersion());
-                return;
+                return null;
             }
 
             if (request.getSpec() == null) {
-                return;
+                return null;
             }
 
-            var taskId = new ValidationTaskId(
-                    requestFile.getFileName().toString().replace(".json", ""));
-
             var taskState = new ValidationTaskState();
-            taskState.setTaskId(taskId);
-            taskState.setType(request.getSpec().getType() != null ? request.getSpec().getType() : "pull");
+            taskState.setTaskId(id);
+            taskState.setType(request.getSpec().getType() != null
+                    ? request.getSpec().getType()
+                    : "pull");
             taskState.setRepoId(request.getSpec().getRepoId());
             taskState.setRef(request.getSpec().getRef());
             taskState.setCreatedAt(request.getSpec().getRequestedAt() != null
                     ? Instant.parse(request.getSpec().getRequestedAt())
                     : Instant.now());
 
-            // Determine state from the sidecar status
             if (request.getStatus() != null && request.getStatus().getState() != null) {
                 SidecarState sidecarState = request.getStatus().getState();
+
                 switch (sidecarState) {
                     case FETCHING -> taskState.setState(ValidationTaskStatus.FETCHING);
                     case FETCHED -> taskState.setState(ValidationTaskStatus.SUBMITTED);
                     case FAILED -> taskState.setState(ValidationTaskStatus.FAILED);
                 }
+
                 taskState.setCheckoutPath(request.getStatus().getCheckoutPath());
             } else {
                 taskState.setState(ValidationTaskStatus.SUBMITTED);
             }
 
-            if (!isExpired(taskState)) {
-                tasks.put(taskId, taskState);
-                log.info("[validate:{}] Loaded pending task from volume: state={}, repoId={}, ref={}",
-                        taskId, taskState.getState(), taskState.getRepoId(), taskState.getRef());
+            if (isExpired(taskState)) {
+                return null;
             }
+
+            return taskState;
         } catch (Exception e) {
-            log.warn("Failed to load validation request from {}: {}", requestFile, e.getMessage());
+            log.warn("Failed to load validation request from {}: {}",
+                    requestFile, e.getMessage());
+            return null;
         }
+    }
+
+    /**
+     * Loads a task from an existing request file on the shared volume.
+     * Called during startup to recover tasks that survived a restart.
+     */
+    private void loadTaskFromFile(Path requestFile) {
+        var taskId = new ValidationTaskId(
+                requestFile.getFileName().toString().replace(".json", ""));
+
+        var taskState = loadTaskStateFromDisk(taskId);
+        if (taskState == null) {
+            return;
+        }
+
+        tasks.put(taskId, taskState);
+
+        log.info("[validate:{}] Loaded pending task from volume: state={}, repoId={}, ref={}",
+                taskId,
+                taskState.getState(),
+                taskState.getRepoId(),
+                taskState.getRef());
     }
 
     // ---- Helpers ----
@@ -459,20 +504,25 @@ public class GitOpsValidationTaskManager {
         if (taskState.getCheckoutPath() == null) {
             return null;
         }
-        return getValidateDir().resolve(taskState.getTaskId().value()).resolve(taskState.getCheckoutPath());
+        return getValidateDir()
+                .resolve(taskState.getTaskId().value())
+                .resolve(taskState.getCheckoutPath());
     }
 
     private boolean cleanupFiles(ValidationTaskState taskState) {
         try {
             Path requestFile = getRequestFilePath(taskState.getTaskId());
             Files.deleteIfExists(requestFile);
+
             Path taskDir = getValidateDir().resolve(taskState.getTaskId().value());
             if (Files.exists(taskDir)) {
                 deleteRecursive(taskDir);
             }
+
             return true;
         } catch (IOException e) {
-            log.warn("[validate:{}] Failed to clean up files: {}", taskState.getTaskId(), e.getMessage());
+            log.warn("[validate:{}] Failed to clean up files: {}",
+                    taskState.getTaskId(), e.getMessage());
             return false;
         }
     }
@@ -511,16 +561,20 @@ public class GitOpsValidationTaskManager {
         dto.setRef(ts.getRef());
         dto.setState(GitOpsValidateTask.State.fromValue(ts.getState().value()));
         dto.setCreatedAt(Date.from(ts.getCreatedAt()));
+
         if (ts.getResult() != null) {
             dto.setResult(GitOpsValidateTask.Result.fromValue(ts.getResult()));
         }
+
         if (ts.getCompletedAt() != null) {
             dto.setCompletedAt(Date.from(ts.getCompletedAt()));
         }
+
         dto.setGroupCount(ts.getGroupCount());
         dto.setArtifactCount(ts.getArtifactCount());
         dto.setVersionCount(ts.getVersionCount());
         dto.setErrors(ts.getErrors() != null ? ts.getErrors() : List.of());
+
         return dto;
     }
 

--- a/app/src/test/java/io/apicurio/registry/storage/impl/gitops/GitOpsValidateTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/gitops/GitOpsValidateTest.java
@@ -4,14 +4,17 @@ import io.apicurio.registry.storage.util.GitopsTestProfile;
 import io.apicurio.registry.util.JsonObjectMapper;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
 import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
@@ -24,6 +27,9 @@ import static org.hamcrest.Matchers.notNullValue;
 @QuarkusTest
 @TestProfile(GitopsTestProfile.class)
 public class GitOpsValidateTest {
+
+    @Inject
+    GitOpsValidationTaskManager validationTaskManager;
 
     @BeforeEach
     void cleanup() {
@@ -96,6 +102,52 @@ public class GitOpsValidateTest {
                 .then()
                 .statusCode(200)
                 .body("taskId", equalTo(taskId))
+                .body("state", notNullValue());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void getTaskLoadsFromDiskWhenMissingFromLocalCache() throws Exception {
+        var taskId = given()
+                .contentType("application/json")
+                .body("""
+                        {"type": "pull", "repoId": "default", "ref": "main"}
+                        """)
+                .when()
+                .post("/apis/registry/v3/admin/gitops/validate")
+                .then()
+                .statusCode(200)
+                .extract().path("taskId").toString();
+
+        // Wait until the validation request has been written to the shared volume.
+        var testRepository = GitTestRepositoryManager.getTestRepository();
+        Path validateDir = Path.of(testRepository.getGitRepoUrl())
+                .getParent()
+                .resolve("validate");
+        Path requestFile = validateDir.resolve(taskId + ".json");
+
+        await().atMost(Duration.ofSeconds(10))
+                .until(() -> Files.exists(requestFile));
+
+        // Simulate another Registry replica: the task exists on the shared volume,
+        // but it is not present in this replica's local in-memory cache.
+        Field tasksField = GitOpsValidationTaskManager.class.getDeclaredField("tasks");
+        tasksField.setAccessible(true);
+
+        var tasks = (ConcurrentHashMap<ValidationTaskId, ValidationTaskState>)
+                tasksField.get(validationTaskManager);
+
+        tasks.remove(new ValidationTaskId(taskId));
+
+        // The task should be recovered from the shared volume instead of returning 404.
+        given()
+                .when()
+                .get("/apis/registry/v3/admin/gitops/validate/" + taskId)
+                .then()
+                .statusCode(200)
+                .body("taskId", equalTo(taskId))
+                .body("repoId", equalTo("default"))
+                .body("ref", equalTo("main"))
                 .body("state", notNullValue());
     }
 


### PR DESCRIPTION
## What

Fixes GitOps dry-run validation task lookups in multi-replica deployments.

Validation task state is currently kept in a local in-memory `ConcurrentHashMap`. When a validation task is created by one Registry replica and a subsequent `GET /admin/gitops/validate/{taskId}` request is routed to another replica, the second replica cannot find the task in its local cache and returns HTTP 404.

This change makes `getTask()` fall back to the existing validation request file on the shared volume when the task is not present in the local cache. The recovered task is then repopulated into the local cache.

The existing disk-loading logic was extracted into a reusable `loadTaskStateFromDisk()` helper and reused by both startup recovery and cache-miss lookups.

## Changes

- Fall back to the shared validation volume when a task is missing from the local cache.
- Reuse the same disk parsing logic for startup recovery and runtime cache misses.
- Add a regression test covering a task that exists on disk but is missing from the local in-memory cache.

## Testing

- `GitOpsValidateTest` — **7 tests passed**
- `git diff --check` — passed

## Issue

Fixes #9600