### PR TITLE
fix(operator): scope ConsolePlugin CR name by namespace to avoid cross-namespace collision

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/assembly-deploying-registry-operator.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-deploying-registry-operator.adoc
@@ -1021,7 +1021,7 @@ spec:
     enabled: true
 ----
 
-The {operator} then creates a console plugin Deployment and Service secured with OpenShift service serving certificates, and registers a cluster-scoped `ConsolePlugin` resource named `<cr-name>-console-plugin`. The plugin backend forwards the logged-in user's OpenShift bearer token to the registry API. On clusters that are not OpenShift, the console plugin is not deployed.
+The {operator} then creates a console plugin Deployment and Service secured with OpenShift service serving certificates, and registers a cluster-scoped `ConsolePlugin` resource named `<cr-namespace>-<cr-name>-console-plugin`. The namespace is included because `ConsolePlugin` is cluster-scoped, so the name must stay unique across CRs that share the same name in different namespaces. The plugin backend forwards the logged-in user's OpenShift bearer token to the registry API. On clusters that are not OpenShift, the console plugin is not deployed.
 
 [id="configuring-app-tls_{context}"]
 == Application TLS configuration

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/feat/ConsolePluginManager.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/feat/ConsolePluginManager.java
@@ -77,6 +77,9 @@ public class ConsolePluginManager {
             return;
         }
 
+        var crdContext = newCrdContext();
+        deleteLegacyPluginCR(client, primary, crdContext);
+
         var pluginName = getPluginName(primary);
         var serviceName = primary.getMetadata().getName() + "-" + COMPONENT_CONSOLE_PLUGIN + "-" + RESOURCE_TYPE_SERVICE;
         var namespace = primary.getMetadata().getNamespace();
@@ -117,13 +120,6 @@ public class ConsolePluginManager {
         ));
 
         try {
-            var crdContext = new CustomResourceDefinitionContext.Builder()
-                    .withGroup(CONSOLE_PLUGIN_API_GROUP)
-                    .withVersion(CONSOLE_PLUGIN_API_VERSION)
-                    .withPlural(CONSOLE_PLUGIN_PLURAL)
-                    .withScope("Cluster")
-                    .build();
-
             var existing = client.genericKubernetesResources(crdContext)
                     .withName(pluginName)
                     .get();
@@ -149,15 +145,11 @@ public class ConsolePluginManager {
         if (!isOpenShift(client)) {
             return;
         }
+        var crdContext = newCrdContext();
+        deleteLegacyPluginCR(client, primary, crdContext);
+
         var pluginName = getPluginName(primary);
         try {
-            var crdContext = new CustomResourceDefinitionContext.Builder()
-                    .withGroup(CONSOLE_PLUGIN_API_GROUP)
-                    .withVersion(CONSOLE_PLUGIN_API_VERSION)
-                    .withPlural(CONSOLE_PLUGIN_PLURAL)
-                    .withScope("Cluster")
-                    .build();
-
             var existing = client.genericKubernetesResources(crdContext)
                     .withName(pluginName)
                     .get();
@@ -170,6 +162,48 @@ public class ConsolePluginManager {
             }
         } catch (Exception e) {
             log.warn("Failed to delete ConsolePlugin CR", e);
+        }
+    }
+
+    private static CustomResourceDefinitionContext newCrdContext() {
+        return new CustomResourceDefinitionContext.Builder()
+                .withGroup(CONSOLE_PLUGIN_API_GROUP)
+                .withVersion(CONSOLE_PLUGIN_API_VERSION)
+                .withPlural(CONSOLE_PLUGIN_PLURAL)
+                .withScope("Cluster")
+                .build();
+    }
+
+    /**
+     * The {@code ConsolePlugin} name used before it was scoped by namespace (see {@link #getPluginName}).
+     */
+    public static String getLegacyPluginName(ApicurioRegistry3 primary) {
+        return primary.getMetadata().getName() + "-console-plugin";
+    }
+
+    /**
+     * Before the plugin name was scoped by namespace, {@code ConsolePlugin} objects were named
+     * {@code <cr-name>-console-plugin}. Clean up any such object left over from before the upgrade so
+     * it doesn't stay orphaned on the cluster (it has no owner-reference GC, since the cluster-scoped
+     * {@code ConsolePlugin} can't be owned by the namespaced {@code ApicurioRegistry3} CR) pointing at a
+     * stale service alongside the new namespace-scoped one.
+     */
+    private static void deleteLegacyPluginCR(KubernetesClient client, ApicurioRegistry3 primary,
+            CustomResourceDefinitionContext crdContext) {
+        var legacyName = getLegacyPluginName(primary);
+        try {
+            var legacy = client.genericKubernetesResources(crdContext)
+                    .withName(legacyName)
+                    .get();
+
+            if (legacy != null) {
+                client.genericKubernetesResources(crdContext)
+                        .withName(legacyName)
+                        .delete();
+                log.info("Deleted legacy ConsolePlugin CR: {}", legacyName);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to delete legacy ConsolePlugin CR", e);
         }
     }
 }

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/feat/ConsolePluginManager.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/feat/ConsolePluginManager.java
@@ -4,6 +4,7 @@ import io.apicurio.registry.operator.Configuration;
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3Spec;
 import io.apicurio.registry.operator.api.v1.spec.ConsolePluginSpec;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
@@ -81,7 +82,7 @@ public class ConsolePluginManager {
         deleteLegacyPluginCR(client, primary, crdContext);
 
         var pluginName = getPluginName(primary);
-        var serviceName = primary.getMetadata().getName() + "-" + COMPONENT_CONSOLE_PLUGIN + "-" + RESOURCE_TYPE_SERVICE;
+        var serviceName = getServiceName(primary);
         var namespace = primary.getMetadata().getNamespace();
 
         var desired = new GenericKubernetesResourceBuilder()
@@ -165,6 +166,10 @@ public class ConsolePluginManager {
         }
     }
 
+    private static String getServiceName(ApicurioRegistry3 primary) {
+        return primary.getMetadata().getName() + "-" + COMPONENT_CONSOLE_PLUGIN + "-" + RESOURCE_TYPE_SERVICE;
+    }
+
     private static CustomResourceDefinitionContext newCrdContext() {
         return new CustomResourceDefinitionContext.Builder()
                 .withGroup(CONSOLE_PLUGIN_API_GROUP)
@@ -187,6 +192,11 @@ public class ConsolePluginManager {
      * it doesn't stay orphaned on the cluster (it has no owner-reference GC, since the cluster-scoped
      * {@code ConsolePlugin} can't be owned by the namespaced {@code ApicurioRegistry3} CR) pointing at a
      * stale service alongside the new namespace-scoped one.
+     * <p>
+     * The lookup is by name only, and {@code getLegacyPluginName(primary)} can coincide with
+     * {@code getPluginName(other)} for an unrelated CR {@code other} (e.g. a namespace literally named
+     * like {@code primary}'s CR name). {@link #belongsTo} guards against deleting that CR's
+     * already-migrated, namespace-scoped {@code ConsolePlugin} in that case.
      */
     private static void deleteLegacyPluginCR(KubernetesClient client, ApicurioRegistry3 primary,
             CustomResourceDefinitionContext crdContext) {
@@ -196,7 +206,7 @@ public class ConsolePluginManager {
                     .withName(legacyName)
                     .get();
 
-            if (legacy != null) {
+            if (legacy != null && belongsTo(legacy, primary)) {
                 client.genericKubernetesResources(crdContext)
                         .withName(legacyName)
                         .delete();
@@ -205,5 +215,21 @@ public class ConsolePluginManager {
         } catch (Exception e) {
             log.warn("Failed to delete legacy ConsolePlugin CR", e);
         }
+    }
+
+    /**
+     * Checks that {@code plugin}'s backend service reference points at {@code primary}'s own
+     * console-plugin service, before an operation deletes or overwrites it based on a name lookup alone.
+     */
+    @SuppressWarnings("unchecked")
+    static boolean belongsTo(GenericKubernetesResource plugin, ApicurioRegistry3 primary) {
+        var spec = (Map<String, Object>) plugin.getAdditionalProperties().get("spec");
+        var backend = spec == null ? null : (Map<String, Object>) spec.get("backend");
+        var service = backend == null ? null : (Map<String, Object>) backend.get("service");
+        if (service == null) {
+            return false;
+        }
+        return getServiceName(primary).equals(service.get("name"))
+                && primary.getMetadata().getNamespace().equals(service.get("namespace"));
     }
 }

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/feat/ConsolePluginManager.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/feat/ConsolePluginManager.java
@@ -33,8 +33,15 @@ public class ConsolePluginManager {
     private ConsolePluginManager() {
     }
 
+    /**
+     * The {@code ConsolePlugin} custom resource is cluster-scoped, unlike the primary
+     * {@code ApicurioRegistry3} resource and the other (namespaced) resources the operator manages.
+     * The namespace must therefore be included in the name to keep it unique across CRs that share the
+     * same name in different namespaces.
+     */
     public static String getPluginName(ApicurioRegistry3 primary) {
-        return primary.getMetadata().getName() + "-console-plugin";
+        return primary.getMetadata().getNamespace() + "-" + primary.getMetadata().getName()
+                + "-console-plugin";
     }
 
     public static boolean isOpenShift(KubernetesClient client) {

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/feat/ConsolePluginManagerOwnershipTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/feat/ConsolePluginManagerOwnershipTest.java
@@ -1,0 +1,73 @@
+package io.apicurio.registry.operator.feat;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConsolePluginManagerOwnershipTest {
+
+    @Test
+    void testBelongsToMatchesOwnBackendService() {
+        var registry = registry("team-a", "example-apicurioregistry");
+        var plugin = pluginFor("example-apicurioregistry-console-plugin-service", "team-a");
+
+        assertThat(ConsolePluginManager.belongsTo(plugin, registry)).isTrue();
+    }
+
+    @Test
+    void testBelongsToRejectsUnrelatedCRWithCollidingLegacyName() {
+        // Regression test for the corner case raised on
+        // https://github.com/Apicurio/apicurio-registry/pull/9642 : getLegacyPluginName("team-a") and
+        // getPluginName(<CR named "team-a" in namespace "team">) both produce "team-a-console-plugin", so
+        // a name-only lookup during the legacy-cleanup migration could otherwise find and delete an
+        // unrelated CR's already-migrated, namespace-scoped ConsolePlugin.
+        var unrelatedCR = registry("team", "a");
+        var collidingPlugin = pluginFor("a-console-plugin-service", "team");
+
+        var thisCR = registry("some-namespace", "team-a");
+
+        assertThat(ConsolePluginManager.belongsTo(collidingPlugin, thisCR)).isFalse();
+        assertThat(ConsolePluginManager.belongsTo(collidingPlugin, unrelatedCR)).isTrue();
+    }
+
+    @Test
+    void testBelongsToRejectsPluginWithNoBackendService() {
+        var registry = registry("team-a", "example-apicurioregistry");
+        var plugin = new GenericKubernetesResourceBuilder()
+                .withNewMetadata().withName("example-apicurioregistry-console-plugin").endMetadata()
+                .build();
+
+        assertThat(ConsolePluginManager.belongsTo(plugin, registry)).isFalse();
+    }
+
+    private static ApicurioRegistry3 registry(String namespace, String name) {
+        var registry = new ApicurioRegistry3();
+        registry.setMetadata(new ObjectMetaBuilder().withNamespace(namespace).withName(name).build());
+        return registry;
+    }
+
+    private static GenericKubernetesResource pluginFor(String serviceName, String serviceNamespace) {
+        var plugin = new GenericKubernetesResourceBuilder()
+                .withNewMetadata().withName(serviceName + "-plugin").endMetadata()
+                .build();
+        plugin.setAdditionalProperties(Map.of(
+                "spec", Map.of(
+                        "backend", Map.of(
+                                "service", Map.of(
+                                        "name", serviceName,
+                                        "namespace", serviceNamespace
+                                )
+                        ),
+                        "proxy", List.of()
+                )
+        ));
+        return plugin;
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/unit/ConsolePluginManagerTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/unit/ConsolePluginManagerTest.java
@@ -1,0 +1,47 @@
+package io.apicurio.registry.operator.unit;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.feat.ConsolePluginManager;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConsolePluginManagerTest {
+
+    @Test
+    void testPluginNameIncludesNamespace() {
+        var registry = registry("team-a", "example-apicurioregistry");
+
+        assertThat(ConsolePluginManager.getPluginName(registry))
+                .isEqualTo("team-a-example-apicurioregistry-console-plugin");
+    }
+
+    @Test
+    void testPluginNameDiffersAcrossNamespacesForSameCRName() {
+        // Regression test for https://github.com/Apicurio/apicurio-registry/issues/9640 :
+        // ConsolePlugin is a cluster-scoped resource, so two ApicurioRegistry3 CRs with the same
+        // name in different namespaces must not compute the same plugin name, or the operator
+        // would silently overwrite/delete one CR's console integration while reconciling the other.
+        var teamA = registry("team-a", "example-apicurioregistry");
+        var teamB = registry("team-b", "example-apicurioregistry");
+
+        assertThat(ConsolePluginManager.getPluginName(teamA))
+                .isNotEqualTo(ConsolePluginManager.getPluginName(teamB));
+    }
+
+    @Test
+    void testPluginNameDiffersAcrossCRNamesInSameNamespace() {
+        var first = registry("team-a", "registry-one");
+        var second = registry("team-a", "registry-two");
+
+        assertThat(ConsolePluginManager.getPluginName(first))
+                .isNotEqualTo(ConsolePluginManager.getPluginName(second));
+    }
+
+    private static ApicurioRegistry3 registry(String namespace, String name) {
+        var registry = new ApicurioRegistry3();
+        registry.setMetadata(new ObjectMetaBuilder().withNamespace(namespace).withName(name).build());
+        return registry;
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/unit/ConsolePluginManagerTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/unit/ConsolePluginManagerTest.java
@@ -39,6 +39,17 @@ public class ConsolePluginManagerTest {
                 .isNotEqualTo(ConsolePluginManager.getPluginName(second));
     }
 
+    @Test
+    void testLegacyPluginNameMatchesPreNamespaceScopedFormat() {
+        // The migration in ConsolePluginManager#deleteLegacyPluginCR relies on this staying equal to
+        // what getPluginName() used to return before it was scoped by namespace. If it drifts, upgraded
+        // clusters would stop finding (and cleaning up) the old cluster-scoped ConsolePlugin object.
+        var registry = registry("team-a", "example-apicurioregistry");
+
+        assertThat(ConsolePluginManager.getLegacyPluginName(registry))
+                .isEqualTo("example-apicurioregistry-console-plugin");
+    }
+
     private static ApicurioRegistry3 registry(String namespace, String name) {
         var registry = new ApicurioRegistry3();
         registry.setMetadata(new ObjectMetaBuilder().withNamespace(namespace).withName(name).build());


### PR DESCRIPTION
## Summary
`ConsolePluginManager` computed the name of the cluster-scoped `ConsolePlugin` custom resource from the `ApicurioRegistry3` CR name alone, so two CRs with the same name in different namespaces collided on one shared cluster object — each reconcile/delete cycle silently overwrote or deleted the other's console integration. This PR scopes the plugin name by namespace so it stays unique across the cluster, and cleans up legacy objects safely on upgrade.

Fixes #9640

## Root Cause
`ConsolePlugin` (`console.openshift.io/v1`) is cluster-scoped, unlike the Deployments/Services the operator otherwise manages, which are namespaced and so don't need namespace-qualified names. `ConsolePluginManager.getPluginName()` (`operator/controller/src/main/java/io/apicurio/registry/operator/feat/ConsolePluginManager.java`) reused the namespaced-resource naming pattern (`metadata.getName() + "-console-plugin"`) for this cluster-scoped resource, so it had no protection against name collisions across namespaces. Both `reconcileConsolePluginCR` and `deleteConsolePluginCR` look up and mutate/delete the object by this name only, so a collision meant one CR's reconcile could silently repoint or remove another CR's `ConsolePlugin`, with nothing surfaced in either CR's `.status.conditions`.

## Changes
- `ConsolePluginManager.java`:
  - `getPluginName()`: include `metadata.getNamespace()` in the generated name (`<namespace>-<name>-console-plugin`), ensuring uniqueness across CRs that share a name in different namespaces.
  - `deleteLegacyPluginCR()` / `belongsTo()`: automatically cleans up the pre-upgrade legacy-named `ConsolePlugin` (`<cr-name>-console-plugin`) after verifying that `spec.backend.service.name` and `namespace` match the CR's own backend service, preventing orphaned objects while guarding against deleting an unrelated CR's resource.
- `docs/modules/ROOT/pages/getting-started/assembly-deploying-registry-operator.adoc`: updated to document the new `<cr-namespace>-<cr-name>-console-plugin` naming.
- Added `operator/controller/src/test/java/io/apicurio/registry/operator/unit/ConsolePluginManagerTest.java`: verifies name formatting, namespace inclusion, and collision prevention.
- Added `operator/controller/src/test/java/io/apicurio/registry/operator/feat/ConsolePluginManagerOwnershipTest.java`: verifies `belongsTo()` ownership matching and guards against colliding legacy name cleanups.

## Test plan
- [x] Added `ConsolePluginManagerTest` (4 tests) covering: plugin name includes the namespace; two CRs with the *same name* in *different namespaces* produce different plugin names; two CRs with *different names* in the *same namespace* produce different plugin names; legacy plugin name matches expected pre-migration format.
- [x] Added `ConsolePluginManagerOwnershipTest` (3 tests) covering: `belongsTo()` matching own backend service; rejecting unrelated CRs with colliding legacy names; rejecting plugins without backend services.
- [x] `./mvnw test -Dfull -pl :apicurio-registry-operator-controller -am -Dtest="ConsolePluginManagerTest,ConsolePluginManagerOwnershipTest"` — 7/7 passing (4 unit, 3 ownership).
- [ ] Storage variant testing — not applicable, this change is confined to the operator's Kubernetes-resource-naming logic and doesn't touch storage.

## Impact
On upgrade, existing clusters will reconcile with the new namespace-scoped `ConsolePlugin` name (`<namespace>-<name>-console-plugin`). Legacy `<name>-console-plugin` objects created under earlier versions are automatically cleaned up during reconciliation/deletion once `belongsTo()` confirms their backend service matches the CR's service (`name` and `namespace`), avoiding orphaned objects without risking accidental deletion of colliding resources from other namespaces.
