### PR TITLE
fix(ui): preserve raw JSON input in prompt template test panel

### DIFF
--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
@@ -62,11 +62,13 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
 
     const {
         values,
+        rawTexts,
         renderedOutput,
         validationErrors,
         isLoading,
         error,
         setValue,
+        setRawText,
         doRender
     } = usePromptTemplateTestPanelState({
         groupId: props.groupId,
@@ -136,8 +138,9 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
             case "object":
                 return (
                     <TextArea
-                        value={typeof values[name] === "string" ? values[name] : JSON.stringify(values[name] || "", null, 2)}
+                        value={rawTexts[name] ?? ""}
                         onChange={(_event, val) => {
+                            setRawText(name, val);
                             try {
                                 setValue(name, JSON.parse(val));
                             } catch {

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.tsx
@@ -13,6 +13,8 @@ import {
     FormGroup,
     FormSelect,
     FormSelectOption,
+    HelperText,
+    HelperTextItem,
     Label,
     Spinner,
     TextArea,
@@ -28,6 +30,7 @@ import {
 import { useGroupsService } from "@services/useGroupsService.ts";
 import {
     coerceEnumValue,
+    parseObjectInput,
     schemaForField,
     toDeclaredMap
 } from "./PromptTemplateTestPanel.utils";
@@ -135,22 +138,31 @@ export const PromptTemplateTestPanel: FunctionComponent<PromptTemplateTestPanelP
                     />
                 );
             case "array":
-            case "object":
+            case "object": {
+                const rawText = rawTexts[name] ?? "";
+                const { parseError } = parseObjectInput(rawText);
                 return (
-                    <TextArea
-                        value={rawTexts[name] ?? ""}
-                        onChange={(_event, val) => {
-                            setRawText(name, val);
-                            try {
-                                setValue(name, JSON.parse(val));
-                            } catch {
-                                setValue(name, val);
-                            }
-                        }}
-                        aria-label={name}
-                        rows={3}
-                    />
+                    <>
+                        <TextArea
+                            value={rawText}
+                            onChange={(_event, val) => {
+                                setRawText(name, val);
+                                setValue(name, parseObjectInput(val).value);
+                            }}
+                            aria-label={name}
+                            rows={3}
+                            validated={parseError ? "warning" : "default"}
+                        />
+                        {parseError && (
+                            <HelperText>
+                                <HelperTextItem variant="warning">
+                                    Not valid JSON yet. Render will submit this as raw text.
+                                </HelperTextItem>
+                            </HelperText>
+                        )}
+                    </>
                 );
+            }
             default:
                 return (
                     <TextInput

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.test.ts
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+    buildInitialRawTexts,
     buildInitialValues,
     buildVersionIdentity,
     coerceEnumValue,
+    initialObjectText,
     shouldAcceptRenderResponse
 } from "./PromptTemplateTestPanel.utils";
 
@@ -109,5 +111,60 @@ describe("shouldAcceptRenderResponse", () => {
 
     it("rejects a stale response after the version identity changes", () => {
         expect(shouldAcceptRenderResponse(3, 3, "g::a::1", "g::a::2")).toBe(false);
+    });
+});
+
+describe("initialObjectText", () => {
+    it("returns an empty string for undefined (no declared default)", () => {
+        expect(initialObjectText(undefined)).toBe("");
+    });
+
+    it("returns the literal string 'null' for an explicit null default", () => {
+        expect(initialObjectText(null)).toBe("null");
+    });
+
+    it("passes strings through unchanged (user-typed raw text)", () => {
+        expect(initialObjectText("{\"partial\":")).toBe("{\"partial\":");
+    });
+
+    it("pretty-prints an object default", () => {
+        expect(initialObjectText({ a: 1 })).toBe("{\n  \"a\": 1\n}");
+    });
+
+    it("pretty-prints an empty object", () => {
+        expect(initialObjectText({})).toBe("{}");
+    });
+
+    it("pretty-prints an array default", () => {
+        expect(initialObjectText([1, 2])).toBe("[\n  1,\n  2\n]");
+    });
+});
+
+describe("buildInitialRawTexts", () => {
+    it("returns an empty map when the template and variables are absent", () => {
+        expect(buildInitialRawTexts(undefined, undefined)).toEqual({});
+    });
+
+    it("only tracks object and array fields, not primitives", () => {
+        const variables = {
+            cfg: { type: "object", default: { a: 1 } },
+            note: { type: "string", default: "hi" },
+            count: { type: "integer", default: 3 }
+        };
+        const result = buildInitialRawTexts("{{cfg}} {{note}} {{count}}", variables);
+        expect(Object.keys(result).sort()).toEqual(["cfg"]);
+        expect(result.cfg).toBe("{\n  \"a\": 1\n}");
+    });
+
+    it("preserves an explicit null default as the string 'null'", () => {
+        const variables = { nul: { type: "object", default: null } };
+        const result = buildInitialRawTexts("{{nul}}", variables);
+        expect(result.nul).toBe("null");
+    });
+
+    it("returns an empty string when an object field has no default", () => {
+        const variables = { cfg: { type: "object" } };
+        const result = buildInitialRawTexts("{{cfg}}", variables);
+        expect(result.cfg).toBe("");
     });
 });

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.test.ts
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
+    buildInitialPanelState,
     buildInitialRawTexts,
     buildInitialValues,
     buildVersionIdentity,
     coerceEnumValue,
     initialObjectText,
-    shouldAcceptRenderResponse
+    parseObjectInput,
+    shouldAcceptRenderResponse,
+    shouldResetPanelState
 } from "./PromptTemplateTestPanel.utils";
 
 describe("coerceEnumValue", () => {
@@ -166,5 +169,64 @@ describe("buildInitialRawTexts", () => {
         const variables = { cfg: { type: "object" } };
         const result = buildInitialRawTexts("{{cfg}}", variables);
         expect(result.cfg).toBe("");
+    });
+});
+
+describe("buildInitialPanelState", () => {
+    it("builds values and rawTexts consistently from one pass", () => {
+        const variables = {
+            cfg: { type: "object", default: { a: 1 } },
+            note: { type: "string", default: "hi" },
+            flag: { type: "boolean" }
+        };
+        const state = buildInitialPanelState("{{cfg}} {{note}} {{flag}}", variables);
+        expect(state.values).toEqual({ cfg: { a: 1 }, note: "hi", flag: false });
+        expect(state.rawTexts).toEqual({ cfg: "{\n  \"a\": 1\n}" });
+    });
+
+    it("returns empty maps for absent content", () => {
+        expect(buildInitialPanelState(undefined, undefined)).toEqual({ values: {}, rawTexts: {} });
+    });
+});
+
+describe("parseObjectInput", () => {
+    it("keeps the raw string and flags an error at every incomplete keystroke, then parses", () => {
+        const keystrokes = ["{", "{\"", "{\"a", "{\"a\"", "{\"a\":", "{\"a\":1"];
+        for (const k of keystrokes) {
+            expect(parseObjectInput(k)).toEqual({ value: k, parseError: true });
+        }
+        expect(parseObjectInput("{\"a\":1}")).toEqual({ value: { a: 1 }, parseError: false });
+    });
+
+    it("does not flag empty or whitespace-only text as an error", () => {
+        expect(parseObjectInput("")).toEqual({ value: "", parseError: false });
+        expect(parseObjectInput("   ")).toEqual({ value: "   ", parseError: false });
+    });
+
+    it("parses the literal null", () => {
+        expect(parseObjectInput("null")).toEqual({ value: null, parseError: false });
+    });
+
+    it("parses arrays", () => {
+        expect(parseObjectInput("[1,2]")).toEqual({ value: [1, 2], parseError: false });
+    });
+});
+
+describe("shouldResetPanelState", () => {
+    it("resets when the version identity changes", () => {
+        expect(shouldResetPanelState(true, true, true)).toBe(true);
+        expect(shouldResetPanelState(true, false, false)).toBe(true);
+    });
+
+    it("resets when content transitions from absent to present", () => {
+        expect(shouldResetPanelState(false, true, false)).toBe(true);
+    });
+
+    it("does not reset on a reference change of already-present content", () => {
+        expect(shouldResetPanelState(false, true, true)).toBe(false);
+    });
+
+    it("does not reset while content is still absent", () => {
+        expect(shouldResetPanelState(false, false, false)).toBe(false);
     });
 });

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.ts
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.ts
@@ -58,6 +58,47 @@ export const buildInitialValues = (
     return values;
 };
 
+/**
+ * Initial textarea text for an object/array variable, derived from its declared default.
+ * The test panel keeps the raw text as the source of truth for these fields so keystrokes
+ * are never re-formatted mid-type once the input happens to parse as valid JSON.
+ *
+ * Rules:
+ *   undefined   -> ""      (no default declared)
+ *   null        -> "null"  (explicit null default; preserved verbatim)
+ *   string      -> as-is   (user-typed or default already stored as text)
+ *   object/etc  -> pretty JSON
+ */
+export const initialObjectText = (value: unknown): string => {
+    if (value === undefined) return "";
+    if (value === null) return "null";
+    if (typeof value === "string") return value;
+    return JSON.stringify(value, null, 2);
+};
+
+/**
+ * Build the initial rawTexts map for object/array fields.
+ * Non-object/array fields are omitted; the standard values map covers them.
+ */
+export const buildInitialRawTexts = (
+    template: string | undefined,
+    variables: Record<string, VariableSchema> | VariableSchema[] | undefined
+): Record<string, string> => {
+    const reconciled = reconcileTemplateVariables(
+        extractTemplateVariableNames(template || ""),
+        toDeclaredMap(variables)
+    );
+    const rawTexts: Record<string, string> = {};
+    reconciled.forEach((entry) => {
+        const schema = schemaForField(entry);
+        const type = (schema.type || "string").toLowerCase();
+        if (type === "object" || type === "array") {
+            rawTexts[entry.name] = initialObjectText(schema.default);
+        }
+    });
+    return rawTexts;
+};
+
 export const coerceEnumValue = (val: string, type: string): any => {
     if (val === "") return "";
     switch (type) {

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.ts
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.ts
@@ -35,30 +35,6 @@ export const schemaForField = (entry: ReconciledVariable): VariableSchema => {
 };
 
 /**
- * Build a fresh values map from template-detected names + declared variable schemas.
- * Used on initial mount and whenever the viewed version identity changes.
- */
-export const buildInitialValues = (
-    template: string | undefined,
-    variables: Record<string, VariableSchema> | VariableSchema[] | undefined
-): Record<string, any> => {
-    const reconciled = reconcileTemplateVariables(
-        extractTemplateVariableNames(template || ""),
-        toDeclaredMap(variables)
-    );
-    const values: Record<string, any> = {};
-    reconciled.forEach((entry) => {
-        const schema = schemaForField(entry);
-        if (schema.default !== undefined) {
-            values[entry.name] = schema.default;
-        } else {
-            values[entry.name] = (schema.type || "string").toLowerCase() === "boolean" ? false : "";
-        }
-    });
-    return values;
-};
-
-/**
  * Initial textarea text for an object/array variable, derived from its declared default.
  * The test panel keeps the raw text as the source of truth for these fields so keystrokes
  * are never re-formatted mid-type once the input happens to parse as valid JSON.
@@ -76,27 +52,83 @@ export const initialObjectText = (value: unknown): string => {
     return JSON.stringify(value, null, 2);
 };
 
+export type TestPanelInitialState = {
+    values: Record<string, any>;
+    rawTexts: Record<string, string>;
+};
+
 /**
- * Build the initial rawTexts map for object/array fields.
- * Non-object/array fields are omitted; the standard values map covers them.
+ * Build the initial values and rawTexts maps from a single reconciliation pass, so the
+ * two can never drift apart. values covers every variable; rawTexts only carries entries
+ * for object/array fields, where the textarea's raw text is the source of truth.
  */
-export const buildInitialRawTexts = (
+export const buildInitialPanelState = (
     template: string | undefined,
     variables: Record<string, VariableSchema> | VariableSchema[] | undefined
-): Record<string, string> => {
+): TestPanelInitialState => {
     const reconciled = reconcileTemplateVariables(
         extractTemplateVariableNames(template || ""),
         toDeclaredMap(variables)
     );
+    const values: Record<string, any> = {};
     const rawTexts: Record<string, string> = {};
     reconciled.forEach((entry) => {
         const schema = schemaForField(entry);
         const type = (schema.type || "string").toLowerCase();
+        if (schema.default !== undefined) {
+            values[entry.name] = schema.default;
+        } else {
+            values[entry.name] = type === "boolean" ? false : "";
+        }
         if (type === "object" || type === "array") {
             rawTexts[entry.name] = initialObjectText(schema.default);
         }
     });
-    return rawTexts;
+    return { values, rawTexts };
+};
+
+/** Values half of buildInitialPanelState, kept for callers/tests that only need one map. */
+export const buildInitialValues = (
+    template: string | undefined,
+    variables: Record<string, VariableSchema> | VariableSchema[] | undefined
+): Record<string, any> => {
+    return buildInitialPanelState(template, variables).values;
+};
+
+/** RawTexts half of buildInitialPanelState, kept for callers/tests that only need one map. */
+export const buildInitialRawTexts = (
+    template: string | undefined,
+    variables: Record<string, VariableSchema> | VariableSchema[] | undefined
+): Record<string, string> => {
+    return buildInitialPanelState(template, variables).rawTexts;
+};
+
+/**
+ * Interpret the raw text of an object/array field. Valid JSON yields the parsed value;
+ * anything else yields the raw string (the backend rejects it with a type validation
+ * error on Render) plus a parseError flag the UI can surface. Empty text is not an
+ * error: it just means the field is untouched.
+ */
+export const parseObjectInput = (text: string): { value: any; parseError: boolean } => {
+    try {
+        return { value: JSON.parse(text), parseError: false };
+    } catch {
+        return { value: text, parseError: text.trim() !== "" };
+    }
+};
+
+/**
+ * Whether the test panel state should be re-initialized. True when the viewed version
+ * changed, or when the artifact content transitioned from absent to present (async
+ * load after mount). Deliberately NOT true for a mere reference change of already
+ * present content, so a parent that fails to memoize props cannot wipe user input.
+ */
+export const shouldResetPanelState = (
+    versionChanged: boolean,
+    contentPresent: boolean,
+    contentWasPresent: boolean
+): boolean => {
+    return versionChanged || (contentPresent && !contentWasPresent);
 };
 
 export const coerceEnumValue = (val: string, type: string): any => {

--- a/ui/ui-app/src/app/components/promptTemplate/usePromptTemplateTestPanelState.ts
+++ b/ui/ui-app/src/app/components/promptTemplate/usePromptTemplateTestPanelState.ts
@@ -2,10 +2,10 @@ import { useEffect, useRef, useState } from "react";
 import { GroupsService } from "@services/useGroupsService.ts";
 import { RenderPromptResponse, RenderPromptValidationError } from "@models/RenderPromptResponse.ts";
 import {
-    buildInitialRawTexts,
-    buildInitialValues,
+    buildInitialPanelState,
     buildVersionIdentity,
-    shouldAcceptRenderResponse
+    shouldAcceptRenderResponse,
+    shouldResetPanelState
 } from "./PromptTemplateTestPanel.utils";
 import { VariableSchema } from "./promptTemplateVariables";
 
@@ -40,40 +40,44 @@ export type PromptTemplateTestPanelState = {
 export const usePromptTemplateTestPanelState = (
     args: UsePromptTemplateTestPanelStateArgs
 ): PromptTemplateTestPanelState => {
-    // Keep the latest template/variables for the version-identity reset without depending on
-    // object identity — the parent may rebuild these on every render for a given version.
-    const templateRef = useRef(args.template);
-    templateRef.current = args.template;
-    const variablesRef = useRef(args.variables);
-    variablesRef.current = args.variables;
-
     // Version identity at the time of the latest reset / Render. Used to ignore stale
     // async Render resolutions after the viewed version has moved on.
     const versionIdentity = buildVersionIdentity(args.groupId, args.artifactId, args.version);
     const versionIdentityRef = useRef(versionIdentity);
     const renderRequestIdRef = useRef(0);
 
+    // Whether artifact content had arrived as of the latest reset. Lets the reset effect
+    // distinguish "content just loaded" from "same content, new object reference".
+    const contentWasPresentRef = useRef(args.template !== undefined || args.variables !== undefined);
+
     const [values, setValues] = useState<Record<string, any>>(
-        () => buildInitialValues(args.template, args.variables)
+        () => buildInitialPanelState(args.template, args.variables).values
     );
     const [rawTexts, setRawTexts] = useState<Record<string, string>>(
-        () => buildInitialRawTexts(args.template, args.variables)
+        () => buildInitialPanelState(args.template, args.variables).rawTexts
     );
     const [renderedOutput, setRenderedOutput] = useState<string>("");
     const [validationErrors, setValidationErrors] = useState<RenderPromptValidationError[]>([]);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string>("");
 
-    // Reset form values and render results whenever the viewed version identity changes,
-    // OR when the artifact content (template/variables) transitions from absent to present.
-    // The parent memoizes template/variables, so these refs only change when the version
-    // key changes or when the artifact content is loaded asynchronously — user input isn't
-    // wiped on incidental re-renders.
+    // Reset form values and render results when the viewed version identity changes, or
+    // when the artifact content transitions from absent to present (async load after
+    // mount). Guarded by shouldResetPanelState rather than raw reference equality, so a
+    // caller that fails to memoize template/variables cannot wipe in-progress user input
+    // on an incidental re-render.
     useEffect(() => {
+        const contentPresent = args.template !== undefined || args.variables !== undefined;
+        const versionChanged = versionIdentityRef.current !== versionIdentity;
+        if (!shouldResetPanelState(versionChanged, contentPresent, contentWasPresentRef.current)) {
+            return;
+        }
+        contentWasPresentRef.current = contentPresent;
         versionIdentityRef.current = versionIdentity;
         renderRequestIdRef.current += 1;
-        setValues(buildInitialValues(templateRef.current, variablesRef.current));
-        setRawTexts(buildInitialRawTexts(templateRef.current, variablesRef.current));
+        const initial = buildInitialPanelState(args.template, args.variables);
+        setValues(initial.values);
+        setRawTexts(initial.rawTexts);
         setRenderedOutput("");
         setValidationErrors([]);
         setError("");

--- a/ui/ui-app/src/app/components/promptTemplate/usePromptTemplateTestPanelState.ts
+++ b/ui/ui-app/src/app/components/promptTemplate/usePromptTemplateTestPanelState.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { GroupsService } from "@services/useGroupsService.ts";
 import { RenderPromptResponse, RenderPromptValidationError } from "@models/RenderPromptResponse.ts";
 import {
+    buildInitialRawTexts,
     buildInitialValues,
     buildVersionIdentity,
     shouldAcceptRenderResponse
@@ -22,11 +23,13 @@ export type UsePromptTemplateTestPanelStateArgs = PromptTemplateTestPanelIdentit
 
 export type PromptTemplateTestPanelState = {
     values: Record<string, any>;
+    rawTexts: Record<string, string>;
     renderedOutput: string;
     validationErrors: RenderPromptValidationError[];
     isLoading: boolean;
     error: string;
     setValue: (name: string, value: any) => void;
+    setRawText: (name: string, text: string) => void;
     doRender: () => void;
 };
 
@@ -53,26 +56,36 @@ export const usePromptTemplateTestPanelState = (
     const [values, setValues] = useState<Record<string, any>>(
         () => buildInitialValues(args.template, args.variables)
     );
+    const [rawTexts, setRawTexts] = useState<Record<string, string>>(
+        () => buildInitialRawTexts(args.template, args.variables)
+    );
     const [renderedOutput, setRenderedOutput] = useState<string>("");
     const [validationErrors, setValidationErrors] = useState<RenderPromptValidationError[]>([]);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string>("");
 
-    // Reset form values and render results whenever the viewed version identity changes.
-    // Depend only on the version key — not template/variables by reference — so an unstable
-    // parent object cannot wipe in-progress user input on every re-render.
+    // Reset form values and render results whenever the viewed version identity changes,
+    // OR when the artifact content (template/variables) transitions from absent to present.
+    // The parent memoizes template/variables, so these refs only change when the version
+    // key changes or when the artifact content is loaded asynchronously — user input isn't
+    // wiped on incidental re-renders.
     useEffect(() => {
         versionIdentityRef.current = versionIdentity;
         renderRequestIdRef.current += 1;
         setValues(buildInitialValues(templateRef.current, variablesRef.current));
+        setRawTexts(buildInitialRawTexts(templateRef.current, variablesRef.current));
         setRenderedOutput("");
         setValidationErrors([]);
         setError("");
         setIsLoading(false);
-    }, [versionIdentity]);
+    }, [versionIdentity, args.template, args.variables]);
 
     const setValue = (name: string, value: any): void => {
         setValues(prev => ({ ...prev, [name]: value }));
+    };
+
+    const setRawText = (name: string, text: string): void => {
+        setRawTexts(prev => ({ ...prev, [name]: text }));
     };
 
     const doRender = (): void => {
@@ -129,11 +142,13 @@ export const usePromptTemplateTestPanelState = (
 
     return {
         values,
+        rawTexts,
         renderedOutput,
         validationErrors,
         isLoading,
         error,
         setValue,
+        setRawText,
         doRender
     };
 };


### PR DESCRIPTION
Fixes #9507

## What

Two bugs on the object/array TextArea in the Test Prompt panel, plus a pre-existing timing bug that surfaced when I tried to verify the fix live.

Bug 1: The TextArea value was derived from parsed state every render:
`value={typeof values[name] === "string" ? values[name] : JSON.stringify(values[name] || "", null, 2)}`

The moment your input parsed as JSON, state became the parsed object, and the next render re-stringified it with pretty-print. Typing `{"a":1}` compact flipped to multi-line the instant you hit `}`, cursor jumps, you can't type properly.

Bug 2: Same line, `values[name] || ""` treats an explicit `default: null` as falsy, so a variable with `"default": null` rendered as an empty textarea instead of the literal `"null"`.

Bonus timing bug: When I ran the fix live, both textareas were still empty. Turns out the reset useEffect only depended on versionIdentity, so the state stayed empty forever when the parent (PromptTemplateVisualizer) mounted the panel with `spec?.template` and `spec?.variables` both undefined (artifact loading async). The old textarea derivation just happened to hide it by recomputing from state every render. Extended the effect deps to also include template and variables. Safe because the visualizer already memoizes those refs.

## Fix

- New `initialObjectText(value)` helper: undefined -> "", null -> "null", strings pass through, objects/arrays -> pretty JSON.
- `usePromptTemplateTestPanelState` now owns a `rawTexts` buffer next to values. rawTexts is what the textarea shows; values is only used for the Render request.
- Every keystroke stores raw text verbatim and try-parses to keep values in sync when input is valid JSON.

## Tests

10 new cases in `PromptTemplateTestPanel.utils.test.ts` covering initialObjectText and buildInitialRawTexts. Local run: 73/73 prompt-template tests pass.

## Live verify

Ran the branch against the latest-snapshot backend with a template containing both cases (cfg with no default, nul with default: null). Typed `{"a":1}` compact into cfg one character at a time via scripted keystrokes. Value stays as `{"a":1}` at every keystroke, no reformat. nul textarea shows the literal `null`.
