### PR TITLE
fix(storage): propagate SQL transaction cleanup failures

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractHandleFactory.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractHandleFactory.java
@@ -36,7 +36,9 @@ public abstract class AbstractHandleFactory implements HandleFactory {
     @Override
     public <R, X extends Exception> R withHandle(HandleCallback<R, X> callback) throws X {
         LocalState state = state();
-        Throwable callbackFailure = null;
+        R result = null;
+        Exception callbackFailure = null;
+        RuntimeException transactionFailure;
         try {
             // Create a new handle if necessary. Increment the "level" if a handle already exists.
             if (state.handle == null) {
@@ -52,7 +54,7 @@ public abstract class AbstractHandleFactory implements HandleFactory {
 
             // Invoke the callback with the handle. This will either return a value (success)
             // or throw some sort of exception.
-            return callback.withHandle(state.handle);
+            result = callback.withHandle(state.handle);
         } catch (SQLException e) {
             // If a SQL exception is thrown, set the handle to rollback.
             if (state.handle != null) {
@@ -62,7 +64,6 @@ public abstract class AbstractHandleFactory implements HandleFactory {
             // Wrap the SQL exception.
             RegistryStorageException wrapped = new RegistryStorageException(e);
             callbackFailure = wrapped;
-            throw wrapped;
         } catch (Exception e) {
             // If any other exception is thrown, also set the handle to rollback.
             if (state.handle != null) {
@@ -70,55 +71,64 @@ public abstract class AbstractHandleFactory implements HandleFactory {
                 state.handle.setRollback(true);
             }
             callbackFailure = e;
-            throw e;
         } finally {
-            if (state.level > 0) {
-                log.trace("Exiting nested call (level {}): {} #{}", state().level,
-                        state().handle.getConnection(), state().handle.getConnection().hashCode());
-                state.level--;
+            transactionFailure = releaseHandle(state);
+        }
+
+        if (transactionFailure != null) {
+            if (callbackFailure != null) {
+                callbackFailure.addSuppressed(transactionFailure);
             } else {
-                // Commit or rollback the transaction
-                RuntimeException transactionFailure = null;
-                try {
-                    if (state.handle != null) {
-                        if (state.handle.isRollback()) {
-                            log.trace("Rollback: {} #{}", state.handle.getConnection(),
-                                    state.handle.getConnection().hashCode());
-                            state.handle.getConnection().rollback();
-                        } else {
-                            log.trace("Commit: {} #{}", state.handle.getConnection(),
-                                    state.handle.getConnection().hashCode());
-                            state().handle.getConnection().commit();
-                        }
-                    }
-                } catch (Exception e) {
-                    log.error("Could not release database connection/transaction", e);
-                    transactionFailure = new RegistryStorageException(
-                            "Could not release database connection/transaction.", e);
-                }
-
-                // Close the connection
-                try {
-                    if (state.handle != null) {
-                        state.handle.close();
-                    }
-                } catch (Exception ex) {
-                    // Nothing we can do
-                    log.error("Could not close a database connection.", ex);
-                } finally {
-                    state.handle = null;
-                    state.level = 0;
-                }
-
-                if (transactionFailure != null) {
-                    if (callbackFailure != null) {
-                        callbackFailure.addSuppressed(transactionFailure);
-                    } else {
-                        throw transactionFailure;
-                    }
-                }
+                throw transactionFailure;
             }
         }
+        if (callbackFailure != null) {
+            @SuppressWarnings("unchecked")
+            X failure = (X) callbackFailure;
+            throw failure;
+        }
+        return result;
+    }
+
+    private RuntimeException releaseHandle(LocalState state) {
+        if (state.level > 0) {
+            log.trace("Exiting nested call (level {}): {} #{}", state.level,
+                    state.handle.getConnection(), state.handle.getConnection().hashCode());
+            state.level--;
+            return null;
+        }
+
+        RuntimeException transactionFailure = null;
+        try {
+            if (state.handle != null) {
+                if (state.handle.isRollback()) {
+                    log.trace("Rollback: {} #{}", state.handle.getConnection(),
+                            state.handle.getConnection().hashCode());
+                    state.handle.getConnection().rollback();
+                } else {
+                    log.trace("Commit: {} #{}", state.handle.getConnection(),
+                            state.handle.getConnection().hashCode());
+                    state.handle.getConnection().commit();
+                }
+            }
+        } catch (Exception e) {
+            log.error("Could not release database connection/transaction", e);
+            transactionFailure = new RegistryStorageException(
+                    "Could not release database connection/transaction.", e);
+        }
+
+        try {
+            if (state.handle != null) {
+                state.handle.close();
+            }
+        } catch (Exception ex) {
+            // Nothing we can do
+            log.error("Could not close a database connection.", ex);
+        } finally {
+            state.handle = null;
+            state.level = 0;
+        }
+        return transactionFailure;
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractHandleFactory.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractHandleFactory.java
@@ -36,6 +36,7 @@ public abstract class AbstractHandleFactory implements HandleFactory {
     @Override
     public <R, X extends Exception> R withHandle(HandleCallback<R, X> callback) throws X {
         LocalState state = state();
+        Throwable callbackFailure = null;
         try {
             // Create a new handle if necessary. Increment the "level" if a handle already exists.
             if (state.handle == null) {
@@ -59,13 +60,16 @@ public abstract class AbstractHandleFactory implements HandleFactory {
                 state.handle.setRollback(true);
             }
             // Wrap the SQL exception.
-            throw new RegistryStorageException(e);
+            RegistryStorageException wrapped = new RegistryStorageException(e);
+            callbackFailure = wrapped;
+            throw wrapped;
         } catch (Exception e) {
             // If any other exception is thrown, also set the handle to rollback.
             if (state.handle != null) {
                 log.debug("Transaction will rollback.", e);
                 state.handle.setRollback(true);
             }
+            callbackFailure = e;
             throw e;
         } finally {
             if (state.level > 0) {
@@ -74,6 +78,7 @@ public abstract class AbstractHandleFactory implements HandleFactory {
                 state.level--;
             } else {
                 // Commit or rollback the transaction
+                RuntimeException transactionFailure = null;
                 try {
                     if (state.handle != null) {
                         if (state.handle.isRollback()) {
@@ -88,18 +93,29 @@ public abstract class AbstractHandleFactory implements HandleFactory {
                     }
                 } catch (Exception e) {
                     log.error("Could not release database connection/transaction", e);
+                    transactionFailure = new RegistryStorageException(
+                            "Could not release database connection/transaction.", e);
                 }
 
                 // Close the connection
                 try {
                     if (state.handle != null) {
                         state.handle.close();
-                        state.handle = null;
-                        state.level = 0;
                     }
                 } catch (Exception ex) {
                     // Nothing we can do
                     log.error("Could not close a database connection.", ex);
+                } finally {
+                    state.handle = null;
+                    state.level = 0;
+                }
+
+                if (transactionFailure != null) {
+                    if (callbackFailure != null) {
+                        callbackFailure.addSuppressed(transactionFailure);
+                    } else {
+                        throw transactionFailure;
+                    }
                 }
             }
         }

--- a/app/src/test/java/io/apicurio/registry/storage/impl/sql/AbstractHandleFactoryTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/sql/AbstractHandleFactoryTest.java
@@ -1,0 +1,85 @@
+package io.apicurio.registry.storage.impl.sql;
+
+import io.agroal.api.AgroalDataSource;
+import io.apicurio.registry.storage.error.RegistryStorageException;
+import io.apicurio.registry.storage.impl.sql.jdb.HandleCallback;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AbstractHandleFactoryTest {
+
+    @Test
+    void shouldPropagateCommitFailureAfterClosingConnection() throws Exception {
+        AgroalDataSource dataSource = mock(AgroalDataSource.class);
+        Connection connection = mock(Connection.class);
+        SQLException commitFailure = new SQLException("commit failed");
+        when(dataSource.getConnection()).thenReturn(connection);
+        doThrow(commitFailure).when(connection).commit();
+
+        RegistryStorageException thrown = assertThrows(RegistryStorageException.class,
+                () -> factory(dataSource).withHandle((HandleCallback<Void, RuntimeException>) handle -> null));
+
+        assertSame(commitFailure, thrown.getCause());
+        verify(connection).close();
+    }
+
+    @Test
+    void shouldPreserveCallbackFailureWhenRollbackFails() throws Exception {
+        AgroalDataSource dataSource = mock(AgroalDataSource.class);
+        Connection connection = mock(Connection.class);
+        SQLException rollbackFailure = new SQLException("rollback failed");
+        RuntimeException callbackFailure = new IllegalStateException("callback failed");
+        when(dataSource.getConnection()).thenReturn(connection);
+        doThrow(rollbackFailure).when(connection).rollback();
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> factory(dataSource).withHandle((HandleCallback<Void, RuntimeException>) handle -> {
+                    throw callbackFailure;
+                }));
+
+        assertSame(callbackFailure, thrown);
+        assertEquals(1, thrown.getSuppressed().length);
+        assertSame(rollbackFailure, thrown.getSuppressed()[0].getCause());
+        verify(connection).close();
+    }
+
+    @Test
+    void shouldResetHandleAfterConnectionCloseFailure() throws Exception {
+        AgroalDataSource dataSource = mock(AgroalDataSource.class);
+        Connection firstConnection = mock(Connection.class);
+        Connection secondConnection = mock(Connection.class);
+        when(dataSource.getConnection()).thenReturn(firstConnection, secondConnection);
+        doThrow(new SQLException("close failed")).when(firstConnection).close();
+
+        AbstractHandleFactory factory = factory(dataSource);
+
+        assertEquals("first", factory.withHandle((HandleCallback<String, RuntimeException>) handle -> "first"));
+        assertEquals("second", factory.withHandle((HandleCallback<String, RuntimeException>) handle -> "second"));
+
+        verify(dataSource, times(2)).getConnection();
+        verify(firstConnection).close();
+        verify(secondConnection).close();
+    }
+
+    private AbstractHandleFactory factory(AgroalDataSource dataSource) {
+        ConnectionRetryConfig config = new ConnectionRetryConfig();
+        config.enabled = false;
+        return new AbstractHandleFactory() {
+            {
+                initialize(dataSource, "test", mock(Logger.class), config);
+            }
+        };
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/storage/impl/sql/AbstractHandleFactoryTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/sql/AbstractHandleFactoryTest.java
@@ -32,6 +32,7 @@ class AbstractHandleFactoryTest {
                 () -> factory(dataSource).withHandle((HandleCallback<Void, RuntimeException>) handle -> null));
 
         assertSame(commitFailure, thrown.getCause());
+        verify(connection).commit();
         verify(connection).close();
     }
 
@@ -52,6 +53,24 @@ class AbstractHandleFactoryTest {
         assertSame(callbackFailure, thrown);
         assertEquals(1, thrown.getSuppressed().length);
         assertSame(rollbackFailure, thrown.getSuppressed()[0].getCause());
+        verify(connection).rollback();
+        verify(connection).close();
+    }
+
+    @Test
+    void shouldPropagateCheckedCallbackFailureAfterRollback() throws Exception {
+        AgroalDataSource dataSource = mock(AgroalDataSource.class);
+        Connection connection = mock(Connection.class);
+        Exception callbackFailure = new Exception("callback failed");
+        when(dataSource.getConnection()).thenReturn(connection);
+
+        Exception thrown = assertThrows(Exception.class,
+                () -> factory(dataSource).withHandle((HandleCallback<Void, Exception>) handle -> {
+                    throw callbackFailure;
+                }));
+
+        assertSame(callbackFailure, thrown);
+        verify(connection).rollback();
         verify(connection).close();
     }
 


### PR DESCRIPTION
Fixes #9646 

## Problem

`AbstractHandleFactory.withHandle` only logs failures from transaction commit or rollback. This can make an operation appear successful even though transaction cleanup failed. Failed connection cleanup can also leave stale thread-local handle state.

## Solution

- Propagate commit and rollback failures as `RegistryStorageException`.
- Preserve callback exceptions when transaction cleanup also fails.
- Attach cleanup failures as suppressed exceptions.
- Always clear the thread-local handle and transaction state after closing.

## Tests

Added `AbstractHandleFactoryTest` covering:

- Commit failure propagation.
- Callback failure combined with rollback failure.
- Connection-close failure and state reset.

