### PR TITLE
refactor(ui): extract shared iframe editor functionality (#9107)

### DIFF
--- a/ui/ui-app/src/editors/AsyncApiEditor.tsx
+++ b/ui/ui-app/src/editors/AsyncApiEditor.tsx
@@ -1,105 +1,25 @@
-import React, { RefObject, useEffect, useMemo } from "react";
-import "./AsyncApiEditor.css";
+import React from "react";
 import { Editor as DraftEditor, EditorProps } from "./editor-types";
-import { parseJson, parseYaml, toJsonString, toYamlString } from "@utils/content.utils.ts";
-import { useConfigService } from "@services/useConfigService.ts";
-import { ContentTypes } from "@models/ContentTypes.ts";
-import { deriveOrigin } from "@utils/url.utils.ts";
+import { IframeEditor } from "./IframeEditor";
+import "./AsyncApiEditor.css";
 
 export type AsyncApiEditorProps = {
     className?: string;
 } & EditorProps;
 
-
 /**
- * AsyncAPI editor.  The actual editor logic is written in Angular as a separate application
- * and loaded via an iframe.  This component is a bridge - it acts as a React component that
+ * AsyncAPI editor. The actual editor logic is written in Angular as a separate application
+ * and loaded via an iframe. This component is a bridge - it acts as a React component that
  * bridges to the iframe.
  */
 export const AsyncApiEditor: DraftEditor = (props: AsyncApiEditorProps) => {
-    const ref: RefObject<any> = React.createRef();
-    const config = useConfigService();
-
-    let editorsUrl: string = config.uiEditorsUrl();
-    if (editorsUrl.startsWith("/")) {
-        editorsUrl = window.location.origin + editorsUrl;
-    }
-
-    // TODO we have a lot of common functionality between the asyncapi and openapi editors.  Need to share!
-    const expectedOrigin = useMemo(() => {
-        return deriveOrigin(editorsUrl, window.location.origin);
-    }, [editorsUrl]);
-    useEffect(() => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        const eventListener = (event: MessageEvent) => {
-            if (!expectedOrigin || event.origin !== expectedOrigin) {
-                return;
-            }
-            if (event.data && event.data.type === "apicurio_onChange") {
-                let newContent: any = event.data.data.content;
-                if (typeof newContent === "object") {
-                    if (props.content.contentType === ContentTypes.APPLICATION_YAML) {
-                        console.info("[AsyncApiEditor] New content is 'object', converting to YAML string");
-                        newContent = toYamlString(newContent);
-                    } else {
-                        console.info("[AsyncApiEditor] New content is 'object', converting to JSON string");
-                        newContent = toJsonString(newContent);
-                    }
-                } else if (typeof newContent === "string" && props.content.contentType === ContentTypes.APPLICATION_YAML) {
-                    console.info("[AsyncApiEditor] Converting from JSON string to YAML string.");
-                    newContent = toYamlString(parseJson(newContent as string));
-                }
-                props.onChange(newContent);
-            }
-        };
-        window.addEventListener("message", eventListener, false);
-        return () => {
-            window.removeEventListener("message", eventListener, false);
-        };
-    });
-
-    const editorAppUrl = (): string => {
-        return editorsUrl;
-    };
-
-    const onEditorLoaded = (): void => {
-        // Now it's OK to post a message to iframe with the content to edit.
-        let value: string;
-        if (typeof props.content.content === "object") {
-            console.info("[AsyncApiEditor] Loading editor data from 'object' - converting to JSON string.");
-            value = toJsonString(props.content.content);
-        } else if (typeof props.content.content === "string" && props.content.contentType === ContentTypes.APPLICATION_YAML) {
-            console.info("[AsyncApiEditor] Loading editor data from 'string' - converting from YAML to JSON.");
-            value = toJsonString(parseYaml(props.content.content as string));
-        } else {
-            console.info("[AsyncApiEditor] Loading editor data from 'string' without content conversion.");
-            value = props.content.content as string;
-        }
-        const message: any = {
-            type: "apicurio-editingInfo",
-            // tslint:disable-next-line:object-literal-sort-keys
-            data: {
-                content: {
-                    type: "ASYNCAPI",
-                    value: value
-                },
-                features: {
-                    allowCustomValidations: false,
-                    allowImports: false
-                }
-            }
-        };
-        if (expectedOrigin) {
-            ref.current.contentWindow.postMessage(message, expectedOrigin);
-        }
-    };
-
     return (
-        <iframe id="asyncapi-editor-frame"
-            ref={ ref }
-            className={ props.className ? props.className : "editor-asyncapi-flex-container" }
-            onLoad={ onEditorLoaded }
-            src={ editorAppUrl() } />
+        <IframeEditor
+            editorType="ASYNCAPI"
+            editorName="AsyncApiEditor"
+            frameId="asyncapi-editor-frame"
+            className={props.className ? props.className : "editor-asyncapi-flex-container"}
+            {...props}
+        />
     );
 };

--- a/ui/ui-app/src/editors/IframeEditor.test.ts
+++ b/ui/ui-app/src/editors/IframeEditor.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock the artifact types service module so PatternFly styles are not pulled into node environment
+vi.mock("@services/useArtifactTypesService.ts", () => ({
+    ArtifactTypes: {
+        PROTOBUF: "PROTOBUF"
+    }
+}));
+
+import { ContentTypes } from "@models/ContentTypes.ts";
+import { deriveOrigin } from "@utils/url.utils.ts";
+import { toJsonString, toYamlString, parseJson, parseYaml } from "@utils/content.utils.ts";
+
+describe("IframeEditor logic and protocol tests", () => {
+    describe("Origin derivation and validation", () => {
+        it("derives origin correctly for absolute and relative URLs", () => {
+            const fallbackOrigin = "http://localhost:8888";
+            expect(deriveOrigin("http://editor.example.com/app", fallbackOrigin)).toBe("http://editor.example.com");
+            expect(deriveOrigin("/editors/oai", fallbackOrigin)).toBe("http://localhost:8888");
+            expect(deriveOrigin("", fallbackOrigin)).toBeUndefined();
+            expect(deriveOrigin(undefined, fallbackOrigin)).toBeUndefined();
+        });
+
+        it("fails closed on malformed URLs or missing origin", () => {
+            expect(deriveOrigin("http://", "invalid-origin")).toBeUndefined();
+        });
+    });
+
+    describe("Incoming message event processing (apicurio_onChange)", () => {
+        const expectedOrigin = "http://editor.example.com";
+
+        const simulateMessage = (
+            eventOrigin: string,
+            eventData: any,
+            currentContentType: string,
+            onChange: (val: any) => void
+        ) => {
+            // Replicate the exact guard and conversion logic from IframeEditor
+            if (!expectedOrigin || eventOrigin !== expectedOrigin) {
+                return;
+            }
+            if (eventData && eventData.type === "apicurio_onChange") {
+                let newContent: any = eventData.data.content;
+                if (typeof newContent === "object") {
+                    if (currentContentType === ContentTypes.APPLICATION_YAML) {
+                        newContent = toYamlString(newContent);
+                    } else {
+                        newContent = toJsonString(newContent);
+                    }
+                } else if (typeof newContent === "string" && currentContentType === ContentTypes.APPLICATION_YAML) {
+                    newContent = toYamlString(parseJson(newContent as string));
+                }
+                onChange(newContent);
+            }
+        };
+
+        it("ignores messages from untrusted origins", () => {
+            const onChange = vi.fn();
+            simulateMessage("http://evil.com", { type: "apicurio_onChange", data: { content: { foo: "bar" } } }, ContentTypes.APPLICATION_JSON, onChange);
+            expect(onChange).not.toHaveBeenCalled();
+        });
+
+        it("ignores messages with unknown event types", () => {
+            const onChange = vi.fn();
+            simulateMessage(expectedOrigin, { type: "unknown_event", data: { content: "test" } }, ContentTypes.APPLICATION_JSON, onChange);
+            expect(onChange).not.toHaveBeenCalled();
+        });
+
+        it("converts object content to JSON string for JSON contentType", () => {
+            const onChange = vi.fn();
+            const obj = { openapi: "3.0.2", info: { title: "Test API" } };
+            simulateMessage(expectedOrigin, { type: "apicurio_onChange", data: { content: obj } }, ContentTypes.APPLICATION_JSON, onChange);
+            expect(onChange).toHaveBeenCalledTimes(1);
+            expect(JSON.parse(onChange.mock.calls[0][0])).toEqual(obj);
+        });
+
+        it("converts object content to YAML string for YAML contentType", () => {
+            const onChange = vi.fn();
+            const obj = { openapi: "3.0.2", info: { title: "Test API" } };
+            simulateMessage(expectedOrigin, { type: "apicurio_onChange", data: { content: obj } }, ContentTypes.APPLICATION_YAML, onChange);
+            expect(onChange).toHaveBeenCalledTimes(1);
+            expect(onChange.mock.calls[0][0]).toContain("openapi: 3.0.2");
+        });
+
+        it("converts JSON string to YAML string when contentType is YAML", () => {
+            const onChange = vi.fn();
+            const jsonStr = JSON.stringify({ openapi: "3.0.2", info: { title: "From Editor" } });
+            simulateMessage(expectedOrigin, { type: "apicurio_onChange", data: { content: jsonStr } }, ContentTypes.APPLICATION_YAML, onChange);
+            expect(onChange).toHaveBeenCalledTimes(1);
+            expect(onChange.mock.calls[0][0]).toContain("openapi: 3.0.2");
+        });
+
+        it("passes raw string without conversion for JSON contentType", () => {
+            const onChange = vi.fn();
+            const jsonStr = "{\"openapi\":\"3.0.2\"}";
+            simulateMessage(expectedOrigin, { type: "apicurio_onChange", data: { content: jsonStr } }, ContentTypes.APPLICATION_JSON, onChange);
+            expect(onChange).toHaveBeenCalledWith(jsonStr);
+        });
+    });
+
+    describe("Outgoing payload construction (apicurio-editingInfo)", () => {
+        const buildEditingInfoMessage = (
+            editorType: "OPENAPI" | "ASYNCAPI",
+            rawContent: any,
+            contentType: string,
+            extraEditingInfo?: Record<string, any>
+        ) => {
+            let value: string;
+            if (typeof rawContent === "object") {
+                value = toJsonString(rawContent);
+            } else if (typeof rawContent === "string" && contentType === ContentTypes.APPLICATION_YAML) {
+                value = toJsonString(parseYaml(rawContent as string));
+            } else {
+                value = rawContent as string;
+            }
+
+            const safeExtra: Record<string, any> = { ...(extraEditingInfo || {}) };
+            delete safeExtra.content;
+            delete safeExtra.features;
+
+            return {
+                type: "apicurio-editingInfo",
+                data: {
+                    content: {
+                        type: editorType,
+                        value: value
+                    },
+                    features: {
+                        allowCustomValidations: false,
+                        allowImports: false
+                    },
+                    ...safeExtra
+                } as Record<string, any>
+            };
+        };
+
+        it("constructs correct OPENAPI message payload with vendor extensions", () => {
+            const msg = buildEditingInfoMessage("OPENAPI", "{\"openapi\":\"3.0.0\"}", ContentTypes.APPLICATION_JSON, {
+                openapi: { vendorExtensions: [] }
+            });
+            expect(msg.type).toBe("apicurio-editingInfo");
+            expect(msg.data.content.type).toBe("OPENAPI");
+            expect(msg.data.content.value).toBe("{\"openapi\":\"3.0.0\"}");
+            expect(msg.data.openapi).toEqual({ vendorExtensions: [] });
+            expect(msg.data.features).toEqual({ allowCustomValidations: false, allowImports: false });
+        });
+
+        it("constructs correct ASYNCAPI message payload", () => {
+            const msg = buildEditingInfoMessage("ASYNCAPI", "{\"asyncapi\":\"2.0.0\"}", ContentTypes.APPLICATION_JSON);
+            expect(msg.type).toBe("apicurio-editingInfo");
+            expect(msg.data.content.type).toBe("ASYNCAPI");
+            expect(msg.data.content.value).toBe("{\"asyncapi\":\"2.0.0\"}");
+        });
+
+        it("prevents extraEditingInfo from overriding content or features keys", () => {
+            const msg = buildEditingInfoMessage("OPENAPI", "{\"openapi\":\"3.0.0\"}", ContentTypes.APPLICATION_JSON, {
+                content: { type: "OVERRIDDEN", value: "BAD" },
+                features: { allowCustomValidations: true },
+                customKey: "safe"
+            });
+            expect(msg.data.content.type).toBe("OPENAPI");
+            expect(msg.data.content.value).toBe("{\"openapi\":\"3.0.0\"}");
+            expect(msg.data.features.allowCustomValidations).toBe(false);
+            expect(msg.data.customKey).toBe("safe");
+        });
+
+        it("converts YAML string content to JSON value for outgoing message", () => {
+            const yamlStr = "openapi: 3.0.0\ninfo:\n  title: Hello";
+            const msg = buildEditingInfoMessage("OPENAPI", yamlStr, ContentTypes.APPLICATION_YAML);
+            const parsed = JSON.parse(msg.data.content.value);
+            expect(parsed.openapi).toBe("3.0.0");
+            expect(parsed.info.title).toBe("Hello");
+        });
+    });
+});

--- a/ui/ui-app/src/editors/IframeEditor.tsx
+++ b/ui/ui-app/src/editors/IframeEditor.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useMemo, useRef } from "react";
+import { EditorProps } from "./editor-types";
+import { parseJson, parseYaml, toJsonString, toYamlString } from "@utils/content.utils.ts";
+import { useConfigService } from "@services/useConfigService.ts";
+import { ContentTypes } from "@models/ContentTypes.ts";
+import { deriveOrigin } from "@utils/url.utils.ts";
+
+export type IframeEditorExtraData = {
+    content?: never;
+    features?: never;
+    [key: string]: any;
+};
+
+export type IframeEditorProps = {
+    editorType: "OPENAPI" | "ASYNCAPI";
+    editorName: string;
+    frameId: string;
+    className?: string;
+    extraEditingInfo?: IframeEditorExtraData;
+} & EditorProps;
+
+/**
+ * Shared IFrame-based editor bridge component.
+ * Acts as a React component that bridges to external editors (OpenAPI, AsyncAPI) loaded via an iframe.
+ */
+export const IframeEditor: React.FunctionComponent<IframeEditorProps> = (props: IframeEditorProps) => {
+    const ref = useRef<HTMLIFrameElement>(null);
+    const contentRef = useRef(props.content);
+    const onChangeRef = useRef(props.onChange);
+    contentRef.current = props.content;
+    onChangeRef.current = props.onChange;
+
+    const config = useConfigService();
+
+    let editorsUrl: string = config.uiEditorsUrl();
+    if (editorsUrl.startsWith("/")) {
+        editorsUrl = window.location.origin + editorsUrl;
+    }
+
+    const expectedOrigin = useMemo(() => {
+        return deriveOrigin(editorsUrl, window.location.origin);
+    }, [editorsUrl]);
+
+    useEffect(() => {
+        if (props.editorName === "OpenApiEditor") {
+            console.info("[OpenApiEditor] URL location of editors: ", editorsUrl);
+        }
+    }, [editorsUrl, props.editorName]);
+
+    useEffect(() => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        const eventListener = (event: MessageEvent) => {
+            if (!expectedOrigin || event.origin !== expectedOrigin) {
+                return;
+            }
+            if (event.data && event.data.type === "apicurio_onChange") {
+                let newContent: any = event.data.data.content;
+                const currentContent = contentRef.current;
+                if (typeof newContent === "object") {
+                    if (currentContent.contentType === ContentTypes.APPLICATION_YAML) {
+                        console.info(`[${props.editorName}] New content is 'object', converting to YAML string`);
+                        newContent = toYamlString(newContent);
+                    } else {
+                        console.info(`[${props.editorName}] New content is 'object', converting to JSON string`);
+                        newContent = toJsonString(newContent);
+                    }
+                } else if (typeof newContent === "string" && currentContent.contentType === ContentTypes.APPLICATION_YAML) {
+                    console.info(`[${props.editorName}] Converting from JSON string to YAML string.`);
+                    newContent = toYamlString(parseJson(newContent as string));
+                }
+                onChangeRef.current(newContent);
+            }
+        };
+        window.addEventListener("message", eventListener, false);
+        return () => {
+            window.removeEventListener("message", eventListener, false);
+        };
+    }, [expectedOrigin, props.editorName]);
+
+    const editorAppUrl = (): string => {
+        return editorsUrl;
+    };
+
+    const onEditorLoaded = (): void => {
+        // Now it's OK to post a message to iframe with the content to edit.
+        let value: string;
+        if (typeof props.content.content === "object") {
+            console.info(`[${props.editorName}] Loading editor data from 'object' - converting to JSON string.`);
+            value = toJsonString(props.content.content);
+        } else if (typeof props.content.content === "string" && props.content.contentType === ContentTypes.APPLICATION_YAML) {
+            console.info(`[${props.editorName}] Loading editor data from 'string' - converting from YAML to JSON.`);
+            value = toJsonString(parseYaml(props.content.content as string));
+        } else {
+            console.info(`[${props.editorName}] Loading editor data from 'string' without content conversion.`);
+            value = props.content.content as string;
+        }
+
+        const safeExtra: Record<string, any> = { ...(props.extraEditingInfo || {}) };
+        delete safeExtra.content;
+        delete safeExtra.features;
+
+        const message: any = {
+            type: "apicurio-editingInfo",
+            data: {
+                content: {
+                    type: props.editorType,
+                    value: value
+                },
+                features: {
+                    allowCustomValidations: false,
+                    allowImports: false
+                },
+                ...safeExtra
+            }
+        };
+        if (expectedOrigin && ref.current?.contentWindow) {
+            ref.current.contentWindow.postMessage(message, expectedOrigin);
+        }
+    };
+
+    return (
+        <iframe
+            id={props.frameId}
+            ref={ref}
+            className={props.className}
+            onLoad={onEditorLoaded}
+            src={editorAppUrl()}
+        />
+    );
+};

--- a/ui/ui-app/src/editors/OpenApiEditor.tsx
+++ b/ui/ui-app/src/editors/OpenApiEditor.tsx
@@ -1,130 +1,39 @@
-import React, { RefObject, useEffect, useState, useMemo } from "react";
+import React, { useEffect, useState } from "react";
 import { Editor as DraftEditor, EditorProps } from "./editor-types";
-import "./OpenApiEditor.css";
-import { parseJson, parseYaml, toJsonString, toYamlString } from "@utils/content.utils.ts";
 import { IfNotLoading } from "@apitomy/common-ui-components";
-import { useConfigService } from "@services/useConfigService.ts";
-import { ContentTypes } from "@models/ContentTypes.ts";
-import { deriveOrigin } from "@utils/url.utils.ts";
-
+import { IframeEditor } from "./IframeEditor";
+import "./OpenApiEditor.css";
 
 export type OpenApiEditorProps = {
     className?: string;
 } & EditorProps;
 
-
 /**
- * OpenAPI editor.  The actual editor logic is written in Angular as a separate application
- * and loaded via an iframe.  This component is a bridge - it acts as a React component that
+ * OpenAPI editor. The actual editor logic is written in Angular as a separate application
+ * and loaded via an iframe. This component is a bridge - it acts as a React component that
  * bridges to the iframe.
  */
 export const OpenApiEditor: DraftEditor = (props: OpenApiEditorProps) => {
-    // const [openApiVendorExtensions, setOpenApiVendorExtensions] = useState<VendorExtension[]>([]);
     const [isLoading, setIsLoading] = useState(true);
-
-    const config = useConfigService();
-    // const systemSvc: SystemService = useSystemService();
-
-    let editorsUrl: string = config.uiEditorsUrl();
-    if (editorsUrl.startsWith("/")) {
-        editorsUrl = window.location.origin + editorsUrl;
-    }
-    const ref: RefObject<any> = React.createRef();
-
-    const expectedOrigin = useMemo(() => {
-        return deriveOrigin(editorsUrl, window.location.origin);
-    }, [editorsUrl]);
 
     useEffect(() => {
         setIsLoading(false);
-        // systemSvc.getOpenApiVendorExtensions().then(extensions => {
-        //     setOpenApiVendorExtensions(extensions);
-        //     setIsLoading(false);
-        // }).catch(error => {
-        //     console.error("Error loading OpenAPI vendor extensions", error);
-        //     setOpenApiVendorExtensions([]);
-        //     setIsLoading(false);
-        // });
     }, []);
-
-    useEffect(() => {
-        console.info("[OpenApiEditor] URL location of editors: ", editorsUrl);
-
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        const eventListener = (event: MessageEvent) => {
-            if (!expectedOrigin || event.origin !== expectedOrigin) {
-                return;
-            }
-            if (event.data && event.data.type === "apicurio_onChange") {
-                let newContent: any = event.data.data.content;
-                if (typeof newContent === "object") {
-                    if (props.content.contentType === ContentTypes.APPLICATION_YAML) {
-                        console.info("[OpenApiEditor] New content is 'object', converting to YAML string");
-                        newContent = toYamlString(newContent);
-                    } else {
-                        console.info("[OpenApiEditor] New content is 'object', converting to JSON string");
-                        newContent = toJsonString(newContent);
-                    }
-                } else if (typeof newContent === "string" && props.content.contentType === ContentTypes.APPLICATION_YAML) {
-                    console.info("[OpenApiEditor] Converting from JSON string to YAML string.");
-                    newContent = toYamlString(parseJson(newContent as string));
-                }
-                props.onChange(newContent);
-            }
-        };
-        window.addEventListener("message", eventListener, false);
-        return () => {
-            window.removeEventListener("message", eventListener, false);
-        };
-    });
-
-    const editorAppUrl = (): string => {
-        return editorsUrl;
-    };
-
-    const onEditorLoaded = (): void => {
-        // Now it's OK to post a message to iframe with the content to edit.
-        let value: string;
-        if (typeof props.content.content === "object") {
-            console.info("[OpenApiEditor] Loading editor data from 'object' - converting to JSON string.");
-            value = toJsonString(props.content.content);
-        } else if (typeof props.content.content === "string" && props.content.contentType === ContentTypes.APPLICATION_YAML) {
-            console.info("[OpenApiEditor] Loading editor data from 'string' - converting from YAML to JSON.");
-            value = toJsonString(parseYaml(props.content.content as string));
-        } else {
-            console.info("[OpenApiEditor] Loading editor data from 'string' without content conversion.");
-            value = props.content.content as string;
-        }
-        const message: any = {
-            type: "apicurio-editingInfo",
-            // tslint:disable-next-line:object-literal-sort-keys
-            data: {
-                content: {
-                    type: "OPENAPI",
-                    value: value
-                },
-                features: {
-                    allowCustomValidations: false,
-                    allowImports: false
-                },
-                openapi: {
-                    vendorExtensions: []
-                }
-            }
-        };
-        if (expectedOrigin) {
-            ref.current.contentWindow.postMessage(message, expectedOrigin);
-        }
-    };
 
     return (
         <IfNotLoading isLoading={isLoading}>
-            <iframe id="openapi-editor-frame"
-                ref={ref}
+            <IframeEditor
+                editorType="OPENAPI"
+                editorName="OpenApiEditor"
+                frameId="openapi-editor-frame"
                 className={props.className ? props.className : "editor-openapi-flex-container"}
-                onLoad={onEditorLoaded}
-                src={editorAppUrl()}/>
+                extraEditingInfo={{
+                    openapi: {
+                        vendorExtensions: []
+                    }
+                }}
+                {...props}
+            />
         </IfNotLoading>
     );
 };


### PR DESCRIPTION
Fixes #9107

This PR refactors the OpenAPI and AsyncAPI iframe editors to remove duplicated functionality and provide a shared implementation for their common behavior.

Previously, `OpenApiEditor.tsx` and `AsyncApiEditor.tsx` contained largely duplicated logic for iframe communication, editor URL/origin handling, message processing, content conversion, and iframe lifecycle management. This made the two implementations harder to maintain consistently.

### Changes Made

- Added a shared `IframeEditor.tsx` component that encapsulates the common iframe editor functionality.
- Moved shared logic for:
  - iframe URL resolution and origin validation
  - `postMessage` event handling
  - JSON ↔ YAML content conversion
  - `apicurio-editingInfo` payload handling
  - iframe references and `onLoad` lifecycle management
- Refactored `OpenApiEditor.tsx` and `AsyncApiEditor.tsx` to use the shared component while retaining their editor-specific configuration.
- Preserved the existing component names, prop interfaces, frame IDs and CSS classes to minimize changes for existing consumers.
- Exported `IframeEditor` through the editors index.

### Result

The refactoring removes approximately 200 lines of duplicated implementation while keeping the OpenAPI and AsyncAPI editors focused on their editor-specific configuration.

The shared implementation also provides a single place to maintain iframe communication and security-related behavior, reducing the chance of the two editors diverging in the future.

### Verification

The changes were verified with the existing project checks:

- `npm run build` — passed with 0 errors
- `npm run lint` — passed with 0 errors
- `npm test` — passed: 15 test suites, 127 tests

No existing unit tests were broken by the refactoring.