### PR TITLE
fix: publish multi-arch OLM bundle and catalog images

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -398,13 +398,13 @@ jobs:
         working-directory: operator
         run: |
           unset IMAGE REGISTRY_APP_IMAGE REGISTRY_GITOPS_SYNC_IMAGE BUNDLE_IMAGE CATALOG_IMAGE
-          make bundle
+          make bundle-buildx
 
       - name: Build and publish operator catalog
         working-directory: operator
         run: |
           unset IMAGE REGISTRY_APP_IMAGE REGISTRY_GITOPS_SYNC_IMAGE BUNDLE_IMAGE CATALOG_IMAGE
-          make catalog
+          make catalog-buildx
 
   # Slack notification using reusable workflow
   notify-slack:

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -130,7 +130,7 @@ jobs:
           if [ "$BRANCH" = "main" ]; then
             ROLLING_CHANNEL_ARG="ROLLING_CHANNEL=3.x"
           fi
-          make OPERAND_IMAGE_TAG=$RELEASE_VERSION $ROLLING_CHANNEL_ARG bundle
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION $ROLLING_CHANNEL_ARG bundle-buildx
 
       - name: Build operator catalog
         working-directory: registry/operator
@@ -139,7 +139,7 @@ jobs:
           if [ "$BRANCH" = "main" ]; then
             ROLLING_CHANNEL_ARG="ROLLING_CHANNEL=3.x"
           fi
-          make OPERAND_IMAGE_TAG=$RELEASE_VERSION ADDITIONAL_CATALOG_IMAGE_TAG=latest $ROLLING_CHANNEL_ARG catalog
+          make OPERAND_IMAGE_TAG=$RELEASE_VERSION ADDITIONAL_CATALOG_IMAGE_TAG=latest $ROLLING_CHANNEL_ARG catalog-buildx
 
       - name: Generate install file for tests
         working-directory: registry/operator

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -415,8 +415,21 @@ endif
 endif
 
 
+.PHONY: bundle-image-buildx-push
+bundle-image-buildx-push: ## Build and push a multi-arch OLM bundle image
+	docker buildx build --push -f $(BUNDLE_DIR)/bundle.Dockerfile \
+		--platform $(IMAGE_PLATFORMS) \
+		-t $(BUNDLE_IMAGE) \
+		$(if $(and $(ADDITIONAL_BUNDLE_IMAGE),$(ADDITIONAL_BUNDLE_TAG)),-t $(ADDITIONAL_BUNDLE_IMAGE),) \
+		.
+
+
 .PHONY: bundle
 bundle: bundle-build bundle-image-build bundle-image-push ## TODO
+
+
+.PHONY: bundle-buildx
+bundle-buildx: bundle-build bundle-image-buildx-push ## Generate the OLM bundle and push it as a multi-arch image
 
 
 .PHONY: catalog-build
@@ -452,8 +465,21 @@ endif
 endif
 
 
+.PHONY: catalog-image-buildx-push
+catalog-image-buildx-push: ## Build and push a multi-arch OLM catalog image
+	docker buildx build --push -f $(CATALOG_TARGET_DIR)/configs.Dockerfile \
+		--platform $(IMAGE_PLATFORMS) \
+		-t $(CATALOG_IMAGE) \
+		$(if $(and $(ADDITIONAL_CATALOG_IMAGE),$(ADDITIONAL_CATALOG_IMAGE_TAG)),-t $(ADDITIONAL_CATALOG_IMAGE),) \
+		$(CATALOG_TARGET_DIR)
+
+
 .PHONY: catalog
 catalog: catalog-build catalog-image-build catalog-image-push ## TODO
+
+
+.PHONY: catalog-buildx
+catalog-buildx: catalog-build catalog-image-buildx-push ## Build the OLM catalog and push it as a multi-arch image
 
 
 .PHONY: catalog-deploy

--- a/operator/README.md
+++ b/operator/README.md
@@ -135,6 +135,15 @@ make image-push
 
 *Options are the same as `image-build`.*
 
+Alternatively, to build and push a multi-arch image in one step (this is what CI uses when publishing), run:
+
+```shell
+make image-buildx-push
+```
+
+*Options are the same as `image-build`, plus `IMAGE_PLATFORMS` (default:
+`linux/amd64,linux/arm64,linux/s390x,linux/ppc64le`). Requires a Docker Buildx builder with QEMU emulation.*
+
 You can now deploy the operator to your current cluster (as configured by `kubectl`):
 
 ```shell
@@ -394,11 +403,16 @@ make bundle-image-push
 
 *Options are the same as `bundle-image-build`.*
 
+Alternatively, run `make bundle-image-buildx-push` (or `make bundle-buildx` to also generate the bundle files) to
+build and push a multi-arch bundle image. This is what CI uses when publishing. Options are the same as
+`bundle-image-build`, plus `IMAGE_PLATFORMS`.
+
 ### Operator Catalog
 
 After you have built and pushed the bundle image, you can build a catalog to use with OLM:
 
-*NOTE: We do not currently release our own upstream catalog image, we only build one for testing.*
+*NOTE: The catalog image is published to quay.io by CI alongside the operator and bundle images, and is used for
+testing. Most users install the operator from the community catalogs (OperatorHub) instead.*
 
 ```shell
 make catalog-build
@@ -417,7 +431,7 @@ Available options:
 | IMAGE_REGISTRY         | string | `quay.io/apicurio`                                                  | -                                     |
 | CATALOG_IMAGE_NAME     | string | `apicurio-registry-3-operator-catalog`                              | -                                     |
 | CATALOG_IMAGE_TAG      | string | *(current version, lowercase)*                                      | -                                     |
-| ADDITIONAL_CATALOG_TAG | string | `latest` *(with version suffix, lowercase, e.g. `latest-snapshot`)* | Tag the image with an additional tag. |
+| ADDITIONAL_CATALOG_IMAGE_TAG | string | - | Tag the image with an additional tag (e.g. `latest`). |
 
 After the catalog image is built, push it by running:
 
@@ -426,6 +440,10 @@ make catalog-image-push
 ```
 
 *Options are the same as `catalog-image-build`.*
+
+Alternatively, run `make catalog-image-buildx-push` (or `make catalog-buildx` to also render the catalog) to build
+and push a multi-arch catalog image. This is what CI uses when publishing. Options are the same as
+`catalog-image-build`, plus `IMAGE_PLATFORMS`.
 
 ### OLM On-cluster Quickstart
 


### PR DESCRIPTION
## Description

Publish the OLM bundle and catalog images as multi-arch manifests
(linux/amd64, linux/arm64, linux/s390x, linux/ppc64le), matching the
operator, app, and UI images.

 - the operator image multi-arch, but the catalog image is still
amd64-only on every quay.io tag. 
- The catalog runs `opm serve` as the
CatalogSource pod, so OLM installs/upgrades on ARM clusters (Graviton,
Apple Silicon minikube) fail with `exec format error` before the operator
image is even pulled. The bundle image is made multi-arch for consistency.

The `opm` base image already supports all four platforms; bundle images
are data-only (`FROM scratch`).

## Testing

Ran the new make targets end-to-end against a local registry: all images
pushed as 4-arch OCI indexes (primary + additional tags), arm64 sub-images
verified to contain arm64 binaries, and the arm64 catalog image runs
`opm serve` natively. Bundle passes `operator-sdk bundle validate`.

Note: already-published tags (e.g. operator `3.2.4`) remain amd64-only
unless re-released; the current upgrade-test baseline (3.3.1) is already
multi-arch.

## Issue
fixes #8278 