### PR TITLE
fix(operator): dynamic catalog discovery for OLM upgrade tests

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -582,6 +582,8 @@
             <project.build.directory>${project.build.directory}</project.build.directory>
             <!-- Prevent OTel SPI conflict between Quarkus ContextStorageProvider and SDK testing -->
             <io.opentelemetry.context.contextStorageProvider>default</io.opentelemetry.context.contextStorageProvider>
+            <!-- Avro 1.12.2 rejects classes not on the trusted list during reflection-based serde -->
+            <org.apache.avro.SERIALIZABLE_PACKAGES>ch.mobi.lead.leadfall,com.kubetrade.schema.trade,io.apicurio.registry.support</org.apache.avro.SERIALIZABLE_PACKAGES>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/app/src/test/resources/io/apicurio/registry/serde/AvroSchemaB.avsc
+++ b/app/src/test/resources/io/apicurio/registry/serde/AvroSchemaB.avsc
@@ -28,20 +28,14 @@
       "name": "mapTest",
       "type": {
         "type": "map",
-        "values": {
-          "name": "schemaFMapValue",
-          "type": "com.kubetrade.schema.trade.AvroSchemaF"
-        }
+        "values": "com.kubetrade.schema.trade.AvroSchemaF"
       }
     },
     {
       "name": "arrayTest",
       "type": {
         "type": "array",
-        "items": {
-          "name": "schemaFArrayValue",
-          "type": "com.kubetrade.schema.trade.AvroSchemaF"
-        }
+        "items": "com.kubetrade.schema.trade.AvroSchemaF"
       }
     },
     {

--- a/app/src/test/resources/io/apicurio/registry/serde/LeadFallErstellen.avsc
+++ b/app/src/test/resources/io/apicurio/registry/serde/LeadFallErstellen.avsc
@@ -59,7 +59,7 @@
             "fields": [
               {
                 "name": "aufgabeTyp",
-                "type": "FdtCodeArt"
+                "type": "ch.mobi.lead.leadfall.FdtCodeArt"
               }
             ]
           }

--- a/operator/controller/src/main/resources/application.properties
+++ b/operator/controller/src/main/resources/application.properties
@@ -35,6 +35,8 @@ quarkus.operator-sdk.start-operator=false
 
 %dev.quarkus.kubernetes-client.trust-certs=true
 %test.quarkus.kubernetes-client.trust-certs=true
+%test.quarkus.kubernetes-client.request-timeout=30000
+%test.quarkus.kubernetes-client.connection-timeout=30000
 
 # Vertx
 

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
@@ -158,6 +158,10 @@ public abstract class ITBase implements OperatorTestContext {
                 namespace,
                 ((operatorDeployment == OperatorDeployment.remote) ? "remote" : "local"),
                 deploymentTarget);
+        await().atMost(MEDIUM_DURATION).untilAsserted(() -> {
+            assertThat(client.resources(ApicurioRegistry3.class).inNamespace(namespace)
+                    .list().getItems()).isEmpty();
+        });
     }
 
     protected void startOperatorPodLog() {

--- a/operator/olm-tests/README.md
+++ b/operator/olm-tests/README.md
@@ -72,5 +72,82 @@ checked without a cluster; the live OLM v1 smoke run is the end-to-end backstop,
 - **`NamespacedPermissionsOLMITTest`** and **`AllNamespacesOLMITTest`** assert the v0 least-privilege
   boundary directly with `SubjectAccessReview`s, and are disabled under v1: they rely on `OperatorGroup`
   install modes and the SingleNamespace boundary, neither of which v1 exposes today.
-- **`ChannelValidationOLMITTest`** and **`UpgradeOLMITTest`** install released bundles from the catalog
-  to exercise channel and upgrade behavior.
+- **`ChannelValidationOLMITTest`** validates channel metadata (names, heads, default channel) against
+  the live catalog.
+- **`UpgradeOLMITTest`** installs an older version from the catalog and verifies OLM upgrades it to the
+  current version. It discovers available versions from the live `PackageManifest` at runtime rather than
+  hardcoding version strings, so it works with both upstream catalogs (built from `catalog.template.yaml`)
+  and downstream IIB images (where CSV names have productized suffixes like `-r1`).
+
+## OLM upgrade test scenarios
+
+The upgrade tests exercise OLM's version resolution across channels. Which tests are applicable depends
+on which channels the current version appears in, which in turn depends on the release branch.
+
+### Channel model
+
+- **Rolling channel (`3.x`):** receives every new minor release from `main`. Contains the full version
+  history across minors (3.0.x → 3.1.x → 3.2.x → 3.3.x → ...).
+- **Minor channels (`3.2.x`, `3.3.x`, ...):** receive only patch releases for that minor. A version
+  released from a maintenance branch (e.g., 3.2.7 from the `3.2.x` branch) goes into `3.2.x` only, not
+  into `3.x`.
+
+### Release from `main` (e.g., 3.3.1)
+
+The version goes into both `3.x` (rolling) and `3.3.x` (minor). All upgrade tests are applicable:
+
+| Test | Channel | Start → Target | What it verifies |
+|------|---------|----------------|------------------|
+| Upgrade within minor | `3.3.x` | 3.3.0 → 3.3.1 | Patch upgrade within the current minor channel |
+| Upgrade across minors | `3.x` | previous minor → 3.3.1 | Cross-minor upgrade via the rolling channel |
+| Channel switch rolling→minor | `3.x` → `3.3.x` | 3.3.0 → 3.3.1 | Install on rolling, switch to minor |
+| Minor channel isolation | `3.3.x` | 3.3.0 → 3.3.1 | Verify no leak to a different minor |
+| Fresh install on minor | `3.3.x` | (none) → 3.3.1 | Fresh install gets the channel head |
+| Manual approval upgrade | `3.3.x` | 3.3.0 → 3.3.1 | Upgrade with manual install plan approval |
+| Downgrade rejected | `3.x` → older minor | 3.3.1 stays | Channel switch doesn't downgrade |
+| Channel switch noop | `3.x` → `3.3.x` | 3.3.1 stays | Switch at head is a no-op |
+
+### First release of a new minor from `main` (e.g., 3.4.0)
+
+The version goes into `3.x` and `3.4.x`. The minor channel has only one entry, so within-minor upgrade
+tests are not applicable:
+
+| Test | Applicable? | Reason |
+|------|-------------|--------|
+| Upgrade within minor | No | `3.4.x` has only one entry (3.4.0) |
+| Upgrade across minors | Yes | `3.x` has entries from previous minors |
+| Channel switch rolling→minor | Yes | Version is in both channels |
+| Minor channel isolation | No | Nothing to upgrade from in `3.4.x` |
+| Fresh install on minor | Yes | Always applicable |
+| Manual approval upgrade | No | `3.4.x` has only one entry |
+| Downgrade rejected | Yes | Version is in `3.x` |
+| Channel switch noop | Yes | Version is in both channels |
+
+### Release from a maintenance branch (e.g., 3.2.7 from `3.2.x`)
+
+The version goes into `3.2.x` only, not `3.x`. Tests involving the rolling channel are not applicable:
+
+| Test | Applicable? | Reason |
+|------|-------------|--------|
+| Upgrade within minor | Yes | `3.2.x` has previous entries |
+| Upgrade across minors | No | Version is not in `3.x` |
+| Channel switch rolling→minor | No | Version is not in `3.x` |
+| Minor channel isolation | Yes | Verify no leak beyond `3.2.x` |
+| Fresh install on minor | Yes | Always applicable |
+| Manual approval upgrade | Yes | `3.2.x` has previous entries |
+| Downgrade rejected | No | Version is not in `3.x` |
+| Channel switch noop | No | Version is not in `3.x` |
+
+### How tests determine applicability
+
+Tests query the live `PackageManifest` (OLM v0) or catalog pod (OLM v1) after the `CatalogSource` is
+created. The discovery result is cached for the duration of the test run. Each test checks its
+preconditions and logs the reason when skipping:
+
+- **Is the current version in `3.x`?** Check if `3.x` channel entries contain a CSV matching the current
+  package version.
+- **Does the minor channel have ≥2 entries?** Required for any within-minor upgrade test.
+- **Does `3.x` have entries from a different minor?** Required for cross-minor upgrade tests.
+
+This approach works for both upstream catalogs and downstream IIB images, since it reads the actual
+catalog content rather than assuming a specific structure.

--- a/operator/olm-tests/pom.xml
+++ b/operator/olm-tests/pom.xml
@@ -67,6 +67,18 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.semver4j</groupId>
+      <artifactId>semver4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogDiscovery.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogDiscovery.java
@@ -1,0 +1,137 @@
+package io.apicurio.registry.operator.it;
+
+import io.apicurio.registry.operator.it.CatalogInfo.ChannelEntry;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import lombok.Getter;
+import org.semver4j.Semver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+import static io.apicurio.registry.operator.it.CatalogInfo.coerceVersion;
+import static io.apicurio.registry.operator.it.CatalogInfo.extractVersionString;
+import static io.apicurio.registry.operator.it.OLMTestUtils.*;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Queries the live OLM catalog (via PackageManifest) to discover channels, CSV names, and upgrade paths.
+ * Results are cached so the catalog is queried only once per test run.
+ * <p>
+ * This replaces hardcoded version strings and template file reads, making upgrade tests work with both
+ * upstream catalogs (built from catalog.template.yaml) and downstream IIB images (where CSV names have
+ * productized suffixes like -r1).
+ */
+public class CatalogDiscovery {
+
+    private static final Logger log = LoggerFactory.getLogger(CatalogDiscovery.class);
+
+    private static CatalogDiscovery instance;
+
+    @Getter
+    private CatalogInfo catalogInfo;
+
+    private CatalogDiscovery(CatalogInfo catalogInfo) {
+        this.catalogInfo = catalogInfo;
+    }
+
+    /**
+     * Returns the singleton instance, performing discovery on first call. Discovery creates a temporary
+     * namespace, deploys a CatalogSource, waits for the PackageManifest, extracts channel data, and
+     * cleans up.
+     */
+    public static synchronized CatalogDiscovery getInstance(KubernetesClient client) throws Exception {
+        if (instance != null) {
+            log.info("Using cached catalog discovery results");
+            return instance;
+        }
+
+        var namespace = "catalog-discovery-" + UUID.randomUUID().toString().substring(0, 8);
+        log.info("Starting catalog discovery in temporary namespace {}", namespace);
+
+        try {
+            ITBase.createNamespace(client, namespace);
+
+            createResource(client, namespace, "olmv0/catalog-source.yaml");
+            waitForCatalogPodReady(client, namespace);
+
+            var info = queryPackageManifest(client, namespace);
+            instance = new CatalogDiscovery(info);
+
+            log.info("Catalog discovery complete:");
+            log.info("  Default channel: {}", info.getDefaultChannel());
+            for (var entry : info.getChannels().entrySet()) {
+                var entries = entry.getValue();
+                log.info("  Channel {}: {} entries, head={}",
+                        entry.getKey(), entries.size(),
+                        entries.isEmpty() ? "(empty)" : entries.get(0).getCsvName());
+            }
+
+            return instance;
+        } finally {
+            try {
+                deleteResourceQuietly(client, namespace, "olmv0/catalog-source.yaml");
+                client.namespaces().withName(namespace).delete();
+            } catch (Exception e) {
+                log.warn("Cleanup of discovery namespace {} failed: {}", namespace, e.getMessage());
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static CatalogInfo queryPackageManifest(KubernetesClient client, String namespace) {
+        var pm = new GenericKubernetesResource[1];
+        await().ignoreExceptions().untilAsserted(() -> {
+            pm[0] = getPackageManifest(client, namespace);
+            if (pm[0] == null) {
+                throw new IllegalStateException("PackageManifest not yet available");
+            }
+        });
+
+        var channels = new LinkedHashMap<String, List<ChannelEntry>>();
+        var rawChannels = (Collection<Map<String, Object>>) pm[0].get("status", "channels");
+        for (var ch : rawChannels) {
+            var name = (String) ch.get("name");
+            var currentCSV = (String) ch.get("currentCSV");
+
+            var entries = new ArrayList<ChannelEntry>();
+            var rawEntries = (Collection<Map<String, Object>>) ch.get("entries");
+            if (rawEntries != null && !rawEntries.isEmpty()) {
+                for (var re : rawEntries) {
+                    var csvName = (String) re.get("name");
+                    var versionStr = (String) re.get("version");
+                    Semver version;
+                    if (versionStr != null) {
+                        version = coerceVersion(versionStr);
+                    } else {
+                        version = coerceVersion(extractVersionString(csvName));
+                    }
+                    entries.add(new ChannelEntry(csvName, version));
+                }
+
+                if (!entries.get(0).getCsvName().equals(currentCSV)) {
+                    log.warn("Channel {} entries are not head-first: first entry is {} but "
+                                    + "currentCSV is {}. Reordering.", name,
+                            entries.get(0).getCsvName(), currentCSV);
+                    entries.sort((a, b) -> {
+                        if (a.getCsvName().equals(currentCSV)) return -1;
+                        if (b.getCsvName().equals(currentCSV)) return 1;
+                        return b.getVersion().compareTo(a.getVersion());
+                    });
+                }
+            } else {
+                var version = coerceVersion(extractVersionString(currentCSV));
+                entries.add(new ChannelEntry(currentCSV, version));
+                log.warn("Channel {} has no entries in PackageManifest, using head only: {}",
+                        name, currentCSV);
+            }
+
+            channels.put(name, entries);
+        }
+
+        var defaultChannel = (String) pm[0].get("status", "defaultChannel");
+
+        return new CatalogInfo(channels, defaultChannel);
+    }
+}

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogDiscovery.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogDiscovery.java
@@ -4,14 +4,13 @@ import io.apicurio.registry.operator.it.CatalogInfo.ChannelEntry;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import lombok.Getter;
-import org.semver4j.Semver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
-import static io.apicurio.registry.operator.it.CatalogInfo.coerceVersion;
 import static io.apicurio.registry.operator.it.CatalogInfo.extractVersionString;
+import static io.apicurio.registry.operator.it.CatalogInfo.parseVersion;
 import static io.apicurio.registry.operator.it.OLMTestUtils.*;
 import static org.awaitility.Awaitility.await;
 
@@ -101,13 +100,8 @@ public class CatalogDiscovery {
                 for (var re : rawEntries) {
                     var csvName = (String) re.get("name");
                     var versionStr = (String) re.get("version");
-                    Semver version;
-                    if (versionStr != null) {
-                        version = coerceVersion(versionStr);
-                    } else {
-                        version = coerceVersion(extractVersionString(csvName));
-                    }
-                    entries.add(new ChannelEntry(csvName, version));
+                    var versionRaw = versionStr != null ? versionStr : extractVersionString(csvName);
+                    entries.add(new ChannelEntry(csvName, parseVersion(versionRaw)));
                 }
 
                 if (!entries.get(0).getCsvName().equals(currentCSV)) {
@@ -121,8 +115,8 @@ public class CatalogDiscovery {
                     });
                 }
             } else {
-                var version = coerceVersion(extractVersionString(currentCSV));
-                entries.add(new ChannelEntry(currentCSV, version));
+                entries.add(new ChannelEntry(currentCSV,
+                        parseVersion(extractVersionString(currentCSV))));
                 log.warn("Channel {} has no entries in PackageManifest, using head only: {}",
                         name, currentCSV);
             }

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogInfo.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogInfo.java
@@ -1,0 +1,154 @@
+package io.apicurio.registry.operator.it;
+
+import lombok.Getter;
+import org.semver4j.Semver;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.apicurio.registry.operator.it.OLMTestUtils.PACKAGE_NAME;
+
+/**
+ * Holds discovered catalog metadata from the live PackageManifest. Provides query methods to determine
+ * channel heads, previous versions for upgrade testing, and whether the current version is in a channel.
+ */
+@Getter
+public class CatalogInfo {
+
+    private final Map<String, List<ChannelEntry>> channels;
+    private final String defaultChannel;
+
+    CatalogInfo(Map<String, List<ChannelEntry>> channels, String defaultChannel) {
+        this.channels = channels;
+        this.defaultChannel = defaultChannel;
+    }
+
+    @Getter
+    public static class ChannelEntry {
+
+        private final String csvName;
+        private final Semver version;
+
+        ChannelEntry(String csvName, Semver version) {
+            this.csvName = csvName;
+            this.version = version;
+        }
+    }
+
+    public boolean hasChannel(String channelName) {
+        return channels.containsKey(channelName);
+    }
+
+    /**
+     * Returns the channel head CSV name, or null if the channel doesn't exist.
+     */
+    public String getChannelHeadCSV(String channelName) {
+        var head = getChannelHead(channelName);
+        return head != null ? head.getCsvName() : null;
+    }
+
+    /**
+     * Returns the version of the channel head.
+     */
+    public Semver getChannelHeadVersion(String channelName) {
+        var head = getChannelHead(channelName);
+        return head != null ? head.getVersion() : null;
+    }
+
+    /**
+     * Returns the head entry, or null if the channel doesn't exist or is empty.
+     */
+    public ChannelEntry getChannelHead(String channelName) {
+        var entries = channels.get(channelName);
+        return (entries != null && !entries.isEmpty()) ? entries.get(0) : null;
+    }
+
+    /**
+     * Returns a suitable "previous" entry for upgrade testing — the second entry in the channel
+     * (i.e., the one immediately before the head). Returns null if the channel has fewer than 2 entries.
+     */
+    public ChannelEntry getPreviousEntry(String channelName) {
+        var entries = channels.get(channelName);
+        if (entries == null || entries.size() < 2) {
+            return null;
+        }
+        return entries.get(1);
+    }
+
+    /**
+     * Returns a previous entry from a different minor version than the channel head, for cross-minor
+     * upgrade testing. Returns null if no such entry exists.
+     */
+    public ChannelEntry getCrossMinorEntry(String channelName) {
+        var entries = channels.get(channelName);
+        if (entries == null || entries.size() < 2) {
+            return null;
+        }
+        var headMinor = getChannelHeadVersion(channelName).getMinor();
+        for (int i = 1; i < entries.size(); i++) {
+            if (entries.get(i).getVersion().getMinor() != headMinor) {
+                return entries.get(i);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds the channel with the highest minor version that is strictly less than the current version's
+     * minor, excluding the rolling channel. Returns null if no such channel exists.
+     */
+    public String getOlderMinorChannel(String currentVersion, String rollingChannel) {
+        var currentMinor = coerceVersion(currentVersion).getMinor();
+        String best = null;
+        int bestMinor = -1;
+        for (var ch : channels.keySet()) {
+            if (ch.equals(rollingChannel)) {
+                continue;
+            }
+            var head = getChannelHeadVersion(ch);
+            if (head != null && head.getMinor() < currentMinor && head.getMinor() > bestMinor) {
+                bestMinor = head.getMinor();
+                best = ch;
+            }
+        }
+        return best;
+    }
+
+    /**
+     * Checks if the given version is the head of the given channel. Uses semver comparison
+     * on major.minor.patch, tolerating downstream pre-release suffixes.
+     */
+    public boolean isVersionChannelHead(String channelName, String version) {
+        var headVersion = getChannelHeadVersion(channelName);
+        if (headVersion == null) {
+            return false;
+        }
+        var target = coerceVersion(version);
+        return headVersion.getMajor() == target.getMajor()
+                && headVersion.getMinor() == target.getMinor()
+                && headVersion.getPatch() == target.getPatch();
+    }
+
+    /**
+     * Extracts the version string from a CSV name by stripping the package prefix.
+     * E.g., "apicurio-registry-3.v3.2.4-r1" -> "3.2.4-r1"
+     */
+    public static String extractVersionString(String csvName) {
+        var prefix = PACKAGE_NAME + ".v";
+        if (csvName != null && csvName.startsWith(prefix)) {
+            return csvName.substring(prefix.length());
+        }
+        return csvName;
+    }
+
+    /**
+     * Coerces a version string into a Semver, tolerating downstream suffixes.
+     */
+    static Semver coerceVersion(String version) {
+        var semver = Semver.coerce(version);
+        if (semver == null) {
+            throw new IllegalArgumentException("Cannot parse version: " + version);
+        }
+        return semver;
+    }
+}

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogInfo.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogInfo.java
@@ -84,7 +84,7 @@ public class CatalogInfo {
         if (entries == null || entries.size() < 2) {
             return null;
         }
-        var headMinor = getChannelHeadVersion(channelName).getMinor();
+        var headMinor = getChannelHead(channelName).getVersion().getMinor();
         for (int i = 1; i < entries.size(); i++) {
             if (entries.get(i).getVersion().getMinor() != headMinor) {
                 return entries.get(i);
@@ -98,16 +98,17 @@ public class CatalogInfo {
      * minor, excluding the rolling channel. Returns null if no such channel exists.
      */
     public String getOlderMinorChannel(String currentVersion, String rollingChannel) {
-        var currentMinor = coerceVersion(currentVersion).getMinor();
+        var currentMinor = parseVersion(currentVersion).getMinor();
         String best = null;
         int bestMinor = -1;
         for (var ch : channels.keySet()) {
             if (ch.equals(rollingChannel)) {
                 continue;
             }
-            var head = getChannelHeadVersion(ch);
-            if (head != null && head.getMinor() < currentMinor && head.getMinor() > bestMinor) {
-                bestMinor = head.getMinor();
+            var head = getChannelHead(ch);
+            if (head != null && head.getVersion().getMinor() < currentMinor
+                    && head.getVersion().getMinor() > bestMinor) {
+                bestMinor = head.getVersion().getMinor();
                 best = ch;
             }
         }
@@ -116,17 +117,17 @@ public class CatalogInfo {
 
     /**
      * Checks if the given version is the head of the given channel. Uses semver comparison
-     * on major.minor.patch, tolerating downstream pre-release suffixes.
+     * on major.minor.patch, tolerating pre-release suffix differences.
      */
     public boolean isVersionChannelHead(String channelName, String version) {
-        var headVersion = getChannelHeadVersion(channelName);
-        if (headVersion == null) {
+        var head = getChannelHead(channelName);
+        if (head == null) {
             return false;
         }
-        var target = coerceVersion(version);
-        return headVersion.getMajor() == target.getMajor()
-                && headVersion.getMinor() == target.getMinor()
-                && headVersion.getPatch() == target.getPatch();
+        var target = parseVersion(version);
+        return head.getVersion().getMajor() == target.getMajor()
+                && head.getVersion().getMinor() == target.getMinor()
+                && head.getVersion().getPatch() == target.getPatch();
     }
 
     /**
@@ -142,12 +143,14 @@ public class CatalogInfo {
     }
 
     /**
-     * Coerces a version string into a Semver, tolerating downstream suffixes.
+     * Parses a version string as strict semver. Fails fast if the version is not valid semver,
+     * since OLM also requires semver-compliant CSV versions.
      */
-    static Semver coerceVersion(String version) {
-        var semver = Semver.coerce(version);
+    static Semver parseVersion(String version) {
+        var semver = Semver.parse(version);
         if (semver == null) {
-            throw new IllegalArgumentException("Cannot parse version: " + version);
+            throw new IllegalArgumentException(
+                    "'" + version + "' is not a valid semver. OLM requires semver-compliant versions.");
         }
         return semver;
     }

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMITTest.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMITTest.java
@@ -8,8 +8,11 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkus.test.junit.QuarkusTest;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.semver4j.Semver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,9 +27,11 @@ import static org.awaitility.Awaitility.await;
 
 /**
  * Tests OLM upgrade paths using OLM v0 (Subscription model).
- *
- * Uses the second-to-last version in the catalog as the starting point, then verifies OLM upgrades to the
- * current version through both the minor-version channel and the rolling channel.
+ * <p>
+ * Discovers available versions from the live catalog's PackageManifest at runtime, so these tests
+ * work with both upstream catalogs (built from catalog.template.yaml) and downstream IIB images
+ * (where CSV names have productized suffixes). See the olm-tests README for which tests apply
+ * in each release scenario.
  */
 @QuarkusTest
 @Tag(OLM)
@@ -35,11 +40,10 @@ public class UpgradeOLMITTest implements OperatorTestContext {
 
     private static final Logger log = LoggerFactory.getLogger(UpgradeOLMITTest.class);
 
-    private static final String UPGRADE_START_VERSION_PROP = "test.operator.upgrade-start-version";
-    // Must be present in both 3.x and 3.2.x channels in catalog.template.yaml
-    private static final String UPGRADE_START_VERSION_DEFAULT = "3.2.4";
     private static final Duration UPGRADE_TIMEOUT = Duration.ofSeconds(
             Integer.getInteger("test.operator.timeout.olm-upgrade", 900));
+
+    private static CatalogInfo catalog;
 
     private KubernetesClient client;
     private String namespace;
@@ -60,46 +64,27 @@ public class UpgradeOLMITTest implements OperatorTestContext {
         return true;
     }
 
-    private String getStartVersion() {
-        return ConfigProvider.getConfig()
-                .getOptionalValue(UPGRADE_START_VERSION_PROP, String.class)
-                .orElse(UPGRADE_START_VERSION_DEFAULT);
+    @BeforeAll
+    static void discoverCatalog() throws Exception {
+        setDefaultAwaitilityTimings();
+        var discoveryClient = ITBase.createK8sClient("default");
+        try {
+            catalog = CatalogDiscovery.getInstance(discoveryClient).getCatalogInfo();
+        } finally {
+            discoveryClient.close();
+        }
     }
 
-    private String getMinorChannelHead() {
-        // Auto-discover from the catalog template file — read the first entry in the
-        // minor channel to find the current head. This avoids hardcoded version constants
-        // that break whenever a new patch is released.
-        var startVersion = getStartVersion();
-        var minorChannel = deriveMinorChannel(startVersion);
-        try {
-            var catalogRaw = loadRawResource("catalog/catalog.template.yaml");
-            var mapper = new com.fasterxml.jackson.dataformat.yaml.YAMLMapper();
-            var tree = mapper.readTree(catalogRaw);
-            var entries = tree.get("entries");
-            if (entries != null) {
-                for (var entry : entries) {
-                    if ("olm.channel".equals(entry.path("schema").asText())
-                            && minorChannel.equals(entry.path("name").asText())) {
-                        var channelEntries = entry.get("entries");
-                        if (channelEntries != null && channelEntries.size() > 0) {
-                            var headName = channelEntries.get(0).path("name").asText();
-                            if (headName.startsWith(PACKAGE_NAME + ".v")) {
-                                var version = headName.substring((PACKAGE_NAME + ".v").length());
-                                log.info("Auto-discovered minor channel head from catalog template: {} -> {}",
-                                        minorChannel, version);
-                                return version;
-                            }
-                        }
-                    }
-                }
-            }
-        } catch (Exception e) {
-            log.warn("Could not auto-discover minor channel head from catalog template: {}",
-                    e.getMessage());
-        }
-        log.info("Falling back to start version as minor channel head: {}", startVersion);
-        return startVersion;
+    private static String projectVersion() {
+        return OLMTestUtils.getProjectVersion();
+    }
+
+    private static String minorChannel() {
+        return deriveMinorChannel(projectVersion());
+    }
+
+    private static String rollingChannel() {
+        return deriveRollingChannel(projectVersion());
     }
 
     private void setUp() throws Exception {
@@ -126,88 +111,183 @@ public class UpgradeOLMITTest implements OperatorTestContext {
         }
     }
 
+    // ---- Condition methods for @EnabledIf ----
+
+    static boolean minorChannelHasPreviousEntry() {
+        var has = catalog.getPreviousEntry(minorChannel()) != null;
+        if (!has) {
+            log.info("Condition not met: channel {} has fewer than 2 entries (first-in-minor release)",
+                    minorChannel());
+        }
+        return has;
+    }
+
+    static boolean isHeadOfRollingChannel() {
+        var is = catalog.isVersionChannelHead(rollingChannel(), projectVersion());
+        if (!is) {
+            log.info("Condition not met: version {} is not the head of {} (maintenance branch release?)",
+                    projectVersion(), rollingChannel());
+        }
+        return is;
+    }
+
+    static boolean hasCrossMinorEntryInRollingChannel() {
+        if (!isHeadOfRollingChannel()) {
+            return false;
+        }
+        var entry = catalog.getCrossMinorEntry(rollingChannel());
+        if (entry == null) {
+            log.info("Condition not met: no cross-minor entry found in {}", rollingChannel());
+            return false;
+        }
+        return true;
+    }
+
+    static boolean isInRollingAndMinorChannel() {
+        var inRolling = catalog.isVersionChannelHead(rollingChannel(), projectVersion());
+        var hasMinor = catalog.hasChannel(minorChannel());
+        if (!inRolling) {
+            log.info("Condition not met: version {} is not the head of {}",
+                    projectVersion(), rollingChannel());
+        }
+        if (!hasMinor) {
+            log.info("Condition not met: channel {} not found in catalog", minorChannel());
+        }
+        return inRolling && hasMinor;
+    }
+
+    static boolean rollingChannelHasPreviousEntry() {
+        if (!isInRollingAndMinorChannel()) {
+            return false;
+        }
+        var has = catalog.getPreviousEntry(rollingChannel()) != null;
+        if (!has) {
+            log.info("Condition not met: {} has fewer than 2 entries", rollingChannel());
+        }
+        return has;
+    }
+
+    static boolean hasOlderMinorChannel() {
+        if (!isHeadOfRollingChannel()) {
+            return false;
+        }
+        var ch = catalog.getOlderMinorChannel(projectVersion(), rollingChannel());
+        if (ch == null) {
+            log.info("Condition not met: no older minor channel found in catalog");
+            return false;
+        }
+        return true;
+    }
+
+    static boolean minorChannelExists() {
+        var exists = catalog.hasChannel(minorChannel());
+        if (!exists) {
+            log.info("Condition not met: channel {} not found in catalog", minorChannel());
+        }
+        return exists;
+    }
+
+    // ---- Test methods ----
+
+    /**
+     * Verifies patch upgrade within the current minor channel (e.g., 3.3.0 -> 3.3.1 on 3.3.x).
+     * Requires at least 2 entries in the minor channel.
+     */
     @RetryTest
+    @EnabledIf("minorChannelHasPreviousEntry")
     void testUpgradeWithinMinorChannel() throws Exception {
         setUp();
 
-        var startVersion = getStartVersion();
-        var minorHead = getMinorChannelHead();
-        var minorChannel = deriveMinorChannel(startVersion);
+        var prev = catalog.getPreviousEntry(minorChannel());
+        var headVersion = catalog.getChannelHeadVersion(minorChannel());
 
-        log.info("Testing upgrade within {} channel: {} -> {}", minorChannel, startVersion,
-                minorHead);
+        log.info("Testing upgrade within {} channel: {} -> {}",
+                minorChannel(), prev.getVersion(), headVersion);
 
-        deployCatalogAndSubscribe(minorChannel, startVersion);
-        waitForOperatorVersion(startVersion);
+        deployCatalogAndSubscribe(minorChannel(), prev.getCsvName());
+        waitForOperatorVersion(prev.getVersion());
 
-        log.info("Operator {} deployed, waiting for upgrade to {}", startVersion, minorHead);
-        verifyUpgradeTo(minorHead);
+        log.info("Operator {} deployed, waiting for upgrade to {}", prev.getVersion(), headVersion);
+        verifyUpgradeTo(headVersion);
 
-        log.info("Upgrade within minor channel succeeded: {} -> {}", startVersion, minorHead);
+        log.info("Upgrade within minor channel succeeded: {} -> {}", prev.getVersion(), headVersion);
     }
 
+    /**
+     * Verifies cross-minor upgrade via the rolling channel (e.g., 3.2.5 -> 3.3.1 on 3.x).
+     * Requires the current version to be in the 3.x channel and an entry from a different minor.
+     */
     @RetryTest
+    @EnabledIf("hasCrossMinorEntryInRollingChannel")
     void testUpgradeAcrossMinors() throws Exception {
         setUp();
 
-        var startVersion = getStartVersion();
-        var projectVersion = getProjectVersion();
-        var rollingChannel = deriveRollingChannel(startVersion);
+        var crossMinorEntry = catalog.getCrossMinorEntry(rollingChannel());
+        var headVersion = catalog.getChannelHeadVersion(rollingChannel());
 
-        log.info("Testing upgrade via {} channel: {} -> {}", rollingChannel, startVersion,
-                projectVersion);
+        log.info("Testing upgrade via {} channel: {} -> {}",
+                rollingChannel(), crossMinorEntry.getVersion(), headVersion);
 
-        deployCatalogAndSubscribe(rollingChannel, startVersion);
-        waitForOperatorVersion(startVersion);
+        deployCatalogAndSubscribe(rollingChannel(), crossMinorEntry.getCsvName());
+        waitForOperatorVersion(crossMinorEntry.getVersion());
 
-        log.info("Operator {} deployed, waiting for upgrade to {}", startVersion, projectVersion);
-        verifyUpgradeTo(projectVersion);
+        log.info("Operator {} deployed, waiting for upgrade to {}",
+                crossMinorEntry.getVersion(), headVersion);
+        verifyUpgradeTo(headVersion);
 
-        verifyUpgradeCompleted(startVersion, projectVersion);
+        verifyUpgradeCompleted(crossMinorEntry.getVersion(), headVersion);
 
-        log.info("Cross-minor upgrade succeeded: {} -> {}", startVersion, projectVersion);
+        log.info("Cross-minor upgrade succeeded: {} -> {}",
+                crossMinorEntry.getVersion(), headVersion);
     }
 
+    /**
+     * Verifies channel switch from rolling to minor channel. Installs on 3.x, then switches
+     * subscription to 3.3.x and verifies the operator reaches the minor channel head.
+     * Requires the current version to be in both channels and a previous entry in the rolling channel.
+     */
     @RetryTest
+    @EnabledIf("rollingChannelHasPreviousEntry")
     void testChannelSwitchFromRollingToMinor() throws Exception {
         setUp();
 
-        var startVersion = getStartVersion();
-        var minorHead = getMinorChannelHead();
-        var minorChannel = deriveMinorChannel(startVersion);
-        var rollingChannel = deriveRollingChannel(startVersion);
+        var prev = catalog.getPreviousEntry(rollingChannel());
+        var minorHeadVersion = catalog.getChannelHeadVersion(minorChannel());
 
-        log.info("Testing channel switch: install {} on {}, then switch to {}", startVersion,
-                rollingChannel, minorChannel);
+        log.info("Testing channel switch: install {} on {}, then switch to {}",
+                prev.getVersion(), rollingChannel(), minorChannel());
 
-        deployCatalogAndSubscribe(rollingChannel, startVersion);
-        waitForOperatorVersion(startVersion);
-        log.info("Operator {} deployed on {} channel", startVersion, rollingChannel);
+        deployCatalogAndSubscribe(rollingChannel(), prev.getCsvName());
+        waitForOperatorVersion(prev.getVersion());
+        log.info("Operator {} deployed on {} channel", prev.getVersion(), rollingChannel());
 
-        // Switch subscription to the minor channel
-        patchSubscriptionChannel(minorChannel);
-        log.info("Switched subscription to {} channel, waiting for upgrade to {}", minorChannel,
-                minorHead);
+        patchSubscriptionChannel(minorChannel());
+        log.info("Switched subscription to {} channel, waiting for upgrade to {}",
+                minorChannel(), minorHeadVersion);
 
-        verifyUpgradeTo(minorHead);
-        log.info("Channel switch succeeded: operator is now at {} on {} channel", minorHead,
-                minorChannel);
+        verifyUpgradeTo(minorHeadVersion);
+        log.info("Channel switch succeeded: operator is now at {} on {} channel",
+                minorHeadVersion, minorChannel());
     }
 
+    /**
+     * Verifies that switching channels at the channel head is a no-op (operator stays at same version).
+     * Requires the current version to be in both 3.x and its minor channel.
+     */
     @RetryTest
+    @EnabledIf("isInRollingAndMinorChannel")
     void testChannelSwitchAtChannelHeadIsNoop() throws Exception {
         setUp();
 
-        var projectVersion = getProjectVersion();
-        var rollingChannel = deriveRollingChannel(projectVersion);
-        var currentMinorChannel = deriveMinorChannel(projectVersion);
+        var headCSV = catalog.getChannelHeadCSV(rollingChannel());
+        var headVersion = catalog.getChannelHeadVersion(rollingChannel());
 
-        log.info("Testing noop channel switch: install {} on {}, then switch to {} where it's also the head",
-                projectVersion, rollingChannel, currentMinorChannel);
+        log.info("Testing noop channel switch: install {} on {}, then switch to {}",
+                headVersion, rollingChannel(), minorChannel());
 
-        deployCatalogAndSubscribe(rollingChannel, projectVersion);
-        waitForOperatorVersion(projectVersion);
-        log.info("Operator {} deployed on {} channel", projectVersion, rollingChannel);
+        deployCatalogAndSubscribe(rollingChannel(), headCSV);
+        waitForOperatorVersion(headVersion);
+        log.info("Operator {} deployed on {} channel", headVersion, rollingChannel());
 
         var podBefore = client.pods().inNamespace(namespace).list().getItems().stream()
                 .filter(p -> p.getMetadata().getName().contains("apicurio-registry-operator"))
@@ -216,21 +296,18 @@ public class UpgradeOLMITTest implements OperatorTestContext {
                 .findFirst().orElseThrow(() -> new IllegalStateException("No operator pod found"));
         log.info("Operator pod UID before switch: {}", podBefore);
 
-        patchSubscriptionChannel(currentMinorChannel);
+        patchSubscriptionChannel(minorChannel());
         log.info("Switched subscription to {} channel, verifying operator stays at same version...",
-                currentMinorChannel);
+                minorChannel());
 
-        // OLM may re-evaluate and restart the pod on a channel switch, even if the
-        // version is the same. Wait for any restarts to settle, then verify the
-        // version hasn't changed and the operator is healthy.
         Thread.sleep(30_000);
 
-        // Verify the deployment still exists at the same version and is healthy
         await().atMost(UPGRADE_TIMEOUT).ignoreExceptions().untilAsserted(() -> {
             var deployment = client.apps().deployments().inNamespace(namespace)
-                    .withName("apicurio-registry-operator-v" + projectVersion.toLowerCase()).get();
+                    .withName(deploymentName(headVersion)).get();
             assertThat(deployment)
-                    .as("Operator deployment at " + projectVersion + " should still exist after channel switch")
+                    .as("Operator deployment at " + headVersion
+                            + " should still exist after channel switch")
                     .isNotNull();
             assertThat(deployment.getStatus().getReadyReplicas())
                     .as("Operator should have 1 ready replica after channel switch")
@@ -241,189 +318,193 @@ public class UpgradeOLMITTest implements OperatorTestContext {
                 .filter(p -> p.getMetadata().getName().contains("apicurio-registry-operator"))
                 .filter(p -> "Running".equals(p.getStatus().getPhase()))
                 .map(p -> p.getMetadata().getUid())
-                .findFirst().orElseThrow(() -> new IllegalStateException("No operator pod found after switch"));
+                .findFirst().orElseThrow(
+                        () -> new IllegalStateException("No operator pod found after switch"));
 
         if (podAfter.equals(podBefore)) {
             log.info("Channel switch was a true noop: same pod UID {}", podAfter);
         } else {
-            log.info("OLM restarted the pod on channel switch (old: {}, new: {}), but version is unchanged",
-                    podBefore, podAfter);
+            log.info("OLM restarted the pod on channel switch (old: {}, new: {}), "
+                    + "but version is unchanged", podBefore, podAfter);
         }
 
-        log.info("Channel switch at channel head verified: operator at {} is healthy", projectVersion);
+        log.info("Channel switch at channel head verified: operator at {} is healthy", headVersion);
     }
 
+    /**
+     * Verifies minor channel isolation — upgrade within the minor channel should not cross minor
+     * boundaries. Requires at least 2 entries in the minor channel.
+     */
     @RetryTest
+    @EnabledIf("minorChannelHasPreviousEntry")
     void testMinorChannelIsolation() throws Exception {
         setUp();
 
-        var startVersion = getStartVersion();
-        var minorHead = getMinorChannelHead();
-        var minorChannel = deriveMinorChannel(startVersion);
+        var prev = catalog.getPreviousEntry(minorChannel());
+        var minorHeadVersion = catalog.getChannelHeadVersion(minorChannel());
 
         log.info("Testing minor channel isolation: {} -> {} on {}, then verify no further upgrade",
-                startVersion, minorHead, minorChannel);
+                prev.getVersion(), minorHeadVersion, minorChannel());
 
-        deployCatalogAndSubscribe(minorChannel, startVersion);
-        waitForOperatorVersion(startVersion);
-        verifyUpgradeTo(minorHead);
-        log.info("Upgraded to {}. Waiting 60s to verify no further upgrade happens...", minorHead);
+        deployCatalogAndSubscribe(minorChannel(), prev.getCsvName());
+        waitForOperatorVersion(prev.getVersion());
+        verifyUpgradeTo(minorHeadVersion);
+        log.info("Upgraded to {}. Waiting 60s to verify no further upgrade happens...",
+                minorHeadVersion);
 
-        // Wait and verify the operator stays at the minor channel head
-        var projectVersion = getProjectVersion();
-        var crossMinorDeployment = "apicurio-registry-operator-v" + projectVersion.toLowerCase();
-        Thread.sleep(60_000);
+        var rollingHeadVersion = catalog.getChannelHeadVersion(rollingChannel());
+        if (rollingHeadVersion != null && !rollingHeadVersion.equals(minorHeadVersion)) {
+            Thread.sleep(60_000);
 
-        var deployment = client.apps().deployments().inNamespace(namespace)
-                .withName(crossMinorDeployment).get();
-        assertThat(deployment)
-                .as("Operator should NOT be upgraded to " + projectVersion
-                        + " on the " + minorChannel + " channel")
-                .isNull();
+            var deployment = client.apps().deployments().inNamespace(namespace)
+                    .withName(deploymentName(rollingHeadVersion)).get();
+            assertThat(deployment)
+                    .as("Operator should NOT be upgraded to " + rollingHeadVersion
+                            + " on the " + minorChannel() + " channel")
+                    .isNull();
+        }
 
         var currentDeployment = client.apps().deployments().inNamespace(namespace)
-                .withName("apicurio-registry-operator-v" + minorHead.toLowerCase()).get();
-        assertThat(currentDeployment).as("Operator should still be at " + minorHead).isNotNull();
+                .withName(deploymentName(minorHeadVersion)).get();
+        assertThat(currentDeployment)
+                .as("Operator should still be at " + minorHeadVersion).isNotNull();
         assertThat(currentDeployment.getStatus().getReadyReplicas())
-                .as("Operator at " + minorHead + " should still have 1 ready replica")
+                .as("Operator at " + minorHeadVersion + " should still have 1 ready replica")
                 .isEqualTo(1);
 
-        log.info("Minor channel isolation confirmed: operator stayed at {}", minorHead);
+        log.info("Minor channel isolation confirmed: operator stayed at {}", minorHeadVersion);
     }
 
+    /**
+     * Verifies fresh install on the minor channel (no startingCSV) gets the channel head.
+     * Requires the minor channel to exist.
+     */
     @RetryTest
+    @EnabledIf("minorChannelExists")
     void testFreshInstallOnEachChannel() throws Exception {
         setUp();
 
-        var minorHead = getMinorChannelHead();
-        var minorChannel = deriveMinorChannel(minorHead);
-        var projectVersion = getProjectVersion();
-        var rollingChannel = deriveRollingChannel(projectVersion);
+        var minorHeadVersion = catalog.getChannelHeadVersion(minorChannel());
 
-        log.info("Testing fresh install on {} channel (no startingCSV)", minorChannel);
+        log.info("Testing fresh install on {} channel (no startingCSV)", minorChannel());
 
-        // Fresh install on minor channel — should get the channel head
         createResource(client, namespace, "olmv0/catalog-source.yaml");
         waitForCatalogPodReady(client, namespace);
         createResource(client, namespace, "olmv0/operator-group.yaml");
 
         var extraVars = Map.of(
-                "${PLACEHOLDER_UPGRADE_CHANNEL}", minorChannel,
+                "${PLACEHOLDER_UPGRADE_CHANNEL}", minorChannel(),
                 "${PLACEHOLDER_UPGRADE_START_CSV}", "");
         var raw = loadRawResource("olmv0/subscription-upgrade.yaml");
-        // Remove the startingCSV field entirely for fresh install
         var subscriptionYaml = replaceVars(raw, namespace, extraVars)
                 .replaceAll("\\s*startingCSV:.*", "");
         client.resource(subscriptionYaml).create();
 
-        verifyUpgradeTo(minorHead);
-        log.info("Fresh install on {} channel got version {} as expected", minorChannel, minorHead);
+        verifyUpgradeTo(minorHeadVersion);
+        log.info("Fresh install on {} channel got version {} as expected",
+                minorChannel(), minorHeadVersion);
     }
 
+    /**
+     * Verifies that switching to an older minor channel does not downgrade the operator.
+     * Requires the current version to be in the rolling channel and an older minor channel to exist.
+     * The older channel is selected by parsed minor version (highest minor < current).
+     */
     @RetryTest
+    @EnabledIf("hasOlderMinorChannel")
     void testDowngradeChannelSwitchIsRejected() throws Exception {
         setUp();
 
-        var projectVersion = getProjectVersion();
-        var rollingChannel = deriveRollingChannel(projectVersion);
-        var minorHead = getMinorChannelHead();
-        var olderMinorChannel = deriveMinorChannel(minorHead);
+        var headCSV = catalog.getChannelHeadCSV(rollingChannel());
+        var headVersion = catalog.getChannelHeadVersion(rollingChannel());
+        var olderMinorChannel = catalog.getOlderMinorChannel(projectVersion(), rollingChannel());
+        var olderHeadVersion = catalog.getChannelHeadVersion(olderMinorChannel);
 
         log.info("Testing downgrade: install current version on {}, then switch to {}",
-                rollingChannel, olderMinorChannel);
+                rollingChannel(), olderMinorChannel);
 
-        // Install the current version on the rolling channel
-        deployCatalogAndSubscribe(rollingChannel, projectVersion);
-        waitForOperatorVersion(projectVersion);
-        log.info("Operator {} deployed on {} channel", projectVersion, rollingChannel);
+        deployCatalogAndSubscribe(rollingChannel(), headCSV);
+        waitForOperatorVersion(headVersion);
+        log.info("Operator {} deployed on {} channel", headVersion, rollingChannel());
 
-        // Switch to the older minor channel — OLM should not downgrade
         patchSubscriptionChannel(olderMinorChannel);
         log.info("Switched subscription to {} channel, waiting 60s to verify no downgrade...",
                 olderMinorChannel);
 
         Thread.sleep(60_000);
 
-        // Verify the operator is still running the current version
         var currentDeployment = client.apps().deployments().inNamespace(namespace)
-                .withName("apicurio-registry-operator-v" + projectVersion.toLowerCase()).get();
+                .withName(deploymentName(headVersion)).get();
         assertThat(currentDeployment)
-                .as("Operator should still be at " + projectVersion + " after channel switch")
+                .as("Operator should still be at " + headVersion + " after channel switch")
                 .isNotNull();
         assertThat(currentDeployment.getStatus().getReadyReplicas())
                 .as("Operator should still have 1 ready replica")
                 .isEqualTo(1);
 
-        // Verify the older version was NOT deployed
         var olderDeployment = client.apps().deployments().inNamespace(namespace)
-                .withName("apicurio-registry-operator-v" + minorHead.toLowerCase()).get();
+                .withName(deploymentName(olderHeadVersion)).get();
         assertThat(olderDeployment)
-                .as("Operator should NOT be downgraded to " + minorHead)
+                .as("Operator should NOT be downgraded to " + olderHeadVersion)
                 .isNull();
 
-        // Log subscription state for diagnostics
-        try {
-            var subscription = client.genericKubernetesResources(
-                            "operators.coreos.com/v1alpha1", "Subscription")
-                    .inNamespace(namespace)
-                    .withName("apicurio-registry-operator-subscription")
-                    .get();
-            log.info("Subscription after downgrade attempt: {}", subscription.getAdditionalProperties());
-        } catch (Exception e) {
-            log.info("Could not read subscription state: {}", e.getMessage());
-        }
-
-        log.info("Downgrade rejection confirmed: operator stayed at {}", projectVersion);
+        log.info("Downgrade rejection confirmed: operator stayed at {}", headVersion);
     }
 
+    /**
+     * Verifies upgrade with manual install plan approval. Requires at least 2 entries in the
+     * minor channel.
+     */
     @RetryTest
+    @EnabledIf("minorChannelHasPreviousEntry")
     void testManualApprovalUpgrade() throws Exception {
         setUp();
 
-        var startVersion = getStartVersion();
-        var minorHead = getMinorChannelHead();
-        var minorChannel = deriveMinorChannel(startVersion);
+        var prev = catalog.getPreviousEntry(minorChannel());
+        var minorHeadVersion = catalog.getChannelHeadVersion(minorChannel());
 
-        log.info("Testing manual approval upgrade on {} channel: {} -> {}", minorChannel,
-                startVersion, minorHead);
+        log.info("Testing manual approval upgrade on {} channel: {} -> {}",
+                minorChannel(), prev.getVersion(), minorHeadVersion);
 
-        // Deploy with Manual install plan approval
         createResource(client, namespace, "olmv0/catalog-source.yaml");
         waitForCatalogPodReady(client, namespace);
         createResource(client, namespace, "olmv0/operator-group.yaml");
 
         var extraVars = Map.of(
-                "${PLACEHOLDER_UPGRADE_CHANNEL}", minorChannel,
-                "${PLACEHOLDER_UPGRADE_START_CSV}", csvName(startVersion));
+                "${PLACEHOLDER_UPGRADE_CHANNEL}", minorChannel(),
+                "${PLACEHOLDER_UPGRADE_START_CSV}", prev.getCsvName());
         var raw = loadRawResource("olmv0/subscription-upgrade.yaml");
         var subscriptionYaml = replaceVars(raw, namespace, extraVars)
                 .replace("installPlanApproval: Automatic", "installPlanApproval: Manual");
         client.resource(subscriptionYaml).create();
 
-        // With Manual approval, wait for the initial install plan then approve it
         waitForAndApproveInstallPlans();
-        waitForOperatorVersion(startVersion);
-        log.info("Operator {} deployed with Manual approval", startVersion);
+        waitForOperatorVersion(prev.getVersion());
+        log.info("Operator {} deployed with Manual approval", prev.getVersion());
 
-        // Approve install plans in a loop until the target version is reached.
-        // Multi-step upgrades (e.g. 3.2.4 → 3.2.5 → 3.2.6) require approving
-        // each intermediate install plan.
         await().atMost(UPGRADE_TIMEOUT).pollInterval(java.time.Duration.ofSeconds(10))
                 .ignoreExceptions().untilAsserted(() -> {
-            approveAllPendingInstallPlans();
-            var deployment = client.apps().deployments().inNamespace(namespace)
-                    .withName("apicurio-registry-operator-v" + minorHead.toLowerCase()).get();
-            assertThat(deployment)
-                    .as("Operator should reach " + minorHead + " after approving all install plans")
-                    .isNotNull();
-            assertThat(deployment.getStatus().getReadyReplicas())
-                    .as("Operator at " + minorHead + " should have 1 ready replica")
-                    .isEqualTo(1);
-        });
-        log.info("Manual approval upgrade succeeded: {} -> {}", startVersion, minorHead);
+                    approveAllPendingInstallPlans();
+                    var deployment = client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(minorHeadVersion)).get();
+                    assertThat(deployment)
+                            .as("Operator should reach " + minorHeadVersion
+                                    + " after approving all install plans")
+                            .isNotNull();
+                    assertThat(deployment.getStatus().getReadyReplicas())
+                            .as("Operator at " + minorHeadVersion + " should have 1 ready replica")
+                            .isEqualTo(1);
+                });
+        log.info("Manual approval upgrade succeeded: {} -> {}", prev.getVersion(), minorHeadVersion);
     }
 
-    private void deployCatalogAndSubscribe(String channel, String startVersion) throws Exception {
+    // ---- Infrastructure methods ----
+
+    private static String deploymentName(Semver version) {
+        return "apicurio-registry-operator-v" + version.toString().toLowerCase();
+    }
+
+    private void deployCatalogAndSubscribe(String channel, String startCSV) throws Exception {
         try {
             createResource(client, namespace, "olmv0/catalog-source.yaml");
             waitForCatalogPodReady(client, namespace);
@@ -431,7 +512,7 @@ public class UpgradeOLMITTest implements OperatorTestContext {
 
             var extraVars = Map.of(
                     "${PLACEHOLDER_UPGRADE_CHANNEL}", channel,
-                    "${PLACEHOLDER_UPGRADE_START_CSV}", csvName(startVersion));
+                    "${PLACEHOLDER_UPGRADE_START_CSV}", startCSV);
             var raw = loadRawResource("olmv0/subscription-upgrade.yaml");
             client.resource(replaceVars(raw, namespace, extraVars)).create();
         } catch (Exception e) {
@@ -441,29 +522,29 @@ public class UpgradeOLMITTest implements OperatorTestContext {
         }
     }
 
-    private void waitForOperatorVersion(String version) {
-        var deploymentName = "apicurio-registry-operator-v" + version.toLowerCase();
+    private void waitForOperatorVersion(Semver version) {
+        var name = deploymentName(version);
         await().atMost(UPGRADE_TIMEOUT).ignoreExceptions().untilAsserted(() -> {
             var deployment = client.apps().deployments().inNamespace(namespace)
-                    .withName(deploymentName).get();
-            assertThat(deployment).as("Deployment " + deploymentName + " should exist").isNotNull();
+                    .withName(name).get();
+            assertThat(deployment).as("Deployment " + name + " should exist").isNotNull();
             assertThat(deployment.getStatus().getReadyReplicas())
-                    .as("Deployment " + deploymentName + " should have 1 ready replica")
+                    .as("Deployment " + name + " should have 1 ready replica")
                     .isEqualTo(1);
         });
         log.info("Operator version {} is ready", version);
     }
 
-    private void verifyUpgradeTo(String targetVersion) {
-        var deploymentName = "apicurio-registry-operator-v" + targetVersion.toLowerCase();
+    private void verifyUpgradeTo(Semver targetVersion) {
+        var name = deploymentName(targetVersion);
         await().atMost(UPGRADE_TIMEOUT).ignoreExceptions().untilAsserted(() -> {
             var deployment = client.apps().deployments().inNamespace(namespace)
-                    .withName(deploymentName).get();
+                    .withName(name).get();
             assertThat(deployment)
-                    .as("Target deployment " + deploymentName + " should exist after upgrade")
+                    .as("Target deployment " + name + " should exist after upgrade")
                     .isNotNull();
             assertThat(deployment.getStatus().getReadyReplicas())
-                    .as("Target deployment " + deploymentName + " should have 1 ready replica")
+                    .as("Target deployment " + name + " should have 1 ready replica")
                     .isEqualTo(1);
         });
     }
@@ -530,10 +611,7 @@ public class UpgradeOLMITTest implements OperatorTestContext {
                 .count();
     }
 
-    private void verifyUpgradeCompleted(String startVersion, String targetVersion) {
-        // OLM cleans up old CSVs after upgrade, so we can only verify the final state.
-        // The fact that we started at startVersion and arrived at targetVersion confirms
-        // intermediate versions were traversed (OLM follows the replaces chain).
+    private void verifyUpgradeCompleted(Semver startVersion, Semver targetVersion) {
         var csvList = client.genericKubernetesResources(
                         "operators.coreos.com/v1alpha1", "ClusterServiceVersion")
                 .inNamespace(namespace).list().getItems();
@@ -542,11 +620,11 @@ public class UpgradeOLMITTest implements OperatorTestContext {
                 .filter(name -> name.startsWith(PACKAGE_NAME))
                 .toList();
 
-        log.info("CSVs present after upgrade from {} to {}: {}", startVersion, targetVersion,
-                installedCSVs);
+        log.info("CSVs present after upgrade from {} to {}: {}",
+                startVersion, targetVersion, installedCSVs);
 
         assertThat(installedCSVs)
                 .as("Target version CSV should be present after upgrade")
-                .anyMatch(csv -> csv.contains(targetVersion.toLowerCase()));
+                .anyMatch(csv -> csv.contains(targetVersion.toString().toLowerCase()));
     }
 }

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMITTest.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMITTest.java
@@ -10,6 +10,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.semver4j.Semver;
@@ -35,6 +36,8 @@ import static org.awaitility.Awaitility.await;
  */
 @QuarkusTest
 @Tag(OLM)
+@DisabledIfSystemProperty(named = OLMTestUtils.OLM_VERSION_PROP, matches = "1",
+        disabledReason = "Upgrade tests use OLM v0 Subscriptions which are not available on OLM v1")
 @ExtendWith(OperatorTestExtension.class)
 public class UpgradeOLMITTest implements OperatorTestContext {
 
@@ -501,7 +504,7 @@ public class UpgradeOLMITTest implements OperatorTestContext {
     // ---- Infrastructure methods ----
 
     private static String deploymentName(Semver version) {
-        return "apicurio-registry-operator-v" + version.toString().toLowerCase();
+        return "apicurio-registry-operator-v" + version;
     }
 
     private void deployCatalogAndSubscribe(String channel, String startCSV) throws Exception {
@@ -625,6 +628,6 @@ public class UpgradeOLMITTest implements OperatorTestContext {
 
         assertThat(installedCSVs)
                 .as("Target version CSV should be present after upgrade")
-                .anyMatch(csv -> csv.contains(targetVersion.toString().toLowerCase()));
+                .anyMatch(csv -> csv.contains(targetVersion.toString()));
     }
 }


### PR DESCRIPTION
## Summary

- OLM upgrade tests (`UpgradeOLMITTest`) now discover available versions from the live `PackageManifest` at runtime instead of hardcoding version strings and reading the upstream `catalog.template.yaml`
- Tests work with both upstream catalogs and downstream IIB images (where CSV names have productized suffixes like `-r1`)
- Tests that are not applicable for the current release scenario are skipped via `@EnabledIf` conditions with logged reasons
- Cherry-picked two stability fixes from `3.2.6-testing` that never made it to `main`

## Details

**Catalog discovery** (`CatalogDiscovery` + `CatalogInfo`): Creates a temporary namespace, deploys the CatalogSource, queries the PackageManifest for channel entries (names, versions, heads), caches results, and cleans up. Queried once per test run.

**Conditional test execution**: Each upgrade test declares its preconditions via `@EnabledIf` annotations. For example, `testUpgradeWithinMinorChannel` requires ≥2 entries in the minor channel (skipped for first-in-minor releases). See the README for the full scenario matrix.

**Stability cherry-picks from `3.2.6-testing`**:
- K8s client request/connection timeout set to 30s for tests (default 10s too aggressive for degraded API servers)
- Wait for CR cleanup in `beforeEach` to prevent 409 AlreadyExists conflicts between tests

## Test plan

- [ ] Upstream CI passes OLM tests
- [ ] Backport to `3.3.1-testing` and run CSD downstream operator tests
- [ ] Verify skipped tests are logged with reasons

Fixes #9645