### PR TITLE
feat(ci): add deterministic PR triage splitter to lifecycle orchestrator

### DIFF
--- a/.github/PR_LIFECYCLE.md
+++ b/.github/PR_LIFECYCLE.md
@@ -14,7 +14,7 @@ Opened --> new --> ready-for-review --> ready-to-merge --> merged
 
 | State | Label | What happens |
 |-------|-------|--------------|
-| **New** | `lifecycle/new` | PR just opened. A welcome message is posted. No tests run. A maintainer must triage. PRs from maintainers and trusted accounts (e.g., Renovate) skip this state. |
+| **New** | `lifecycle/new` | PR just opened. A welcome message is posted and **automated triage** runs (see below). No tests run. A maintainer must triage. PRs from maintainers and trusted accounts (e.g., Renovate) skip this state. |
 | **Ready for review** | `lifecycle/ready-for-review` | Maintainer accepted the PR (or auto-accepted for trusted authors). The full test suite runs on each push. Reviewers can review. |
 | **Ready to merge** | `lifecycle/ready-to-merge` | PR is approved and all tests pass. A maintainer can merge. |
 | **Merged** | — | PR is merged. Branch may be deleted automatically. |
@@ -30,6 +30,36 @@ Converting a PR **back** to draft removes all of its `lifecycle/*` labels and st
 CI from running on subsequent pushes — useful if you need to iterate without burning
 CI capacity. Marking it ready for review again re-enters the lifecycle at
 `lifecycle/new`, so a maintainer has to `/accept` it a second time.
+
+### Automated triage
+
+Every external (non-trusted) PR is checked automatically when it is opened and on
+every push. The checks are deterministic and derive from the Contributor Checklist
+in `CLAUDE.md` — no AI involved. The result is a `triage/*` label plus a report
+comment that updates in place:
+
+| Verdict | Label | Effect |
+|---------|-------|--------|
+| **Green** | `triage/green` | No findings. Ready for a maintainer to `/accept`. |
+| **Yellow** | `triage/yellow` | Findings the author should fix (missing tests, style violations, oversized diff, overlapping PR...). Maintainers can still `/accept`. |
+| **Red** | `triage/red` | Blocking problems (missing DCO sign-off, no linked/approved issue, generated files in the diff). The PR is set to `lifecycle/waiting-on-author` and follows the accelerated stale/close cycle until fixed. |
+
+Red findings and what they mean:
+
+- **Missing DCO sign-off** — one or more commits lack `Signed-off-by`. Fix with
+  `git rebase --signoff main` and force-push.
+- **No linked issue / issue not approved** — the PR description must reference an
+  issue (`Fixes #NNN`) that has a comment from a project maintainer. Implementing
+  unapproved requests wastes review time and gets rejected.
+- **Generated or binary files** — build outputs (`target/`, jars) don't belong in a PR.
+
+Fixing the findings and pushing (or editing the PR description and running
+`/triage`) re-evaluates the PR: a red verdict that turns green/yellow automatically
+returns the PR to the maintainer triage queue. Triage runs from patch text and
+metadata via the GitHub API — PR code is never executed.
+
+Triage is configured under the `triage:` key in `.github/pr-lifecycle.yml`
+(enable/disable, linked-issue requirement, diff size threshold).
 
 ### Additional labels
 
@@ -77,6 +107,7 @@ after 7 total days of inactivity; other PRs go stale at 7 days and close at 14 t
 | Command | Description |
 |---------|-------------|
 | `/unstale` | Remove the stale label |
+| `/triage` | Re-run the automated triage checks (author or maintainer) |
 | `/assign-me` | Self-assign an open issue to volunteer for implementation |
 | `/unassign-me` | Release an issue you are currently assigned to |
 
@@ -94,8 +125,11 @@ Contributors can self-assign open issues by commenting `/assign-me` (or `/claim`
 ### Triaging new PRs
 
 When a new PR arrives (`lifecycle/new`):
-1. Review the PR description and scope
-2. Accept with `/accept` (transitions directly to `ready-for-review`, full test
+1. Check the `triage/*` label and report — green PRs can usually be accepted at a
+   glance, yellow PRs list exactly what reviewers would flag, red PRs are already
+   bounced back to the author and need no attention until fixed
+2. Review the PR description and scope
+3. Accept with `/accept` (transitions directly to `ready-for-review`, full test
    suite runs) or reject with `/reject [reason]`
 
 ### Managing the lifecycle
@@ -116,7 +150,7 @@ PRs are merged using **rebase** by default (linear history). This can be changed
 
 ### Label protection
 
-All `lifecycle/*` and `orchestrator/*` labels are managed exclusively by the orchestrator.
+All `lifecycle/*`, `orchestrator/*` and `triage/*` labels are managed exclusively by the orchestrator.
 Manual label changes will be reverted automatically. Use the appropriate slash command
 instead of adding or removing labels directly.
 

--- a/.github/pr-lifecycle.yml
+++ b/.github/pr-lifecycle.yml
@@ -13,6 +13,19 @@ auto_accept:
 
 max_contributor_prs: 1
 
+# Automated triage of external PRs at open and on every push. Verdicts:
+#   green  — no findings, ready for maintainer /accept
+#   yellow — findings the author should fix; maintainer judgment call
+#   red    — blocking problems; PR is set to waiting-on-author and follows the
+#            accelerated stale/close cycle until fixed
+triage:
+  enabled: true
+  # Missing linked issue (or linked issue without a maintainer comment) is a
+  # red finding — implementing unapproved requests wastes review time.
+  require_linked_issue: true
+  # Diffs larger than this (added+deleted lines) get a yellow finding.
+  max_diff_lines: 3000
+
 merge:
   strategy: rebase
   delete_branch: true
@@ -46,6 +59,7 @@ welcome_message: |
   |---------|-------------|
   | `/unstale` | Remove the stale label |
   | `/retry` | Re-run the lifecycle orchestrator and retry failed tests |
+  | `/triage` | Re-run the automated triage checks |
 
   **Maintainer commands:**
   | Command | Description |

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -5,6 +5,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const triage = require('./pr-triage.js');
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -31,9 +32,12 @@ const PRIMARY_STATES = [
   LABELS.READY_TO_MERGE,
 ];
 
-const CONTROL_LABELS = Object.values(LABELS).filter(
-  l => l.startsWith('lifecycle/') || l.startsWith('orchestrator/')
-);
+const CONTROL_LABELS = [
+  ...Object.values(LABELS).filter(
+    l => l.startsWith('lifecycle/') || l.startsWith('orchestrator/')
+  ),
+  ...Object.values(triage.TRIAGE_LABELS),
+];
 
 const COLORS = {
   INFO: 'A8D8F0',
@@ -683,13 +687,28 @@ async function initNewPr(github, owner, repo, api, config, pr, core) {
   }
 
   await api.addLabel(pr.number, LABELS.NEW);
-  await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
   let message = config.welcome_message.replace(/\{author\}/g, pr.user.login);
   if (pr.head.repo?.full_name !== `${owner}/${repo}`) {
     message += `\n**Note (fork PR):** Review label updates may not apply automatically. ` +
       `A maintainer can use \`/retry\` after reviewing to update the labels.`;
   }
   await api.postComment(pr.number, message);
+
+  // Automated triage splits the queue: red PRs go straight to
+  // waiting-on-author (feeding the accelerated stale/close cycle), everything
+  // else waits on maintainer acceptance. Triage failure is non-fatal — the PR
+  // just follows the default path.
+  let triageResult = null;
+  try {
+    triageResult = await triage.runTriage({ github, owner, repo, pr, config, core });
+  } catch (e) {
+    core.warning(`PR #${pr.number} triage failed (non-fatal): ${e.message}`);
+  }
+  if (triageResult?.verdict === 'red') {
+    await api.addLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
+  } else {
+    await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
+  }
   core.info(`PR #${pr.number} opened, set to lifecycle/new`);
 }
 
@@ -768,6 +787,27 @@ async function handlePrSynchronize({ github, context, core }) {
 
   const freshPr = await api.getPr(pr.number);
   await reconcile(github, api, freshPr, core);
+
+  // Re-run triage so the report and triage/* label track the latest push.
+  // Only in lifecycle/new does the verdict drive the waiting-on-* labels —
+  // in later states those are owned by review/test results.
+  const config = loadConfig();
+  if (!isAutoAccepted(config, freshPr.user.login)) {
+    try {
+      const result = await triage.runTriage({ github, owner, repo, pr: freshPr, config, core });
+      if (result && getLifecycleState(freshPr) === LABELS.NEW) {
+        if (result.verdict === 'red') {
+          await api.removeLabel(freshPr.number, LABELS.WAITING_ON_MAINTAINER);
+          await api.addLabel(freshPr.number, LABELS.WAITING_ON_AUTHOR);
+        } else {
+          await api.removeLabel(freshPr.number, LABELS.WAITING_ON_AUTHOR);
+          await api.addLabel(freshPr.number, LABELS.WAITING_ON_MAINTAINER);
+        }
+      }
+    } catch (e) {
+      core.warning(`PR #${pr.number} triage failed (non-fatal): ${e.message}`);
+    }
+  }
 
   // For fork PRs in a testable state, the synchronize event creates a new
   // Verify run that needs approval. Wait for it to appear, then approve.
@@ -851,6 +891,7 @@ async function handleComment({ github, context, core }) {
     'skip-review': () => cmdSkipReview(api, config, core, pr, actor, maintainer, comment.id),
     'unstale': () => cmdUnstale(api, config, core, pr, actor, isAuthor, maintainer, comment.id),
     'retry': () => cmdRetry(github, api, core, pr, actor, isAuthor, maintainer, comment.id),
+    'triage': () => cmdTriage(github, owner, repo, api, config, core, pr, actor, isAuthor, maintainer, comment.id),
   };
 
   const handler = handlers[parsed.command];
@@ -880,6 +921,9 @@ async function cmdAccept(api, config, core, pr, actor, maintainer, commentId) {
   }
 
   await api.setLifecycleState(pr, LABELS.READY_FOR_REVIEW);
+  // A red triage verdict may have left waiting-on-author set — acceptance
+  // overrides triage, so reset to waiting-on-maintainer.
+  await api.removeLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
   await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
   await api.addReaction(commentId, '+1');
   await api.postComment(pr.number,
@@ -893,6 +937,34 @@ async function cmdAccept(api, config, core, pr, actor, maintainer, commentId) {
   // approval (fork PRs). Wait for GitHub to create it, then approve.
   await new Promise(r => setTimeout(r, 5000));
   await approvePendingVerifyRuns(api, pr, core);
+}
+
+async function cmdTriage(github, owner, repo, api, config, core, pr, actor, isAuthor, maintainer, commentId) {
+  if (!isAuthor && !maintainer) {
+    await api.addReaction(commentId, '-1');
+    await api.postComment(pr.number, `@${actor} Only the PR author or a maintainer can re-run triage.`);
+    return;
+  }
+
+  const result = await triage.runTriage({ github, owner, repo, pr, config, core });
+  if (!result) {
+    await api.addReaction(commentId, 'confused');
+    core.info(`PR #${pr.number} /triage requested but triage is disabled`);
+    return;
+  }
+
+  // Verdict drives waiting-on-* only while the PR awaits maintainer triage.
+  if (getLifecycleState(pr) === LABELS.NEW) {
+    if (result.verdict === 'red') {
+      await api.removeLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
+      await api.addLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
+    } else {
+      await api.removeLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
+      await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
+    }
+  }
+  await api.addReaction(commentId, '+1');
+  core.info(`PR #${pr.number} /triage by ${actor}: verdict=${result.verdict}`);
 }
 
 async function cmdReject(api, config, core, pr, actor, maintainer, reason, commentId) {

--- a/.github/scripts/pr-triage.js
+++ b/.github/scripts/pr-triage.js
@@ -1,0 +1,555 @@
+// PR Triage — deterministic quality splitter for external contributions.
+//
+// Runs machine-checkable items from the Contributor Checklist (CLAUDE.md)
+// against PR metadata and patch text fetched via the GitHub API. Produces a
+// verdict (green/yellow/red), a triage/* label, and an upserted report comment.
+//
+// SECURITY: this module analyzes patch TEXT and metadata only. It must never
+// execute, check out, or evaluate PR head code — it runs under
+// pull_request_target with write permissions.
+
+const MARKER = '<!-- pr-triage-report -->';
+
+const TRIAGE_LABELS = {
+  GREEN: 'triage/green',
+  YELLOW: 'triage/yellow',
+  RED: 'triage/red',
+};
+
+const TRIAGE_LABEL_DEFS = {
+  [TRIAGE_LABELS.GREEN]:  { color: '5BB85B', description: 'Automated triage passed — ready for maintainer acceptance' },
+  [TRIAGE_LABELS.YELLOW]: { color: 'F7BF6A', description: 'Automated triage found issues the author should fix' },
+  [TRIAGE_LABELS.RED]:    { color: 'E8836B', description: 'Automated triage found blocking problems' },
+};
+
+const DEFAULTS = {
+  enabled: true,
+  require_linked_issue: true,
+  max_diff_lines: 3000,
+  max_files: 300,
+};
+
+// ---------------------------------------------------------------------------
+// Patch parsing helpers (unified diff text from the GitHub API)
+// ---------------------------------------------------------------------------
+
+// Returns the added lines of a file patch (without the leading '+').
+function addedLines(patch) {
+  if (!patch) return [];
+  return patch
+    .split('\n')
+    .filter(l => l.startsWith('+') && !l.startsWith('+++'))
+    .map(l => l.slice(1));
+}
+
+// Sanitizes attacker-controlled text (titles, filenames, patch fragments) for
+// embedding in a markdown code span: strips backticks so the span cannot be
+// broken out of, drops newlines, and truncates.
+function code(s) {
+  return String(s ?? '').replace(/[`\r\n]/g, '').slice(0, 200);
+}
+
+function isJavaFile(file) {
+  return file.filename.endsWith('.java');
+}
+
+function isMainCode(file) {
+  return file.filename.includes('src/main/') && isJavaFile(file);
+}
+
+function isTestCode(file) {
+  return (file.filename.includes('src/test/') || file.filename.includes('/it/') ||
+          file.filename.includes('integration-tests/')) && isJavaFile(file);
+}
+
+// ---------------------------------------------------------------------------
+// Issue reference extraction
+// ---------------------------------------------------------------------------
+
+function extractLinkedIssueNumbers(body, owner, repo) {
+  if (!body) return [];
+  const numbers = new Set();
+  const shortRefs = body.matchAll(/(?:^|[\s(:,])#(\d{1,6})\b/g);
+  for (const m of shortRefs) numbers.add(parseInt(m[1], 10));
+  const esc = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const urlRe = new RegExp(
+    `github\\.com/${esc(owner)}/${esc(repo)}/issues/(\\d{1,6})\\b`, 'gi');
+  for (const m of body.matchAll(urlRe)) numbers.add(parseInt(m[1], 10));
+  return [...numbers];
+}
+
+// Target-repo coordinates from the PR object (base side — never the fork).
+function prRepoCoords(pr) {
+  return { owner: pr.base.repo.owner.login, repo: pr.base.repo.name };
+}
+
+// ---------------------------------------------------------------------------
+// Checks — each returns a finding object or null.
+// data: { pr, commits, files, linkedIssues, openPrs, config, maintainers }
+// finding: { id, severity: 'red'|'yellow', title, detail }
+// ---------------------------------------------------------------------------
+
+function checkDco({ commits }) {
+  const missing = commits
+    .filter(c => (c.parents || []).length <= 1)
+    .filter(c => !/^Signed-off-by: .+ <.+@.+>/m.test(c.commit.message));
+  if (missing.length === 0) return null;
+  const shas = missing.slice(0, 5).map(c => `\`${c.sha.slice(0, 7)}\``).join(', ');
+  return {
+    id: 'dco-missing',
+    severity: 'red',
+    title: 'Missing DCO sign-off',
+    detail: `${missing.length} commit(s) lack a \`Signed-off-by\` trailer (${shas}). ` +
+      `Amend with \`git commit --amend -s\` (or \`git rebase --signoff main\`) and force-push.`,
+  };
+}
+
+function checkLinkedIssue({ pr, linkedIssues, config }) {
+  if (!(config.require_linked_issue ?? DEFAULTS.require_linked_issue)) return null;
+  if (linkedIssues.length > 0) return null;
+  return {
+    id: 'no-linked-issue',
+    severity: 'red',
+    title: 'No linked issue',
+    detail: 'The PR description does not reference an issue. Every contribution needs a ' +
+      'linked issue with maintainer approval before implementation — edit the description ' +
+      'to add `Fixes #<issue>` and use `/triage` to re-check.',
+  };
+}
+
+function checkIssueApproval({ linkedIssues, maintainers }) {
+  if (linkedIssues.length === 0) return null;
+  const approved = linkedIssues.some(issue =>
+    maintainers.includes(issue.issue.user.login) ||
+    issue.comments.some(c => maintainers.includes(c.user.login)));
+  if (approved) return null;
+  const refs = linkedIssues.map(i => `#${i.issue.number}`).join(', ');
+  return {
+    id: 'issue-not-approved',
+    severity: 'red',
+    title: 'Linked issue has no maintainer approval',
+    detail: `Issue(s) ${refs} were not opened by a project maintainer and have no comment from one. ` +
+      'Feature/fix requests need maintainer sign-off before implementation — ' +
+      'otherwise the work may be rejected regardless of quality.',
+  };
+}
+
+function checkGeneratedFiles({ files }) {
+  const bad = files.filter(f =>
+    /(^|\/)target\//.test(f.filename) ||
+    /\.(jar|class|war|ear|zip|exe|dll|so|dylib)$/.test(f.filename));
+  if (bad.length === 0) return null;
+  const names = bad.slice(0, 5).map(f => `\`${code(f.filename)}\``).join(', ');
+  return {
+    id: 'generated-files',
+    severity: 'red',
+    title: 'Generated or binary files in diff',
+    detail: `${bad.length} file(s) under \`target/\` or binary artifacts: ${names}. ` +
+      'These are build outputs — remove them from the PR.',
+  };
+}
+
+function checkTestsPresent({ files }) {
+  const mainChanged = files.filter(f => isMainCode(f) && f.additions > 0);
+  if (mainChanged.length === 0) return null;
+  const testChanged = files.some(f => isTestCode(f));
+  if (testChanged) return null;
+  return {
+    id: 'tests-missing',
+    severity: 'yellow',
+    title: 'No test changes for production code',
+    detail: `${mainChanged.length} file(s) under \`src/main\` changed but no test files were ` +
+      'touched. Every new code path needs tests — missing tests are an automatic rejection.',
+  };
+}
+
+function checkStarImports({ files }) {
+  const hits = [];
+  for (const f of files.filter(isJavaFile)) {
+    for (const line of addedLines(f.patch)) {
+      if (/^\s*import\s+(static\s+)?[\w.]+\.\*\s*;/.test(line)) {
+        hits.push(f.filename);
+        break;
+      }
+    }
+  }
+  if (hits.length === 0) return null;
+  return {
+    id: 'star-imports',
+    severity: 'yellow',
+    title: 'Star imports added',
+    detail: `Wildcard imports in: ${hits.slice(0, 5).map(f => `\`${code(f)}\``).join(', ')}. ` +
+      'Use explicit imports (project convention, staged checkstyle rule).',
+  };
+}
+
+const ALLOWED_CONFIG_PREFIXES = ['apicurio.', 'registry.', 'quarkus.', 'mp.', 'smallrye.', 'kafka.'];
+
+function checkConfigPrefix({ files }) {
+  const hits = [];
+  for (const f of files.filter(isJavaFile)) {
+    for (const line of addedLines(f.patch)) {
+      const m = line.match(/@ConfigProperty\s*\(\s*name\s*=\s*"([^"]+)"/);
+      if (m && !ALLOWED_CONFIG_PREFIXES.some(p => m[1].startsWith(p))) {
+        hits.push(`\`${code(m[1])}\``);
+      }
+    }
+  }
+  if (hits.length === 0) return null;
+  return {
+    id: 'config-prefix',
+    severity: 'yellow',
+    title: 'Config property outside the apicurio.* namespace',
+    detail: `New config properties ${hits.slice(0, 5).join(', ')} do not use the \`apicurio.*\` ` +
+      'prefix. Registry properties must follow `.claude/rules/config-properties.md` and carry ' +
+      '`@Info` in the `app` module.',
+  };
+}
+
+function checkLicenseHeaders({ files }) {
+  const hits = files
+    .filter(f => f.status === 'added' && isJavaFile(f))
+    .filter(f => addedLines(f.patch).some(l => /Licensed under the Apache License/i.test(l)))
+    .map(f => f.filename);
+  if (hits.length === 0) return null;
+  return {
+    id: 'license-headers',
+    severity: 'yellow',
+    title: 'Per-file license headers added',
+    detail: `New file(s) ${hits.slice(0, 3).map(f => `\`${code(f)}\``).join(', ')} carry an Apache ` +
+      'license header. This project does not use per-file headers — the repository-root ' +
+      '`LICENSE` governs. Remove them.',
+  };
+}
+
+function checkLocale({ files }) {
+  const hits = [];
+  for (const f of files.filter(isJavaFile)) {
+    for (const line of addedLines(f.patch)) {
+      if (/\.to(Upper|Lower)Case\(\s*\)/.test(line)) {
+        hits.push(f.filename);
+        break;
+      }
+    }
+  }
+  if (hits.length === 0) return null;
+  return {
+    id: 'locale-missing',
+    severity: 'yellow',
+    title: 'Case conversion without Locale',
+    detail: `\`.toUpperCase()\`/\`.toLowerCase()\` without a \`Locale\` argument in ` +
+      `${hits.slice(0, 5).map(f => `\`${code(f)}\``).join(', ')}. Use \`Locale.ROOT\`.`,
+  };
+}
+
+function checkSynchronizedReactive({ files }) {
+  const hits = [];
+  for (const f of files.filter(isJavaFile)) {
+    if (!f.patch) continue;
+    const reactive = /io\.smallrye\.mutiny|Uni<|Multi</.test(f.patch);
+    if (!reactive) continue;
+    if (addedLines(f.patch).some(l => /\bsynchronized\b/.test(l))) {
+      hits.push(f.filename);
+    }
+  }
+  if (hits.length === 0) return null;
+  return {
+    id: 'synchronized-reactive',
+    severity: 'yellow',
+    title: 'synchronized in reactive code path',
+    detail: `\`synchronized\` added in Mutiny-using file(s): ` +
+      `${hits.slice(0, 3).map(f => `\`${code(f)}\``).join(', ')}. Use \`AtomicReference\` + CAS or ` +
+      'framework-provided mechanisms — never block reactive threads.',
+  };
+}
+
+function checkTabs({ files }) {
+  const hits = [];
+  for (const f of files.filter(isJavaFile)) {
+    if (addedLines(f.patch).some(l => l.includes('\t'))) hits.push(f.filename);
+  }
+  if (hits.length === 0) return null;
+  return {
+    id: 'tab-characters',
+    severity: 'yellow',
+    title: 'Tab characters added',
+    detail: `Tabs in ${hits.slice(0, 5).map(f => `\`${code(f)}\``).join(', ')}. ` +
+      'The build enforces spaces (checkstyle error tier). Convert to 4-space indentation.',
+  };
+}
+
+// Inline fully-qualified names in code are a common LLM artifact — the
+// checklist requires them to be imports instead.
+function checkInlineFqn({ files }) {
+  const hits = [];
+  // Bounded quantifiers: patch text is attacker-controlled.
+  const fqnRe = /(?:^|[\s(={,])(java\.(?:util|io|nio|time|net)\.(?:[a-z]{1,40}\.){0,10}[A-Z]\w{0,80})/;
+  for (const f of files.filter(isJavaFile)) {
+    for (const line of addedLines(f.patch)) {
+      if (/^\s*import\s/.test(line) || /^\s*\/\/|^\s*\*/.test(line)) continue;
+      const m = line.match(fqnRe);
+      if (m) {
+        hits.push(`\`${code(m[1])}\` in \`${code(f.filename)}\``);
+        break;
+      }
+    }
+  }
+  if (hits.length === 0) return null;
+  return {
+    id: 'inline-fqn',
+    severity: 'yellow',
+    title: 'Inline fully-qualified names',
+    detail: `${hits.slice(0, 3).join(', ')}. Fully qualified names must be imports — ` +
+      'inline FQNs are a common generated-code artifact and get flagged in review.',
+  };
+}
+
+function checkTitleFormat({ pr }) {
+  const conventional = /^(feat|fix|chore|docs|ci|test|refactor)(\([\w\-./]{1,60}\))?!?: .+/;
+  if (conventional.test(pr.title)) return null;
+  return {
+    id: 'title-format',
+    severity: 'yellow',
+    title: 'PR title is not a Conventional Commit',
+    detail: `\`${code(pr.title)}\` — expected \`type(scope): description\` with type one of ` +
+      '`feat|fix|chore|docs|ci|test|refactor` (see CONTRIBUTING.md).',
+  };
+}
+
+function checkDiffSize({ pr, config }) {
+  const maxLines = config.max_diff_lines ?? DEFAULTS.max_diff_lines;
+  const total = (pr.additions || 0) + (pr.deletions || 0);
+  if (total <= maxLines) return null;
+  return {
+    id: 'oversized',
+    severity: 'yellow',
+    title: 'Very large diff',
+    detail: `${total} changed lines (threshold ${maxLines}). Consider splitting — ` +
+      'large drive-by PRs are hard to review and often stall.',
+  };
+}
+
+function checkOverlappingPrs({ pr, linkedIssues, openPrs }) {
+  if (linkedIssues.length === 0) return null;
+  const issueNumbers = linkedIssues.map(i => i.issue.number);
+  const { owner, repo } = prRepoCoords(pr);
+  const overlapping = openPrs.filter(p => {
+    if (p.number === pr.number || !p.body) return false;
+    // Symmetric with how this PR's own links are extracted (short refs + URLs).
+    const theirs = extractLinkedIssueNumbers(p.body, owner, repo);
+    return issueNumbers.some(n => theirs.includes(n));
+  });
+  if (overlapping.length === 0) return null;
+  const refs = overlapping.slice(0, 3).map(p => `#${p.number}`).join(', ');
+  return {
+    id: 'overlapping-pr',
+    severity: 'yellow',
+    title: 'Another open PR references the same issue',
+    detail: `Open PR(s) ${refs} reference the same issue. Duplicate work gets the later ` +
+      'PR closed — coordinate on the issue before continuing.',
+  };
+}
+
+const CHECKS = [
+  checkDco,
+  checkLinkedIssue,
+  checkIssueApproval,
+  checkGeneratedFiles,
+  checkTestsPresent,
+  checkStarImports,
+  checkConfigPrefix,
+  checkLicenseHeaders,
+  checkLocale,
+  checkSynchronizedReactive,
+  checkTabs,
+  checkInlineFqn,
+  checkTitleFormat,
+  checkDiffSize,
+  checkOverlappingPrs,
+];
+
+// ---------------------------------------------------------------------------
+// Aggregation and rendering
+// ---------------------------------------------------------------------------
+
+function runChecks(data) {
+  const findings = [];
+  for (const check of CHECKS) {
+    const finding = check(data);
+    if (finding) findings.push(finding);
+  }
+  return findings;
+}
+
+function computeVerdict(findings) {
+  if (findings.some(f => f.severity === 'red')) return 'red';
+  if (findings.some(f => f.severity === 'yellow')) return 'yellow';
+  return 'green';
+}
+
+function renderReport({ verdict, findings, pr }) {
+  const icon = { green: '🟢', yellow: '🟡', red: '🔴' }[verdict];
+  const headline = {
+    green: 'All automated triage checks passed. A maintainer can accept this PR with `/accept`.',
+    yellow: 'Triage found issues that will come up in review. Fixing them now speeds up acceptance.',
+    red: 'Triage found blocking problems. Please fix them — the PR will not be triaged by a ' +
+      'maintainer until the blocking findings are resolved. It will be closed automatically ' +
+      'if there is no activity.',
+  }[verdict];
+
+  let body = `${MARKER}\n## ${icon} Automated triage: ${verdict.toUpperCase()}\n\n${headline}\n`;
+
+  const sections = [
+    ['red', '### 🚫 Blocking'],
+    ['yellow', '### ⚠️ Should fix'],
+  ];
+  for (const [severity, heading] of sections) {
+    const items = findings.filter(f => f.severity === severity);
+    if (items.length === 0) continue;
+    body += `\n${heading}\n\n`;
+    for (const f of items) {
+      body += `- **${f.title}** — ${f.detail}\n`;
+    }
+  }
+
+  body += `\n---\n*Checks derive from the [Contributor Checklist](https://github.com/${pr.base.repo.owner.login}/${pr.base.repo.name}/blob/main/CLAUDE.md). ` +
+    `The report refreshes on every push, or on demand with \`/triage\`. ` +
+    `Head: \`${code(pr.head.sha).slice(0, 7)}\`.*\n`;
+  return body;
+}
+
+// ---------------------------------------------------------------------------
+// Data collection (GitHub API only — never touches PR code)
+// ---------------------------------------------------------------------------
+
+async function collectTriageData(github, owner, repo, pr, config, maintainers) {
+  const maxFiles = config.max_files ?? DEFAULTS.max_files;
+
+  const commits = await github.paginate(github.rest.pulls.listCommits, {
+    owner, repo, pull_number: pr.number, per_page: 100,
+  });
+
+  // Early-exit pagination: stop fetching pages once we have enough files —
+  // no point walking hundreds of pages of an oversized PR just to slice them.
+  let fileCount = 0;
+  let files = await github.paginate(github.rest.pulls.listFiles, {
+    owner, repo, pull_number: pr.number, per_page: 100,
+  }, (response, done) => {
+    fileCount += response.data.length;
+    if (fileCount >= maxFiles) done();
+    return response.data;
+  });
+  if (files.length > maxFiles) files = files.slice(0, maxFiles);
+
+  const issueNumbers = extractLinkedIssueNumbers(pr.body, owner, repo).slice(0, 3);
+  const linkedIssues = [];
+  for (const number of issueNumbers) {
+    try {
+      const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: number });
+      if (issue.pull_request) continue; // reference was to a PR, not an issue
+      const comments = await github.paginate(github.rest.issues.listComments, {
+        owner, repo, issue_number: number, per_page: 100,
+      });
+      linkedIssues.push({ issue, comments });
+    } catch (e) {
+      if (e.status !== 404) throw e;
+    }
+  }
+
+  let openPrs = [];
+  if (linkedIssues.length > 0) {
+    openPrs = await github.paginate(github.rest.pulls.list, {
+      owner, repo, state: 'open', per_page: 100,
+    });
+  }
+
+  return { pr, commits, files, linkedIssues, openPrs, config, maintainers };
+}
+
+// ---------------------------------------------------------------------------
+// Label + comment side effects
+// ---------------------------------------------------------------------------
+
+async function ensureTriageLabel(github, owner, repo, name) {
+  const def = TRIAGE_LABEL_DEFS[name];
+  try {
+    await github.rest.issues.getLabel({ owner, repo, name });
+  } catch (e) {
+    if (e.status === 404) {
+      await github.rest.issues.createLabel({ owner, repo, name, ...def });
+    } else {
+      throw e;
+    }
+  }
+}
+
+async function applyTriageLabel(github, owner, repo, pr, verdict) {
+  const target = {
+    green: TRIAGE_LABELS.GREEN,
+    yellow: TRIAGE_LABELS.YELLOW,
+    red: TRIAGE_LABELS.RED,
+  }[verdict];
+  await ensureTriageLabel(github, owner, repo, target);
+  const current = (pr.labels || []).map(l => l.name);
+  for (const label of Object.values(TRIAGE_LABELS)) {
+    if (label !== target && current.includes(label)) {
+      // Best-effort: a failed removal must not prevent applying the correct label.
+      await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name: label })
+        .catch(() => {});
+    }
+  }
+  if (!current.includes(target)) {
+    await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: [target] });
+  }
+}
+
+async function upsertReportComment(github, owner, repo, prNumber, body) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner, repo, issue_number: prNumber, per_page: 100,
+  });
+  const existing = comments.find(c => c.body && c.body.includes(MARKER));
+  if (existing) {
+    await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+  } else {
+    await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+// Runs triage end to end: collect → check → label → report.
+// Returns { verdict, findings } or null when triage is disabled.
+// Callers decide lifecycle consequences (waiting-on-* labels).
+async function runTriage({ github, owner, repo, pr, config, core }) {
+  const triageConfig = { ...DEFAULTS, ...(config.triage || {}) };
+  if (!triageConfig.enabled) return null;
+
+  const maintainers = config.maintainers || [];
+  const data = await collectTriageData(github, owner, repo, pr, triageConfig, maintainers);
+  const findings = runChecks(data);
+  const verdict = computeVerdict(findings);
+
+  await applyTriageLabel(github, owner, repo, pr, verdict);
+  await upsertReportComment(github, owner, repo, pr.number, renderReport({ verdict, findings, pr }));
+
+  core.info(`PR #${pr.number} triage verdict=${verdict} findings=[${findings.map(f => f.id).join(', ')}]`);
+  return { verdict, findings };
+}
+
+module.exports = {
+  runTriage,
+  runChecks,
+  computeVerdict,
+  renderReport,
+  extractLinkedIssueNumbers,
+  addedLines,
+  code,
+  applyTriageLabel,
+  upsertReportComment,
+  TRIAGE_LABELS,
+  TRIAGE_LABEL_DEFS,
+  MARKER,
+  DEFAULTS,
+};

--- a/.github/scripts/pr-triage.test.js
+++ b/.github/scripts/pr-triage.test.js
@@ -1,0 +1,415 @@
+// Tests for pr-triage.js — run with: node --test .github/scripts/
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const triage = require('./pr-triage.js');
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+function makePr(overrides = {}) {
+  return {
+    number: 42,
+    title: 'fix(storage): handle null artifact refs',
+    body: 'Fixes #100',
+    additions: 50,
+    deletions: 10,
+    labels: [],
+    user: { login: 'junior-dev' },
+    head: { sha: 'abcdef1234567890' },
+    base: { repo: { owner: { login: 'Apicurio' }, name: 'apicurio-registry' } },
+    ...overrides,
+  };
+}
+
+function makeCommit(message, parents = 1) {
+  return {
+    sha: 'c0ffee1234567890',
+    parents: Array(parents).fill({ sha: 'p' }),
+    commit: { message },
+  };
+}
+
+function signedCommit() {
+  return makeCommit('fix(storage): handle nulls\n\nSigned-off-by: Junior Dev <jr@example.com>');
+}
+
+function makeFile(filename, patch, overrides = {}) {
+  return { filename, patch, status: 'modified', additions: 1, deletions: 0, ...overrides };
+}
+
+function makeIssue(number, authorLogin, commentAuthors = []) {
+  return {
+    issue: { number, user: { login: authorLogin } },
+    comments: commentAuthors.map(login => ({ user: { login } })),
+  };
+}
+
+// A data object that produces zero findings.
+function cleanData(overrides = {}) {
+  return {
+    pr: makePr(),
+    commits: [signedCommit()],
+    files: [
+      makeFile('app/src/main/java/io/apicurio/registry/storage/Foo.java',
+        '+import java.util.List;\n+    doWork();'),
+      makeFile('app/src/test/java/io/apicurio/registry/storage/FooTest.java',
+        '+    assertEquals(3, counter);'),
+    ],
+    linkedIssues: [makeIssue(100, 'someone', ['carlesarnal'])],
+    openPrs: [],
+    config: { ...triage.DEFAULTS },
+    maintainers: ['carlesarnal', 'EricWittmann'],
+    ...overrides,
+  };
+}
+
+function findingIds(data) {
+  return triage.runChecks(data).map(f => f.id);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+test('addedLines extracts only added lines, without +++ header', () => {
+  const patch = '@@ -1,2 +1,3 @@\n context\n+added one\n-removed\n+++ not this\n+added two';
+  assert.deepEqual(triage.addedLines(patch), ['added one', 'added two']);
+});
+
+test('addedLines handles missing patch (binary/large files)', () => {
+  assert.deepEqual(triage.addedLines(undefined), []);
+});
+
+test('extractLinkedIssueNumbers finds short refs, URLs, and dedups', () => {
+  const body = 'Fixes #123 and relates to #456.\n' +
+    'See https://github.com/Apicurio/apicurio-registry/issues/123 too.';
+  assert.deepEqual(
+    triage.extractLinkedIssueNumbers(body, 'Apicurio', 'apicurio-registry'),
+    [123, 456]);
+});
+
+test('extractLinkedIssueNumbers handles null body', () => {
+  assert.deepEqual(triage.extractLinkedIssueNumbers(null, 'o', 'r'), []);
+});
+
+// ---------------------------------------------------------------------------
+// Clean PR → green
+// ---------------------------------------------------------------------------
+
+test('clean PR produces no findings and a green verdict', () => {
+  const findings = triage.runChecks(cleanData());
+  assert.deepEqual(findings, []);
+  assert.equal(triage.computeVerdict(findings), 'green');
+});
+
+// ---------------------------------------------------------------------------
+// Red checks
+// ---------------------------------------------------------------------------
+
+test('commit without Signed-off-by is a red dco-missing finding', () => {
+  const findings = triage.runChecks(cleanData({ commits: [makeCommit('fix: no signoff')] }));
+  const dco = findings.find(f => f.id === 'dco-missing');
+  assert.ok(dco, 'dco-missing finding expected');
+  assert.equal(dco.severity, 'red');
+  assert.ok(dco.detail.includes('Signed-off-by'));
+  assert.ok(dco.detail.includes('c0ffee1'), 'detail names the offending sha');
+});
+
+test('merge commits are exempt from DCO', () => {
+  const ids = findingIds(cleanData({
+    commits: [signedCommit(), makeCommit('Merge branch main', 2)],
+  }));
+  assert.ok(!ids.includes('dco-missing'));
+});
+
+test('missing linked issue is red when required', () => {
+  const ids = findingIds(cleanData({ pr: makePr({ body: 'trust me' }), linkedIssues: [] }));
+  assert.ok(ids.includes('no-linked-issue'));
+});
+
+test('missing linked issue is ignored when not required', () => {
+  const data = cleanData({ pr: makePr({ body: '' }), linkedIssues: [] });
+  data.config.require_linked_issue = false;
+  assert.ok(!findingIds(data).includes('no-linked-issue'));
+});
+
+test('linked issue without maintainer comment is red', () => {
+  const findings = triage.runChecks(cleanData({
+    linkedIssues: [makeIssue(100, 'someone', ['other-user'])],
+  }));
+  const f = findings.find(x => x.id === 'issue-not-approved');
+  assert.ok(f, 'issue-not-approved finding expected');
+  assert.equal(f.severity, 'red');
+  assert.ok(f.detail.includes('#100'), 'detail names the issue');
+});
+
+test('issue authored by a maintainer counts as approved', () => {
+  const ids = findingIds(cleanData({
+    linkedIssues: [makeIssue(100, 'EricWittmann', [])],
+  }));
+  assert.ok(!ids.includes('issue-not-approved'));
+});
+
+test('files under target/ or binaries are red', () => {
+  for (const name of ['app/target/generated/Foo.java', 'lib/thing.jar']) {
+    const data = cleanData();
+    data.files.push(makeFile(name, undefined));
+    assert.ok(findingIds(data).includes('generated-files'), name);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Yellow checks
+// ---------------------------------------------------------------------------
+
+test('main code without test changes is yellow tests-missing', () => {
+  const data = cleanData();
+  data.files = [makeFile('app/src/main/java/Foo.java', '+    newCodePath();')];
+  assert.ok(findingIds(data).includes('tests-missing'));
+});
+
+test('integration-tests changes count as tests', () => {
+  const data = cleanData();
+  data.files = [
+    makeFile('app/src/main/java/Foo.java', '+    newCodePath();'),
+    makeFile('integration-tests/src/test/java/FooIT.java', '+    check();'),
+  ];
+  assert.ok(!findingIds(data).includes('tests-missing'));
+});
+
+test('star import added is yellow', () => {
+  const data = cleanData();
+  data.files.push(makeFile('app/src/main/java/Bar.java', '+import java.util.*;'));
+  assert.ok(findingIds(data).includes('star-imports'));
+});
+
+test('config property outside allowed prefixes is yellow', () => {
+  const data = cleanData();
+  data.files.push(makeFile('app/src/main/java/Cfg.java',
+    '+    @ConfigProperty(name = "myfeature.enabled", defaultValue = "false")'));
+  assert.ok(findingIds(data).includes('config-prefix'));
+});
+
+test('apicurio.* and quarkus.* config properties are allowed', () => {
+  const data = cleanData();
+  data.files.push(makeFile('app/src/main/java/Cfg.java',
+    '+    @ConfigProperty(name = "apicurio.rest.enabled")\n' +
+    '+    @ConfigProperty(name = "quarkus.http.port")'));
+  assert.ok(!findingIds(data).includes('config-prefix'));
+});
+
+test('license header in new file is yellow', () => {
+  const data = cleanData();
+  data.files.push(makeFile('app/src/main/java/New.java',
+    '+ * Licensed under the Apache License, Version 2.0', { status: 'added' }));
+  assert.ok(findingIds(data).includes('license-headers'));
+});
+
+test('license header in pre-existing file is not flagged', () => {
+  const data = cleanData();
+  data.files.push(makeFile('app/src/main/java/Old.java',
+    '+ * Licensed under the Apache License, Version 2.0', { status: 'modified' }));
+  assert.ok(!findingIds(data).includes('license-headers'));
+});
+
+test('toLowerCase without Locale is yellow; with Locale is fine', () => {
+  const bad = cleanData();
+  bad.files.push(makeFile('app/src/main/java/A.java', '+    s.toLowerCase();'));
+  assert.ok(findingIds(bad).includes('locale-missing'));
+
+  const good = cleanData();
+  good.files.push(makeFile('app/src/main/java/A.java', '+    s.toLowerCase(Locale.ROOT);'));
+  assert.ok(!findingIds(good).includes('locale-missing'));
+});
+
+test('synchronized in Mutiny file is yellow; in plain file is not', () => {
+  const bad = cleanData();
+  bad.files.push(makeFile('app/src/main/java/R.java',
+    '+import io.smallrye.mutiny.Uni;\n+    synchronized (lock) {'));
+  assert.ok(findingIds(bad).includes('synchronized-reactive'));
+
+  const good = cleanData();
+  good.files.push(makeFile('app/src/main/java/P.java', '+    synchronized (lock) {'));
+  assert.ok(!findingIds(good).includes('synchronized-reactive'));
+});
+
+test('tab characters in java file is yellow', () => {
+  const data = cleanData();
+  data.files.push(makeFile('app/src/main/java/T.java', '+\tdoWork();'));
+  assert.ok(findingIds(data).includes('tab-characters'));
+});
+
+test('inline FQN in code is yellow, but import lines and comments are fine', () => {
+  const bad = cleanData();
+  bad.files.push(makeFile('app/src/main/java/F.java',
+    '+    throw new java.util.concurrent.TimeoutException();'));
+  assert.ok(findingIds(bad).includes('inline-fqn'));
+
+  const good = cleanData();
+  good.files.push(makeFile('app/src/main/java/F.java',
+    '+import java.util.concurrent.TimeoutException;\n+// see java.util.concurrent.TimeoutException'));
+  assert.ok(!findingIds(good).includes('inline-fqn'));
+});
+
+test('non-conventional PR title is yellow and quoted in the detail', () => {
+  const findings = triage.runChecks(cleanData({ pr: makePr({ title: 'Fixed the bug' }) }));
+  const f = findings.find(x => x.id === 'title-format');
+  assert.ok(f, 'title-format finding expected');
+  assert.equal(f.severity, 'yellow');
+  assert.ok(f.detail.includes('Fixed the bug'));
+});
+
+test('conventional titles with scope, without scope, and breaking marker pass', () => {
+  for (const title of ['feat(ui): add search', 'fix: null check', 'refactor(storage/sql)!: split dao']) {
+    const ids = findingIds(cleanData({ pr: makePr({ title }) }));
+    assert.ok(!ids.includes('title-format'), title);
+  }
+});
+
+test('diff above max_diff_lines is yellow', () => {
+  const ids = findingIds(cleanData({ pr: makePr({ additions: 4000, deletions: 100 }) }));
+  assert.ok(ids.includes('oversized'));
+});
+
+test('another open PR referencing the same issue is yellow', () => {
+  const ids = findingIds(cleanData({
+    openPrs: [{ number: 41, body: 'Fixes #100' }, { number: 42, body: 'Fixes #100' }],
+  }));
+  assert.ok(ids.includes('overlapping-pr'));
+});
+
+test('overlap detection also matches full issue URLs', () => {
+  const ids = findingIds(cleanData({
+    openPrs: [{ number: 41, body: 'See https://github.com/Apicurio/apicurio-registry/issues/100' }],
+  }));
+  assert.ok(ids.includes('overlapping-pr'));
+});
+
+test('own PR and unrelated PRs do not count as overlap', () => {
+  const ids = findingIds(cleanData({
+    openPrs: [{ number: 42, body: 'Fixes #100' }, { number: 43, body: 'Fixes #999' }],
+  }));
+  assert.ok(!ids.includes('overlapping-pr'));
+});
+
+// ---------------------------------------------------------------------------
+// Verdict aggregation and report rendering
+// ---------------------------------------------------------------------------
+
+test('verdict: red beats yellow beats green', () => {
+  assert.equal(triage.computeVerdict([]), 'green');
+  assert.equal(triage.computeVerdict([{ severity: 'yellow' }]), 'yellow');
+  assert.equal(triage.computeVerdict([{ severity: 'yellow' }, { severity: 'red' }]), 'red');
+});
+
+test('report contains marker, verdict, findings, and head sha', () => {
+  const findings = [
+    { id: 'dco-missing', severity: 'red', title: 'Missing DCO sign-off', detail: 'sign your commits' },
+    { id: 'star-imports', severity: 'yellow', title: 'Star imports added', detail: 'be explicit' },
+  ];
+  const body = triage.renderReport({ verdict: 'red', findings, pr: makePr() });
+  assert.ok(body.includes(triage.MARKER));
+  assert.ok(body.includes('RED'));
+  assert.ok(body.includes('Blocking'));
+  assert.ok(body.includes('Missing DCO sign-off'));
+  assert.ok(body.includes('Should fix'));
+  assert.ok(body.includes('abcdef1'));
+});
+
+// ---------------------------------------------------------------------------
+// Markdown injection hardening (report runs under pull_request_target)
+// ---------------------------------------------------------------------------
+
+test('code() strips backticks and newlines and truncates', () => {
+  assert.equal(triage.code('safe.java'), 'safe.java');
+  assert.equal(triage.code('evil`![x](https://evil)`\nrest'), 'evil![x](https://evil)rest');
+  assert.equal(triage.code(null), '');
+  assert.equal(triage.code('a'.repeat(500)).length, 200);
+});
+
+test('malicious PR title cannot break out of the report code span', () => {
+  const title = 'pwn` — [click me](https://evil.example) `@maintainers do /accept';
+  const findings = triage.runChecks(cleanData({ pr: makePr({ title }) }));
+  const f = findings.find(x => x.id === 'title-format');
+  assert.ok(f, 'weird title should fail conventional format');
+  assert.ok(!f.detail.includes('`ick'), 'sanity');
+  assert.ok(!f.detail.includes('pwn`'), 'backticks must be stripped from the title');
+  assert.ok(f.detail.includes('pwn — [click me](https://evil.example) @maintainers do /accept'));
+});
+
+test('malicious filename with backticks is sanitized in finding details', () => {
+  const data = cleanData();
+  data.files.push(makeFile('app/src/main/java/evil`](x)`.java', '+import java.util.*;'));
+  const f = triage.runChecks(data).find(x => x.id === 'star-imports');
+  assert.ok(f, 'star-imports finding expected');
+  assert.ok(!f.detail.includes('evil`'), 'backticks must be stripped from filenames');
+});
+
+test('extractLinkedIssueNumbers escapes regex metacharacters in owner/repo', () => {
+  // A repo name with a dot must not act as a regex wildcard.
+  const body = 'https://github.com/o/a.b/issues/7 and https://github.com/o/aXb/issues/8';
+  assert.deepEqual(triage.extractLinkedIssueNumbers(body, 'o', 'a.b'), [7]);
+});
+
+// ---------------------------------------------------------------------------
+// Side effects with a fake github client
+// ---------------------------------------------------------------------------
+
+function fakeGithub({ labels = [], comments = [] } = {}) {
+  const calls = { addLabels: [], removeLabel: [], createLabel: [], createComment: [], updateComment: [] };
+  return {
+    calls,
+    // Mirrors octokit paginate's optional mapFn signature, including done().
+    paginate: async (fn, args, mapFn) => {
+      const r = await fn(args);
+      const data = r.data ?? r;
+      return mapFn ? mapFn({ data }, () => {}) : data;
+    },
+    rest: {
+      issues: {
+        getLabel: async ({ name }) => {
+          if (labels.includes(name)) return { data: { name } };
+          const err = new Error('not found'); err.status = 404; throw err;
+        },
+        createLabel: async (args) => { calls.createLabel.push(args); return { data: {} }; },
+        addLabels: async (args) => { calls.addLabels.push(args); return { data: {} }; },
+        removeLabel: async (args) => { calls.removeLabel.push(args); return { data: {} }; },
+        listComments: async () => ({ data: comments }),
+        createComment: async (args) => { calls.createComment.push(args); return { data: {} }; },
+        updateComment: async (args) => { calls.updateComment.push(args); return { data: {} }; },
+      },
+    },
+  };
+}
+
+test('applyTriageLabel swaps to the verdict label and creates it if missing', async () => {
+  const gh = fakeGithub({ labels: [] });
+  const pr = makePr({ labels: [{ name: 'triage/red' }] });
+  await triage.applyTriageLabel(gh, 'o', 'r', pr, 'green');
+  assert.equal(gh.calls.createLabel[0].name, 'triage/green');
+  assert.equal(gh.calls.removeLabel[0].name, 'triage/red');
+  assert.deepEqual(gh.calls.addLabels[0].labels, ['triage/green']);
+});
+
+test('applyTriageLabel is idempotent when label already applied', async () => {
+  const gh = fakeGithub({ labels: ['triage/green'] });
+  const pr = makePr({ labels: [{ name: 'triage/green' }] });
+  await triage.applyTriageLabel(gh, 'o', 'r', pr, 'green');
+  assert.equal(gh.calls.addLabels.length, 0);
+  assert.equal(gh.calls.removeLabel.length, 0);
+});
+
+test('upsertReportComment creates on first run, updates thereafter', async () => {
+  const fresh = fakeGithub({ comments: [{ id: 1, body: 'welcome!' }] });
+  await triage.upsertReportComment(fresh, 'o', 'r', 42, `${triage.MARKER}\nreport`);
+  assert.equal(fresh.calls.createComment.length, 1);
+
+  const existing = fakeGithub({
+    comments: [{ id: 1, body: 'welcome!' }, { id: 2, body: `${triage.MARKER}\nold report` }],
+  });
+  await triage.upsertReportComment(existing, 'o', 'r', 42, `${triage.MARKER}\nnew report`);
+  assert.equal(existing.calls.createComment.length, 0);
+  assert.equal(existing.calls.updateComment[0].comment_id, 2);
+});

--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -164,7 +164,7 @@ jobs:
       github.event_name == 'pull_request_target' &&
       (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
       github.event.sender.login != 'github-actions[bot]' &&
-      (startsWith(github.event.label.name, 'lifecycle/') || startsWith(github.event.label.name, 'orchestrator/'))
+      (startsWith(github.event.label.name, 'lifecycle/') || startsWith(github.event.label.name, 'orchestrator/') || startsWith(github.event.label.name, 'triage/'))
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -294,6 +294,11 @@ jobs:
       - name: Verify unit test shard partition
         run: python3 .github/scripts/verify-test-shards.py
 
+      # Orchestrator/triage scripts run with repo write permissions under
+      # pull_request_target — their logic must be tested before merge.
+      - name: Test PR lifecycle scripts
+        run: node --test .github/scripts/pr-triage.test.js
+
       - name: Verify docs generation
         run: |
           if [ -n "$(git status --untracked-files=no --porcelain docs)" ]; then

--- a/app/src/test/resources/io/apicurio/registry/serde/AvroSchemaB.avsc
+++ b/app/src/test/resources/io/apicurio/registry/serde/AvroSchemaB.avsc
@@ -28,20 +28,14 @@
       "name": "mapTest",
       "type": {
         "type": "map",
-        "values": {
-          "name": "schemaFMapValue",
-          "type": "com.kubetrade.schema.trade.AvroSchemaF"
-        }
+        "values": "com.kubetrade.schema.trade.AvroSchemaF"
       }
     },
     {
       "name": "arrayTest",
       "type": {
         "type": "array",
-        "items": {
-          "name": "schemaFArrayValue",
-          "type": "com.kubetrade.schema.trade.AvroSchemaF"
-        }
+        "items": "com.kubetrade.schema.trade.AvroSchemaF"
       }
     },
     {


### PR DESCRIPTION
## What

Adds a deterministic PR triage splitter to the lifecycle orchestrator. When an external contributor opens a PR (and on every push, or on demand with `/triage`), the orchestrator now runs the machine-checkable items from the Contributor Checklist against PR metadata and patch text fetched via the GitHub API, and:

- applies a `triage/green`, `triage/yellow`, or `triage/red` label,
- upserts a single report comment telling the author exactly what to fix and how,
- routes the PR: **red** → `lifecycle/waiting-on-author` (existing accelerated stale timers then nudge after 4d and close after 7d if the author never engages), **green/yellow** → `lifecycle/waiting-on-maintainer`.

### Checks

| Severity | Check |
|---|---|
| 🔴 red (blocking) | missing DCO sign-off, no linked issue, linked issue without maintainer approval, generated/binary files in diff |
| 🟡 yellow (should fix) | no test changes for main code, star imports, config property outside `apicurio.*`, per-file license headers, `toUpperCase/toLowerCase` without `Locale`, `synchronized` in Mutiny files, tabs, inline FQNs, non-conventional title, oversized diff, overlapping open PR |

## Why

Drive-by contributions have grown much faster than maintainer triage capacity. Most of the rejected ones fail the same mechanical checklist items — DCO, no approved issue, no tests — which today are only caught after a maintainer spends time reading the PR. Splitting the queue deterministically means:

- maintainer attention goes only to PRs that are actually reviewable (`triage/green|yellow` + `waiting-on-maintainer`),
- authors of red PRs get immediate, actionable feedback and a self-service `/triage` re-check instead of waiting days for a human to say "please sign your commits",
- abandoned bad PRs self-close through the existing stale timers with zero maintainer touch,
- external orchestration (e.g. AI review tooling) can route on the `triage/*` labels instead of re-judging raw events — red is ignored, green/yellow proceeds to review.

## Security

The workflow runs under `pull_request_target` with write permissions, so the triage module analyzes patch **text** and metadata only — it never checks out or executes PR code. Attacker-controlled text (titles, filenames, config names) is sanitized before being embedded in the report comment, regexes over patch text use bounded quantifiers, file pagination early-exits at the cap, and `triage/*` labels are protected by the existing label guard (bot-managed only).

## Testing

- 38 `node:test` unit tests covering every check (positive + negative), verdict aggregation, report rendering, label/comment side effects, and markdown-injection hardening.
- Wired into the Verify `lint-and-validate` job so the suite runs on every PR.
- Docs updated in `.github/PR_LIFECYCLE.md` (verdict table, `/triage` command, maintainer flow).
