### PR TITLE
fix(build): use fully qualified type name in Avro test schema for 1.12.2 compatibility

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -582,6 +582,8 @@
             <project.build.directory>${project.build.directory}</project.build.directory>
             <!-- Prevent OTel SPI conflict between Quarkus ContextStorageProvider and SDK testing -->
             <io.opentelemetry.context.contextStorageProvider>default</io.opentelemetry.context.contextStorageProvider>
+            <!-- Avro 1.12.2 rejects classes not on the trusted list during reflection-based serde -->
+            <org.apache.avro.SERIALIZABLE_PACKAGES>ch.mobi.lead.leadfall,com.kubetrade.schema.trade,io.apicurio.registry.support</org.apache.avro.SERIALIZABLE_PACKAGES>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/ConfluentClientTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/ConfluentClientTest.java
@@ -926,8 +926,7 @@ public class ConfluentClientTest extends AbstractResourceTestBase {
                     "type" : "long"
                   }, {
                     "name" : "currency",
-                    "type" : {
-                      "type" : "myavro.currencies.Currency"    }
+                    "type" : "myavro.currencies.Currency"
                   }, {
                     "name" : "amount",
                     "type" : "double"
@@ -944,8 +943,7 @@ public class ConfluentClientTest extends AbstractResourceTestBase {
                     "type" : "long"
                   }, {
                     "name" : "currency",
-                    "type" : {
-                      "type" : "myavro.currencies.Currency"    }
+                    "type" : "myavro.currencies.Currency"
                   }, {
                     "name" : "updatedValue",
                     "type" : "double"

--- a/app/src/test/resources/io/apicurio/registry/serde/AvroSchemaB.avsc
+++ b/app/src/test/resources/io/apicurio/registry/serde/AvroSchemaB.avsc
@@ -28,20 +28,14 @@
       "name": "mapTest",
       "type": {
         "type": "map",
-        "values": {
-          "name": "schemaFMapValue",
-          "type": "com.kubetrade.schema.trade.AvroSchemaF"
-        }
+        "values": "com.kubetrade.schema.trade.AvroSchemaF"
       }
     },
     {
       "name": "arrayTest",
       "type": {
         "type": "array",
-        "items": {
-          "name": "schemaFArrayValue",
-          "type": "com.kubetrade.schema.trade.AvroSchemaF"
-        }
+        "items": "com.kubetrade.schema.trade.AvroSchemaF"
       }
     },
     {

--- a/app/src/test/resources/io/apicurio/registry/serde/LeadFallErstellen.avsc
+++ b/app/src/test/resources/io/apicurio/registry/serde/LeadFallErstellen.avsc
@@ -59,7 +59,7 @@
             "fields": [
               {
                 "name": "aufgabeTyp",
-                "type": "FdtCodeArt"
+                "type": "ch.mobi.lead.leadfall.FdtCodeArt"
               }
             ]
           }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -213,6 +213,8 @@
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <maven.home>${maven.home}</maven.home>
             <groups>${groups}</groups>
+            <!-- Avro 1.12.2 requires reflection serde classes/packages to be trusted explicitly. -->
+            <org.apache.avro.SERIALIZABLE_PACKAGES>io.apicurio.tests.common.serdes</org.apache.avro.SERIALIZABLE_PACKAGES>
           </systemPropertyVariables>
         </configuration>
         <executions>


### PR DESCRIPTION
## What

Hotfix extracted from #9654 (authored by @jsenko) so main goes green without waiting for the operator feature work.

Avro 1.12.2 (bumped in #9649) is stricter about named type references in schemas compiled by `avro-maven-plugin`:

- `LeadFallErstellen.avsc` referenced the inline-defined type `FdtCodeArt` by short name — 1.12.2 rejects this; use the fully qualified name.
- `AvroSchemaB.avsc` wrapped map values / array items in a `{name, type}` object — 1.12.2 rejects the wrapper; reference `com.kubetrade.schema.trade.AvroSchemaF` directly.
- Surefire now sets `org.apache.avro.SERIALIZABLE_PACKAGES` for the test packages, since 1.12.2 rejects classes not on the trusted list during reflection-based serde.

## Why

Every CI run on main fails at `avro-maven-plugin:1.12.2:schema` since #9649 merged, which blocks the Build job and the Verification Gate for **all** open PRs. The fix already exists inside #9654 but is coupled to an unrelated operator feature; this PR carries only the build fix (cherry-picked with `-x`, original authorship preserved).

## Testing

Verified locally on top of current main (`c4ac25963b`): `./mvnw generate-sources -pl app -am` succeeds and all Avro test classes (`AvroSchemaA-F`, `LeadFallErstellen` tree) are generated. Once merged, #9654 should rebase to drop its copy of the commit.