### PR TITLE
fix(build): produce schema-util-common test-jar earlier for parallel builds

### DIFF
--- a/schema-util/common/pom.xml
+++ b/schema-util/common/pom.xml
@@ -97,6 +97,7 @@
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>
+            <phase>process-test-classes</phase>
             <goals>
               <goal>test-jar</goal>
             </goals>


### PR DESCRIPTION
## Summary

- Move `maven-jar-plugin` `test-jar` goal from default `package` phase to `process-test-classes` in `schema-util/common`

## Problem

The parallel build (`-T 0.5C`) introduced a race condition: `schema-util/json`'s `test-compile` phase needs the test-jar from `schema-util/common`, but Maven's reactor doesn't always consider test-jar dependencies for build ordering. When `schema-util/json` starts test-compile before `schema-util/common` reaches its `package` phase, compilation fails:

```
cannot find symbol: io.apicurio.registry.rules.compatibility.CompatibilityTestExecutor
```

This breaks the `Build Java Application (no tests)` CI job on all PRs.

## Fix

Bind the `test-jar` goal to `process-test-classes` (runs right after test compilation) instead of `package`. This ensures the test-jar is available before any downstream module's test-compile starts.