### PR TITLE
feat(federation): prototype federated agent search fan-out

### DIFF
--- a/app/src/main/java/io/apicurio/registry/federation/AgentResultFilter.java
+++ b/app/src/main/java/io/apicurio/registry/federation/AgentResultFilter.java
@@ -1,0 +1,83 @@
+package io.apicurio.registry.federation;
+
+import io.apicurio.registry.rest.v3.beans.AgentCapabilities;
+import io.apicurio.registry.rest.v3.beans.AgentSearchResult;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Applies the structured agent filters locally.
+ *
+ * <p>Needed because those filters map to {@code SearchFilterType.structure}, which is handled only
+ * by {@code ElasticsearchSearchService}. On the SQL path the type falls through to the default case
+ * in {@code SqlSearchRepository} and throws {@code RegistryStorageException}, so a peer backed by
+ * SQL, KafkaSQL or in-memory storage cannot service a skill or capability filter at all (#8058).
+ *
+ * <p>Rather than dropping such a peer from the results, the coordinator re-queries it without the
+ * structured filters and applies them here. The result set is identical; only the place the
+ * filtering happens differs, and the source is reported as
+ * {@link PeerSearchOutcome.Status#DEGRADED} so the caller knows.
+ */
+@ApplicationScoped
+public class AgentResultFilter {
+
+    /**
+     * Keeps only the agents that satisfy every requested skill and capability.
+     */
+    public List<AgentSearchResult> apply(List<AgentSearchResult> agents, List<String> skills,
+            List<String> capabilities) {
+        return agents.stream()
+                .filter(agent -> matchesSkills(agent, skills))
+                .filter(agent -> matchesCapabilities(agent, capabilities))
+                .toList();
+    }
+
+    private boolean matchesSkills(AgentSearchResult agent, List<String> required) {
+        if (required == null || required.isEmpty()) {
+            return true;
+        }
+        List<String> declared = agent.getSkills();
+        if (declared == null) {
+            return false;
+        }
+        return declared.containsAll(required);
+    }
+
+    /**
+     * Capability filters arrive as {@code name} or {@code name:true} / {@code name:false}, matching
+     * the parsing the local search endpoint already does.
+     */
+    private boolean matchesCapabilities(AgentSearchResult agent, List<String> required) {
+        if (required == null || required.isEmpty()) {
+            return true;
+        }
+        AgentCapabilities declared = agent.getCapabilities();
+        for (String capability : required) {
+            String[] parts = capability.split(":", 2);
+            String key = parts[0].toLowerCase(Locale.ROOT);
+            boolean wanted = parts.length < 2 || !"false".equals(parts[1]);
+            if (valueOf(declared, key) != wanted) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * SPIKE: only the capabilities carried on {@code AgentSearchResult} can be evaluated here.
+     * A full implementation would need the stored Agent Card, since arbitrary boolean capabilities
+     * and {@code capabilities.extensions} never reach this bean.
+     */
+    private boolean valueOf(AgentCapabilities capabilities, String key) {
+        if (capabilities == null) {
+            return false;
+        }
+        return switch (key) {
+            case "streaming" -> Boolean.TRUE.equals(capabilities.getStreaming());
+            case "pushnotifications" -> Boolean.TRUE.equals(capabilities.getPushNotifications());
+            default -> false;
+        };
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/federation/FederatedAgentSearchService.java
+++ b/app/src/main/java/io/apicurio/registry/federation/FederatedAgentSearchService.java
@@ -1,0 +1,225 @@
+package io.apicurio.registry.federation;
+
+import io.apicurio.registry.rest.v3.beans.AgentInterface;
+import io.apicurio.registry.rest.v3.beans.AgentSearchResult;
+import io.apicurio.registry.rest.v3.beans.AgentSearchResults;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Fans an agent search out across the local registry and every configured peer, then merges the
+ * results.
+ *
+ * <p>Peers are queried in parallel on a bounded pool and awaited against a single deadline. A peer
+ * that fails or does not answer in time becomes a non-OK {@link PeerSearchOutcome} rather than an
+ * exception, so one unreachable registry degrades the result instead of failing the request.
+ *
+ * <p>SPIKE: peers come from static configuration. There is no persistence, no management API and
+ * no UI. The purpose is to exercise the merge, timeout and deduplication semantics.
+ */
+@ApplicationScoped
+public class FederatedAgentSearchService {
+
+    private static final Logger log = LoggerFactory.getLogger(FederatedAgentSearchService.class);
+
+    private static final String LOCAL_SOURCE = "local";
+    private static final int POOL_SIZE = 8;
+
+    @Inject
+    FederationConfig config;
+
+    @Inject
+    PeerClient peerClient;
+
+    @Inject
+    PeerCircuitBreaker breaker;
+
+    @Inject
+    AgentResultFilter resultFilter;
+
+    /**
+     * Bounded on purpose. An unbounded pool would allow (peers x concurrent searches) threads,
+     * which is a denial of service against ourselves under load.
+     */
+    private final ExecutorService pool = Executors.newFixedThreadPool(POOL_SIZE);
+
+    @PreDestroy
+    void shutdown() {
+        pool.shutdownNow();
+    }
+
+    /**
+     * Merges already-computed local results with results from every configured peer.
+     *
+     * @param localResults results the local registry produced for this query
+     * @param offset       offset into the merged result set
+     * @param limit        page size of the merged result set
+     */
+    public FederatedSearchResponse search(List<AgentSearchResult> localResults, String name,
+            List<String> skills, List<String> capabilities, int offset, int limit) {
+
+        List<PeerSearchOutcome> outcomes = new ArrayList<>();
+
+        // Local is added first so that, on a deduplication tie, the local registry wins. Your own
+        // registry is authoritative for agents it also holds.
+        outcomes.add(PeerSearchOutcome.ok(LOCAL_SOURCE, localResults));
+
+        List<String> peers = config.getPeers();
+        if (!peers.isEmpty()) {
+            outcomes.addAll(queryPeers(peers, name, skills, capabilities, offset, limit));
+        }
+
+        List<AgentSearchResult> merged = mergeAndPage(outcomes, offset, limit);
+        return new FederatedSearchResponse(merged, outcomes);
+    }
+
+    private List<PeerSearchOutcome> queryPeers(List<String> peers, String name, List<String> skills,
+            List<String> capabilities, int offset, int limit) {
+
+        List<CompletableFuture<PeerSearchOutcome>> futures = new ArrayList<>();
+        for (String peer : peers) {
+            futures.add(CompletableFuture.supplyAsync(
+                    () -> queryOnePeer(peer, name, skills, capabilities, offset, limit), pool));
+        }
+
+        // allOf alone completes only when every future completes, which would let one dead peer
+        // hold the whole response. completeOnTimeout puts a ceiling on the wait; anything still
+        // unfinished is reported as a timeout below.
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .completeOnTimeout(null, config.getTimeoutMs(), TimeUnit.MILLISECONDS)
+                .join();
+
+        List<PeerSearchOutcome> outcomes = new ArrayList<>();
+        for (int i = 0; i < futures.size(); i++) {
+            CompletableFuture<PeerSearchOutcome> future = futures.get(i);
+            if (future.isDone() && !future.isCompletedExceptionally()) {
+                outcomes.add(future.join());
+            } else {
+                future.cancel(true);
+                outcomes.add(PeerSearchOutcome.timeout(peers.get(i)));
+            }
+        }
+        return outcomes;
+    }
+
+    private PeerSearchOutcome queryOnePeer(String peer, String name, List<String> skills,
+            List<String> capabilities, int offset, int limit) {
+
+        // Checked per peer rather than per method. A single dead registry must not stop calls to
+        // healthy ones, which is what a method-scoped breaker would do.
+        if (breaker.isOpen(peer)) {
+            log.debug("Skipping peer {}: circuit open", peer);
+            return PeerSearchOutcome.circuitOpen(peer);
+        }
+
+        boolean structured = hasStructuredFilters(skills, capabilities);
+
+        try {
+            AgentSearchResults results =
+                    peerClient.search(peer, name, skills, capabilities, offset, limit);
+            breaker.recordSuccess(peer);
+            return PeerSearchOutcome.ok(peer, agentsOf(results));
+        } catch (Exception e) {
+            if (structured) {
+                // The peer may simply be unable to apply structured filters: they map to
+                // SearchFilterType.structure, which only ElasticsearchSearchService handles, and
+                // SqlSearchRepository throws on it (#8058). Retry without them and filter here.
+                return retryDegraded(peer, name, skills, capabilities, offset, limit, e);
+            }
+            breaker.recordFailure(peer);
+            log.warn("Federated search failed for peer {}: {}", peer, e.getMessage());
+            return PeerSearchOutcome.error(peer);
+        }
+    }
+
+    private PeerSearchOutcome retryDegraded(String peer, String name, List<String> skills,
+            List<String> capabilities, int offset, int limit, Exception original) {
+        try {
+            AgentSearchResults results =
+                    peerClient.search(peer, name, null, null, offset, limit);
+            List<AgentSearchResult> filtered =
+                    resultFilter.apply(agentsOf(results), skills, capabilities);
+            breaker.recordSuccess(peer);
+            log.info("Peer {} could not apply structured filters, filtered locally instead", peer);
+            return PeerSearchOutcome.degraded(peer, filtered);
+        } catch (Exception retryFailure) {
+            breaker.recordFailure(peer);
+            log.warn("Federated search failed for peer {}: {} (unfiltered retry also failed: {})",
+                    peer, original.getMessage(), retryFailure.getMessage());
+            return PeerSearchOutcome.error(peer);
+        }
+    }
+
+    private boolean hasStructuredFilters(List<String> skills, List<String> capabilities) {
+        return (skills != null && !skills.isEmpty())
+                || (capabilities != null && !capabilities.isEmpty());
+    }
+
+    private List<AgentSearchResult> agentsOf(AgentSearchResults results) {
+        return results.getAgents() == null ? List.of() : results.getAgents();
+    }
+
+    /**
+     * Concatenates every source, removes duplicates, sorts, then applies the requested page.
+     *
+     * <p>Paging happens here rather than at each source, because a source numbers only its own
+     * results. Peer position N is not position N of the merged set, which is why each peer was
+     * asked for its first {@code offset + limit} rows instead of its own slice.
+     */
+    private List<AgentSearchResult> mergeAndPage(List<PeerSearchOutcome> outcomes, int offset, int limit) {
+        Map<String, AgentSearchResult> deduped = new LinkedHashMap<>();
+
+        for (PeerSearchOutcome outcome : outcomes) {
+            for (AgentSearchResult agent : outcome.results()) {
+                deduped.putIfAbsent(identityOf(agent, outcome.source()), agent);
+            }
+        }
+
+        List<AgentSearchResult> merged = new ArrayList<>(deduped.values());
+
+        // artifactId is a tiebreaker, not decoration. Two agents sharing a createdOn have undefined
+        // relative order without it, and an unstable sort makes an item appear on two pages or none.
+        merged.sort(Comparator
+                .comparing(AgentSearchResult::getCreatedOn,
+                        Comparator.nullsLast(Comparator.reverseOrder()))
+                .thenComparing(AgentSearchResult::getArtifactId,
+                        Comparator.nullsLast(Comparator.naturalOrder())));
+
+        int from = Math.min(offset, merged.size());
+        int to = Math.min(from + limit, merged.size());
+        return merged.subList(from, to);
+    }
+
+    /**
+     * Identity of an agent across registries.
+     *
+     * <p>Keyed on the first declared interface URL, because an agent is defined by where it answers
+     * rather than by which catalogue lists it. Two registries may both hold
+     * {@code default/translator} for entirely different agents, so group and artifact ID are not
+     * globally unique. Falls back to source-qualified coordinates when no interface is declared,
+     * which can never collapse two distinct agents.
+     */
+    private String identityOf(AgentSearchResult agent, String source) {
+        List<AgentInterface> interfaces = agent.getSupportedInterfaces();
+        if (interfaces != null && !interfaces.isEmpty()) {
+            String url = interfaces.get(0).getUrl();
+            if (url != null && !url.isBlank()) {
+                return "url:" + url;
+            }
+        }
+        return "ga:" + source + "/" + agent.getGroupId() + "/" + agent.getArtifactId();
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/federation/FederatedSearchResponse.java
+++ b/app/src/main/java/io/apicurio/registry/federation/FederatedSearchResponse.java
@@ -1,0 +1,16 @@
+package io.apicurio.registry.federation;
+
+import io.apicurio.registry.rest.v3.beans.AgentSearchResult;
+
+import java.util.List;
+
+/**
+ * The merged outcome of a federated agent search.
+ *
+ * <p>{@code sources} carries one entry per source consulted, including the local registry, so a
+ * caller can tell the difference between "no agent matched" and "the registry holding it did not
+ * answer". A single global count is deliberately absent: the local total understates, and summing
+ * peer totals double-counts duplicates, so per-source counts are reported instead.
+ */
+public record FederatedSearchResponse(List<AgentSearchResult> agents, List<PeerSearchOutcome> sources) {
+}

--- a/app/src/main/java/io/apicurio/registry/federation/FederationConfig.java
+++ b/app/src/main/java/io/apicurio/registry/federation/FederationConfig.java
@@ -1,0 +1,46 @@
+package io.apicurio.registry.federation;
+
+import io.apicurio.common.apps.config.Info;
+import jakarta.inject.Singleton;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_A2A;
+
+/**
+ * Configuration for federated agent discovery.
+ *
+ * <p>SPIKE: peers are supplied as a static list of base URLs. A real implementation stores them
+ * through the storage layer so they can be managed at runtime and survive across all storage
+ * variants.
+ */
+@Singleton
+public class FederationConfig {
+
+    @ConfigProperty(name = "apicurio.federation.enabled", defaultValue = "false")
+    @Info(category = CATEGORY_A2A, description = "Enable federated agent discovery across peer registries", availableSince = "3.3.2", experimental = true)
+    boolean enabled;
+
+    @ConfigProperty(name = "apicurio.federation.peers")
+    @Info(category = CATEGORY_A2A, description = "Comma separated base URLs of peer registries to federate agent searches across", availableSince = "3.3.2")
+    Optional<List<String>> peers;
+
+    @ConfigProperty(name = "apicurio.federation.timeout.ms", defaultValue = "2000")
+    @Info(category = CATEGORY_A2A, description = "Milliseconds to wait for peer registries before returning partial results", availableSince = "3.3.2")
+    long timeoutMs;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public List<String> getPeers() {
+        return peers.orElse(Collections.emptyList());
+    }
+
+    public long getTimeoutMs() {
+        return timeoutMs;
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/federation/PeerCircuitBreaker.java
+++ b/app/src/main/java/io/apicurio/registry/federation/PeerCircuitBreaker.java
@@ -1,0 +1,70 @@
+package io.apicurio.registry.federation;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A failure guard keyed by peer.
+ *
+ * <p>MicroProfile's {@code @CircuitBreaker} binds its state to the annotated <em>method</em>, not to
+ * the arguments. Placing it on a method that takes the peer URL as a parameter therefore trips one
+ * breaker shared by every peer: four failures against a single dead registry would start rejecting
+ * calls to healthy ones. This keeps one independent counter per peer instead.
+ *
+ * <p>SPIKE: a deliberately small implementation. Production should build per-peer guards through
+ * SmallRye's programmatic {@code FaultTolerance} API rather than hand-rolling the state machine.
+ */
+@ApplicationScoped
+public class PeerCircuitBreaker {
+
+    private static final int FAILURE_THRESHOLD = 4;
+    private static final long OPEN_DURATION_MS = 30_000L;
+
+    private final Map<String, State> states = new ConcurrentHashMap<>();
+
+    /**
+     * True when the peer should be skipped because it has failed repeatedly and the cool-off has
+     * not yet elapsed.
+     */
+    public boolean isOpen(String peer) {
+        State state = states.get(peer);
+        if (state == null) {
+            return false;
+        }
+        long openUntil = state.openUntil.get();
+        if (openUntil == 0L) {
+            return false;
+        }
+        if (System.currentTimeMillis() >= openUntil) {
+            // Cool-off elapsed. Half-open: allow the next call through to probe the peer.
+            state.openUntil.set(0L);
+            state.consecutiveFailures.set(0);
+            return false;
+        }
+        return true;
+    }
+
+    public void recordSuccess(String peer) {
+        State state = states.get(peer);
+        if (state != null) {
+            state.consecutiveFailures.set(0);
+            state.openUntil.set(0L);
+        }
+    }
+
+    public void recordFailure(String peer) {
+        State state = states.computeIfAbsent(peer, k -> new State());
+        if (state.consecutiveFailures.incrementAndGet() >= FAILURE_THRESHOLD) {
+            state.openUntil.set(System.currentTimeMillis() + OPEN_DURATION_MS);
+        }
+    }
+
+    private static final class State {
+        private final AtomicInteger consecutiveFailures = new AtomicInteger();
+        private final AtomicLong openUntil = new AtomicLong();
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/federation/PeerClient.java
+++ b/app/src/main/java/io/apicurio/registry/federation/PeerClient.java
@@ -1,0 +1,120 @@
+package io.apicurio.registry.federation;
+
+import io.apicurio.registry.rest.v3.beans.AgentSearchResults;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Calls a peer registry's agent discovery endpoint.
+ *
+ * <p>This is deliberately a separate CDI bean. {@link Timeout} and {@link CircuitBreaker} are
+ * interceptors, and an interceptor only fires when the call crosses a bean boundary. Inlining this
+ * method into the fan-out service would mean calling it as {@code this.search(...)}, which bypasses
+ * the proxy and silently disables both annotations.
+ */
+@ApplicationScoped
+public class PeerClient {
+
+    private static final Logger log = LoggerFactory.getLogger(PeerClient.class);
+
+    /**
+     * Marks a request as already being part of a federated search. A registry receiving this header
+     * serves only its own agents and does not fan out again, which makes federation non-transitive
+     * and stops two mutually-peered registries from recursing indefinitely.
+     */
+    public static final String FEDERATION_HEADER = "X-Apicurio-Federated";
+
+    @Inject
+    WebClient webClient;
+
+    /**
+     * Queries a peer for agents matching the given criteria.
+     *
+     * <p>Asks the peer for its first {@code offset + limit} results rather than for its own slice
+     * at {@code offset}. Each source numbers only its own results, so a peer's position N is not
+     * position N of the merged set. The caller applies the real offset after merging.
+     */
+    @Timeout(value = 5, unit = ChronoUnit.SECONDS)
+    public AgentSearchResults search(String peerUrl, String name, List<String> skills,
+            List<String> capabilities, int offset, int limit) throws PeerClientException {
+
+        String url = buildUrl(peerUrl, name, skills, capabilities, offset + limit);
+        log.debug("Federating agent search to peer: {}", url);
+
+        try {
+            // Redirects are not followed on purpose. The peer URL is validated when it is
+            // registered; honouring a redirect would let the peer send this request somewhere that
+            // was never validated, including link-local and internal addresses.
+            HttpRequest<Buffer> request = webClient.getAbs(url)
+                    .putHeader(FEDERATION_HEADER, "true")
+                    .putHeader("Accept", "application/json")
+                    .followRedirects(false);
+
+            HttpResponse<Buffer> response = request.send()
+                    .toCompletionStage().toCompletableFuture().get();
+
+            int status = response.statusCode();
+            if (status < 200 || status >= 300) {
+                throw new PeerClientException("Peer " + peerUrl + " returned HTTP " + status);
+            }
+
+            Buffer body = response.body();
+            if (body == null || body.length() == 0) {
+                throw new PeerClientException("Peer " + peerUrl + " returned an empty body");
+            }
+
+            return body.toJsonObject().mapTo(AgentSearchResults.class);
+
+        } catch (ExecutionException e) {
+            throw new PeerClientException("Failed to query peer " + peerUrl, e);
+        } catch (InterruptedException e) {
+            // Restore the interrupt flag so the caller can still observe the interruption.
+            Thread.currentThread().interrupt();
+            throw new PeerClientException("Interrupted while querying peer " + peerUrl, e);
+        }
+    }
+
+    private String buildUrl(String peerUrl, String name, List<String> skills,
+            List<String> capabilities, int fetchSize) {
+        StringBuilder url = new StringBuilder(trimTrailingSlash(peerUrl))
+                .append("/.well-known/agents?offset=0&limit=")
+                .append(fetchSize);
+
+        if (name != null && !name.isBlank()) {
+            url.append("&name=").append(encode(name));
+        }
+        appendRepeated(url, "skill", skills);
+        appendRepeated(url, "capability", capabilities);
+        return url.toString();
+    }
+
+    private void appendRepeated(StringBuilder url, String param, List<String> values) {
+        if (values == null) {
+            return;
+        }
+        for (String value : values) {
+            url.append("&").append(param).append("=").append(encode(value));
+        }
+    }
+
+    private String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private String trimTrailingSlash(String url) {
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/federation/PeerClientException.java
+++ b/app/src/main/java/io/apicurio/registry/federation/PeerClientException.java
@@ -1,0 +1,19 @@
+package io.apicurio.registry.federation;
+
+/**
+ * Raised when a peer registry cannot be queried. Callers convert this into a non-OK
+ * {@link PeerSearchOutcome} rather than propagating it, so one unreachable peer degrades the
+ * result instead of failing the request.
+ */
+public class PeerClientException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public PeerClientException(String message) {
+        super(message);
+    }
+
+    public PeerClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/federation/PeerSearchOutcome.java
+++ b/app/src/main/java/io/apicurio/registry/federation/PeerSearchOutcome.java
@@ -1,0 +1,49 @@
+package io.apicurio.registry.federation;
+
+import io.apicurio.registry.rest.v3.beans.AgentSearchResult;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The outcome of querying a single source (the local registry, or one peer).
+ *
+ * <p>A peer that fails or times out produces an outcome with a non-OK status and no results,
+ * rather than an exception. That is what allows the overall search to degrade instead of fail.
+ */
+public record PeerSearchOutcome(String source, Status status, List<AgentSearchResult> results) {
+
+    public enum Status {
+        /** Source answered, and applied the filters itself. */
+        OK,
+        /**
+         * Source could not apply the structured filters, so it returned its unfiltered list and the
+         * filters were applied here instead. The result set is the same; only the place the work
+         * happened differs.
+         */
+        DEGRADED,
+        TIMEOUT,
+        ERROR,
+        CIRCUIT_OPEN
+    }
+
+    public static PeerSearchOutcome ok(String source, List<AgentSearchResult> results) {
+        return new PeerSearchOutcome(source, Status.OK, results);
+    }
+
+    public static PeerSearchOutcome degraded(String source, List<AgentSearchResult> results) {
+        return new PeerSearchOutcome(source, Status.DEGRADED, results);
+    }
+
+    public static PeerSearchOutcome timeout(String source) {
+        return new PeerSearchOutcome(source, Status.TIMEOUT, Collections.emptyList());
+    }
+
+    public static PeerSearchOutcome error(String source) {
+        return new PeerSearchOutcome(source, Status.ERROR, Collections.emptyList());
+    }
+
+    public static PeerSearchOutcome circuitOpen(String source) {
+        return new PeerSearchOutcome(source, Status.CIRCUIT_OPEN, Collections.emptyList());
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -22,6 +22,11 @@ import io.apicurio.registry.mcptools.rest.beans.McpCompatibleToolsResults;
 import io.apicurio.registry.rest.v3.beans.McpToolSearchResult;
 import io.apicurio.registry.rest.v3.beans.McpToolSearchResults;
 import io.apicurio.registry.cdi.Current;
+import io.apicurio.registry.federation.FederatedAgentSearchService;
+import io.apicurio.registry.federation.FederatedSearchResponse;
+import io.apicurio.registry.federation.FederationConfig;
+import io.apicurio.registry.federation.PeerClient;
+import io.apicurio.registry.federation.PeerSearchOutcome;
 import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessCheck;
@@ -113,6 +118,12 @@ public class WellKnownResourceImpl implements WellKnownResource {
 
     @Inject
     AuthConfig authConfig;
+
+    @Inject
+    FederationConfig federationConfig;
+
+    @Inject
+    FederatedAgentSearchService federatedSearch;
 
     @Context
     HttpServletRequest request;
@@ -416,6 +427,12 @@ public class WellKnownResourceImpl implements WellKnownResource {
                     .build();
         }
 
+        // SPIKE: federated discovery. Skipped when this request is itself a federated call, which
+        // keeps federation non-transitive and stops mutually-peered registries from recursing.
+        if (federationConfig.isEnabled() && !isFederatedRequest()) {
+            return searchAgentsFederated(filters, name, skills, capabilities, safeOffset, safeLimit);
+        }
+
         ArtifactSearchResultsDto results = storage.searchArtifacts(
                 filters, OrderBy.createdOn, OrderDirection.desc, safeOffset, safeLimit, false);
 
@@ -427,6 +444,49 @@ public class WellKnownResourceImpl implements WellKnownResource {
         return AgentSearchResults.builder()
                 .count((int) results.getCount())
                 .agents(agents)
+                .build();
+    }
+
+    /**
+     * True when the incoming request is already part of a federated search.
+     */
+    private boolean isFederatedRequest() {
+        return Boolean.parseBoolean(request.getHeader(PeerClient.FEDERATION_HEADER));
+    }
+
+    /**
+     * Runs the local query and merges it with every configured peer.
+     *
+     * <p>The local side is queried from offset zero for {@code offset + limit} rows rather than for
+     * its own slice, for the same reason peers are: a source orders only its own results, so local
+     * position N is not position N of the merged set. Paging is applied after the merge.
+     */
+    private AgentSearchResults searchAgentsFederated(Set<SearchFilter> filters, String name,
+            List<String> skills, List<String> capabilities, int offset, int limit) {
+
+        int fetchSize = Math.min(offset + limit, MAX_VISIBILITY_FILTER_RESULTS);
+        ArtifactSearchResultsDto results = storage.searchArtifacts(
+                filters, OrderBy.createdOn, OrderDirection.desc, 0, fetchSize, false);
+
+        List<AgentSearchResult> localAgents = new ArrayList<>();
+        for (SearchedArtifactDto artifact : results.getArtifacts()) {
+            localAgents.add(convertToAgentSearchResult(artifact));
+        }
+
+        FederatedSearchResponse federated = federatedSearch.search(
+                localAgents, name, skills, capabilities, offset, limit);
+
+        // SPIKE: per-source status is logged rather than returned. Reporting it properly means
+        // adding a "sources" array to AgentSearchResults, which is an OpenAPI change and a
+        // regeneration of all four SDKs.
+        for (PeerSearchOutcome outcome : federated.sources()) {
+            log.info("Federated search source {}: {} ({} results)",
+                    outcome.source(), outcome.status(), outcome.results().size());
+        }
+
+        return AgentSearchResults.builder()
+                .count(federated.agents().size())
+                .agents(federated.agents())
                 .build();
     }
 


### PR DESCRIPTION
Read-time fan-out across peer registries: local storage plus every configured peer queried in parallel under a single deadline, merged and paged by the coordinator.

- bounded executor; allOf with a timeout ceiling, futures inspected individually so one dead peer cannot hold the response
- per-peer failure guard, since MicroProfile @CircuitBreaker binds its state to the annotated method rather than its arguments
- deduplication keyed on the declared interface URL, falling back to source-qualified coordinates; local wins on collision
- over-fetch of offset+limit per source, with paging applied after the merge, because a source orders only its own results
- degradation fallback for peers that cannot service structured filters (SqlSearchRepository throws on SearchFilterType.structure), retried unfiltered and filtered locally, reported as DEGRADED
- non-transitive federation via X-Apicurio-Federated, so mutually-peered registries cannot recurse
- redirects not followed, so a peer cannot redirect past URL validation

PROTOTYPE. Static peer configuration; no persistence, no management API, no UI, no tests. Built to explore the design questions in Apicurio/apicurio-registry#8424.