### PR TITLE
fix(build): replace maven-antrun-plugin with maven-resources-plugin for meta dir creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
     <version.assembly.plugin>3.7.1</version.assembly.plugin>
     <version.resources.plugin>3.3.1</version.resources.plugin>
     <version.clean.plugin>3.4.0</version.clean.plugin>
-    <version.maven-antrun.plugin>3.1.0</version.maven-antrun.plugin>
+
     <version.license-maven-plugin>2.7.1</version.license-maven-plugin>
     <version.exec-maven-plugin>3.6.3</version.exec-maven-plugin>
     <version.apicurio-codegen-plugin>1.2.11.Final</version.apicurio-codegen-plugin>
@@ -1321,18 +1321,24 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>${version.maven-antrun.plugin}</version>
+        <artifactId>maven-resources-plugin</artifactId>
         <executions>
           <execution>
-            <goals>
-              <goal>run</goal>
-            </goals>
+            <id>create-meta-dir</id>
             <phase>initialize</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
             <configuration>
-              <target>
-                <mkdir dir="${project.build.directory}/meta"/>
-              </target>
+              <outputDirectory>${project.build.directory}/meta</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}</directory>
+                  <excludes>
+                    <exclude>**</exclude>
+                  </excludes>
+                </resource>
+              </resources>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## Summary

Fixes a race condition in parallel Maven builds (`-T`) that causes `Build Java Application` CI jobs to fail with:

```
Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:3.1.0:run (default)
on project apicurio-registry-schema-util-iceberg: Error executing Ant tasks:
Cannot invoke "java.io.File.getPath()" because the return value of
"org.apache.maven.artifact.Artifact.getFile()" is null
```

### Root cause

The `maven-antrun-plugin` resolves the full project classpath (including test-scoped dependencies) during the `initialize` phase, even though its only task is `mkdir target/meta/`. In a parallel build with `-Daether.syncContext.named.factory=noop` (used to prevent resolver deadlocks), `schema-util-iceberg` can reach `initialize` before `schema-util-common` has finished `package` — the `test-jar` dependency artifact has no file yet, and the plugin crashes.

### Fix

Replace `maven-antrun-plugin` with `maven-resources-plugin`'s `copy-resources` goal, which creates the output directory without resolving Maven dependencies.

### Affected PRs

Multiple open PRs are failing with this error (e.g. #9335, #9328, #9686, #9673). The failure is not caused by those PRs — it's a build infrastructure race condition.

## Test plan

- [x] `./mvnw clean initialize -pl schema-util/iceberg -am` succeeds and creates `target/meta/`
- [ ] CI `Build Java Application` job passes on this PR
- [ ] Affected PRs pass after rebasing onto this fix