### PR TITLE
Add OCI image labels for build traceability

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -45,11 +45,23 @@ jobs:
 
       - name: Build operand image
         run: |
-          docker build -f ./distro/docker/target/docker/Dockerfile.jvm -t "$REGISTRY_APP_IMAGE" ./distro/docker/target/docker
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          docker build -f ./distro/docker/target/docker/Dockerfile.jvm \
+            --label org.opencontainers.image.source="https://github.com/Apicurio/apicurio-registry" \
+            --label org.opencontainers.image.revision="${{ github.sha }}" \
+            --label org.opencontainers.image.version="latest-snapshot" \
+            --label org.opencontainers.image.created="$BUILD_DATE" \
+            -t "$REGISTRY_APP_IMAGE" ./distro/docker/target/docker
 
       - name: Build GitOps sync sidecar image
         run: |
-          docker build -t "$REGISTRY_GITOPS_SYNC_IMAGE" ./distro/gitops
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          docker build \
+            --label org.opencontainers.image.source="https://github.com/Apicurio/apicurio-registry" \
+            --label org.opencontainers.image.revision="${{ github.sha }}" \
+            --label org.opencontainers.image.version="latest-snapshot" \
+            --label org.opencontainers.image.created="$BUILD_DATE" \
+            -t "$REGISTRY_GITOPS_SYNC_IMAGE" ./distro/gitops
 
       - name: Build operator image
         working-directory: operator

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -155,7 +155,12 @@ jobs:
       - name: Build and push Apicurio Registry GitOps Sync image
         working-directory: registry
         run: |
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           docker buildx build --push -f ./distro/gitops/Dockerfile \
+              --label org.opencontainers.image.source="https://github.com/Apicurio/apicurio-registry" \
+              --label org.opencontainers.image.revision="$(git -C "$GITHUB_WORKSPACE/registry" rev-parse HEAD)" \
+              --label org.opencontainers.image.version="$RELEASE_VERSION" \
+              --label org.opencontainers.image.created="$BUILD_DATE" \
               -t quay.io/apicurio/apicurio-registry-gitops-sync:$RELEASE_VERSION \
               -t quay.io/apicurio/apicurio-registry-gitops-sync:latest \
               --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le ./distro/gitops
@@ -168,7 +173,12 @@ jobs:
           if [ "$IS_LATEST_RELEASE" = "true" ]; then
             TAGS="$TAGS -t quay.io/apicurio/apicurio-registry-mcp-server:latest"
           fi
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           docker buildx build --push -f ./target/docker/Dockerfile.jvm \
+              --label org.opencontainers.image.source="https://github.com/Apicurio/apicurio-registry" \
+              --label org.opencontainers.image.revision="$(git -C "$GITHUB_WORKSPACE/registry" rev-parse HEAD)" \
+              --label org.opencontainers.image.version="$RELEASE_VERSION" \
+              --label org.opencontainers.image.created="$BUILD_DATE" \
               $TAGS \
               --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le ./target/docker
 
@@ -185,7 +195,12 @@ jobs:
             TAGS="$TAGS -t quay.io/apicurio/apicurio-registry:latest"
             TAGS="$TAGS -t quay.io/apicurio/apicurio-registry:latest-release"
           fi
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           docker buildx build --push -f ./distro/docker/target/docker/Dockerfile.jvm \
+              --label org.opencontainers.image.source="https://github.com/Apicurio/apicurio-registry" \
+              --label org.opencontainers.image.revision="$(git -C "$GITHUB_WORKSPACE/registry" rev-parse HEAD)" \
+              --label org.opencontainers.image.version="$RELEASE_VERSION" \
+              --label org.opencontainers.image.created="$BUILD_DATE" \
               $TAGS \
               --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le ./distro/docker/target/docker
 
@@ -197,7 +212,12 @@ jobs:
           if [ "$IS_LATEST_RELEASE" = "true" ]; then
             TAGS="$TAGS -t quay.io/apicurio/apicurio-registry-console-plugin:latest"
           fi
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           docker buildx build --push -f ./Dockerfile.jvm \
+              --label org.opencontainers.image.source="https://github.com/Apicurio/apicurio-registry" \
+              --label org.opencontainers.image.revision="$(git -C "$GITHUB_WORKSPACE/registry" rev-parse HEAD)" \
+              --label org.opencontainers.image.version="$RELEASE_VERSION" \
+              --label org.opencontainers.image.created="$BUILD_DATE" \
               $TAGS \
               --platform linux/amd64,linux/arm64 ./backend
 
@@ -214,7 +234,12 @@ jobs:
             TAGS="$TAGS -t quay.io/apicurio/apicurio-registry-ui:latest"
             TAGS="$TAGS -t quay.io/apicurio/apicurio-registry-ui:latest-release"
           fi
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           docker buildx build --push -f ./Dockerfile \
+              --label org.opencontainers.image.source="https://github.com/Apicurio/apicurio-registry" \
+              --label org.opencontainers.image.revision="$(git -C "$GITHUB_WORKSPACE/registry" rev-parse HEAD)" \
+              --label org.opencontainers.image.version="$RELEASE_VERSION" \
+              --label org.opencontainers.image.created="$BUILD_DATE" \
               $TAGS \
               --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le .
 

--- a/.github/workflows/reusable-docker-build.yaml
+++ b/.github/workflows/reusable-docker-build.yaml
@@ -207,9 +207,14 @@ jobs:
               TAG_ARGS="$TAG_ARGS --tag $tag"
             done
 
+            BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
             docker buildx build \
               --push \
               --file ${{ inputs.dockerfile }} \
               --platform ${{ inputs.platforms }} \
+              --label org.opencontainers.image.source="https://github.com/Apicurio/apicurio-registry" \
+              --label org.opencontainers.image.revision="${{ github.sha }}" \
+              --label org.opencontainers.image.version="${{ inputs.tag }}" \
+              --label org.opencontainers.image.created="$BUILD_DATE" \
               $TAG_ARGS \
               ${{ inputs.context }}

--- a/.github/workflows/verify-publish.yaml
+++ b/.github/workflows/verify-publish.yaml
@@ -121,9 +121,14 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 30
           command: |
+            BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
             docker buildx build \
               --push \
               --file ./support-chat/src/main/docker/Dockerfile.jvm \
               --platform linux/amd64,linux/arm64 \
+              --label org.opencontainers.image.source="https://github.com/Apicurio/apicurio-registry" \
+              --label org.opencontainers.image.revision="${{ github.sha }}" \
+              --label org.opencontainers.image.version="latest-snapshot" \
+              --label org.opencontainers.image.created="$BUILD_DATE" \
               --tag quay.io/apicurio/apicurio-registry-support-chat:latest-snapshot \
               ./support-chat

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -125,7 +125,12 @@ jobs:
 
       - name: Build Docker Image
         run: |
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           docker build -f ./distro/docker/target/docker/Dockerfile.jvm \
+            --label org.opencontainers.image.source="https://github.com/Apicurio/apicurio-registry" \
+            --label org.opencontainers.image.revision="${{ github.sha }}" \
+            --label org.opencontainers.image.version="latest-snapshot" \
+            --label org.opencontainers.image.created="$BUILD_DATE" \
             -t apicurio/apicurio-registry:${{ github.sha }} \
             ./distro/docker/target/docker
 
@@ -213,7 +218,13 @@ jobs:
       - name: Build UI Docker Image
         working-directory: ui
         run: |
-          docker build -t apicurio/apicurio-registry-ui:${{ github.sha }} .
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          docker build \
+            --label org.opencontainers.image.source="https://github.com/Apicurio/apicurio-registry" \
+            --label org.opencontainers.image.revision="${{ github.sha }}" \
+            --label org.opencontainers.image.version="latest-snapshot" \
+            --label org.opencontainers.image.created="$BUILD_DATE" \
+            -t apicurio/apicurio-registry-ui:${{ github.sha }} .
 
       - name: Save UI Docker Image
         uses: apicurio/apicurio-github-actions/save-docker-image@ecae58cc1a9b5eeb810b90f8a9e15d2266a371d3 # v2


### PR DESCRIPTION
Fixes #9682

### Description
- Adds recommended OCI image labels (`org.opencontainers.image.source`, `org.opencontainers.image.revision`, `org.opencontainers.image.version`, `org.opencontainers.image.created`) to container image builds across CI workflows.
- Dynamically populates git commit SHA (`${{ github.sha }}`), version (`$RELEASE_VERSION` / `${{ inputs.tag }}`), and build timestamp (`BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')`).
- Covers both release builds (`release-images.yaml`) and snapshot/PR builds (`reusable-docker-build.yaml`, `verify-publish.yaml`, `verify-build.yaml`, `operator.yaml`).
