### PR TITLE
Operator mock server delete test

### DIFF
--- a/operator/controller/pom.xml
+++ b/operator/controller/pom.xml
@@ -72,6 +72,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-kubernetes-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/AppFeaturesReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/AppFeaturesReconcileTest.java
@@ -1,0 +1,106 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.EnvironmentVariables;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.spec.AppFeaturesSpec;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.apicurio.registry.operator.api.v1.ContainerNames.REGISTRY_APP_CONTAINER_NAME;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static io.apicurio.registry.operator.resource.app.AppDeploymentResource.getContainerFromDeployment;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Mock-server equivalents of {@code AppFeaturesITTest}.
+ * All tests verify only env var presence/absence on the Deployment spec.
+ */
+@QuarkusTest
+public class AppFeaturesReconcileTest extends MockServerTestBase {
+
+    @Test
+    void allowDeletesTrue() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getSpec().getApp().setFeatures(AppFeaturesSpec.builder().resourceDeleteEnabled(true).build());
+        createRegistry(registry);
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var env = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_APP)).get(),
+                    REGISTRY_APP_CONTAINER_NAME).getEnv();
+            assertThat(env).map(EnvVar::getName).contains(
+                    EnvironmentVariables.APICURIO_REST_DELETION_ARTIFACT_ENABLED,
+                    EnvironmentVariables.APICURIO_REST_DELETION_ARTIFACT_VERSION_ENABLED,
+                    EnvironmentVariables.APICURIO_REST_DELETION_GROUP_ENABLED);
+        });
+    }
+
+    @Test
+    void allowDeletesDefault() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        createRegistry(registry);
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var env = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_APP)).get(),
+                    REGISTRY_APP_CONTAINER_NAME).getEnv();
+            assertThat(env).map(EnvVar::getName).doesNotContain(
+                    EnvironmentVariables.APICURIO_REST_DELETION_ARTIFACT_ENABLED,
+                    EnvironmentVariables.APICURIO_REST_DELETION_ARTIFACT_VERSION_ENABLED,
+                    EnvironmentVariables.APICURIO_REST_DELETION_GROUP_ENABLED);
+        });
+    }
+
+    @Test
+    void versionMutabilityEnabledTrue() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getSpec().getApp().setFeatures(AppFeaturesSpec.builder().versionMutabilityEnabled(true).build());
+        createRegistry(registry);
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var env = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_APP)).get(),
+                    REGISTRY_APP_CONTAINER_NAME).getEnv();
+            assertThat(env)
+                    .filteredOn(e -> e.getName().equals(
+                            EnvironmentVariables.APICURIO_REST_MUTABILITY_ARTIFACT_VERSION_CONTENT_ENABLED))
+                    .hasSize(1)
+                    .first()
+                    .extracting(EnvVar::getValue)
+                    .isEqualTo("true");
+        });
+    }
+
+    @Test
+    void versionMutabilityEnabledDefault() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        createRegistry(registry);
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var env = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_APP)).get(),
+                    REGISTRY_APP_CONTAINER_NAME).getEnv();
+            assertThat(env).map(EnvVar::getName)
+                    .doesNotContain(EnvironmentVariables.APICURIO_REST_MUTABILITY_ARTIFACT_VERSION_CONTENT_ENABLED);
+        });
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/CRUpdateEdgeCasesReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/CRUpdateEdgeCasesReconcileTest.java
@@ -1,0 +1,79 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Mock-server coverage for {@code IngressCRUpdater} branches not exercised by
+ * {@code CRUpdateReconcileTest}, which only covers the case where the deprecated {@code host}
+ * field is set and the current {@code ingress.host} field is empty.
+ */
+@QuarkusTest
+public class CRUpdateEdgeCasesReconcileTest extends MockServerTestBase {
+
+    /**
+     * When both the deprecated {@code host} field and the current {@code ingress.host} field are
+     * set to different values, {@code IngressCRUpdater} deliberately declines to auto-migrate
+     * (it would silently discard an explicit value the user just set). The spec must be left
+     * exactly as submitted, while the rendered Ingress must still use the current field.
+     */
+    @Test
+    void conflictingHostFieldsAreNotAutoMigrated() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getMetadata().setName("cr-update-conflict");
+        registry.getSpec().getApp().setHost("deprecated.apps.cluster.example");
+        registry.getSpec().getApp().getIngress().setHost("current.apps.cluster.example");
+        createRegistry(registry);
+
+        awaitIngressExists(ingressName(registry, COMPONENT_APP));
+
+        // The rendered Ingress uses the current field...
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() ->
+                assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                        .withName(ingressName(registry, COMPONENT_APP)).get()
+                        .getSpec().getRules().get(0).getHost())
+                        .isEqualTo("current.apps.cluster.example"));
+
+        // ...while the CR spec itself is left untouched: both fields remain exactly as
+        // submitted, proving the deprecated value was not silently overwritten or discarded.
+        await().during(MOCK_STABILITY).atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions()
+                .untilAsserted(() -> {
+                    var cr = client.resources(ApicurioRegistry3.class).inNamespace(namespace)
+                            .withName("cr-update-conflict").get();
+                    assertThat(cr.getSpec().getApp().getHost()).isEqualTo("deprecated.apps.cluster.example");
+                    assertThat(cr.getSpec().getApp().getIngress().getHost())
+                            .isEqualTo("current.apps.cluster.example");
+                });
+    }
+
+    /**
+     * A CR already in the current (post-migration) form must remain stable across the natural
+     * reconciliation loop: no spurious re-patch should occur just because the operator keeps
+     * reconciling in response to its own writes (status updates, etc.).
+     */
+    @Test
+    void alreadyMigratedSpecIsStableAcrossReconciliation() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getMetadata().setName("cr-update-stable");
+        createRegistry(registry);
+
+        awaitIngressExists(ingressName(registry, COMPONENT_APP));
+
+        await().during(MOCK_STABILITY).atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions()
+                .untilAsserted(() -> {
+                    var cr = client.resources(ApicurioRegistry3.class).inNamespace(namespace)
+                            .withName("cr-update-stable").get();
+                    assertThat(cr.getSpec().getApp().getHost()).isNull();
+                    assertThat(cr.getSpec().getApp().getIngress().getHost())
+                            .isEqualTo("simple-app.apps.cluster.example");
+                });
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/CRUpdateReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/CRUpdateReconcileTest.java
@@ -1,0 +1,41 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Mock-server equivalent of {@code CRUpdateITTest}: verifies that a deprecated CR spec is
+ * automatically migrated to the current form on creation.
+ */
+@QuarkusTest
+public class CRUpdateReconcileTest extends MockServerTestBase {
+
+    @Test
+    void crSpecMigrated() {
+        var deprecated = ResourceFactory.deserialize(
+                "/k8s/examples/simple-deprecated.apicurioregistry3.yaml", ApicurioRegistry3.class);
+        var expectedSpec = ResourceFactory.deserialize(
+                "/k8s/examples/simple.apicurioregistry3.yaml", ApicurioRegistry3.class).getSpec();
+
+        createRegistry(deprecated);
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL)
+                .ignoreExceptionsInstanceOf(KubernetesClientException.class)
+                .untilAsserted(() -> {
+                    var updated = client.resources(ApicurioRegistry3.class)
+                            .inNamespace(namespace).list().getItems().stream()
+                            .filter(r -> r.getMetadata().getName().equals(deprecated.getMetadata().getName()))
+                            .toList();
+                    assertThat(updated).hasSize(1);
+                    assertThat(updated.get(0).getSpec())
+                            .usingRecursiveComparison()
+                            .isEqualTo(expectedSpec);
+                });
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/DeleteLifecycleReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/DeleteLifecycleReconcileTest.java
@@ -1,0 +1,131 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Mock-server coverage for the CR delete/finalizer lifecycle, which is not exercised by any test
+ * migrated in the mock-server test tier.
+ *
+ * <p>
+ * {@code ApicurioRegistry3Reconciler} implements JOSDK's {@code Cleaner}, so a finalizer is
+ * registered on the primary CR and {@code cleanup()} must run to completion (removing the
+ * finalizer) before the API server will actually delete the CR. That sequencing, and the
+ * ownerReference contract dependent resources are stamped with, are both observable against the
+ * Fabric8 CRUD mock server without a real cluster.
+ *
+ * <p>
+ * <b>Not covered here:</b> actual cascade deletion of dependent resources when the primary is
+ * removed. Dependent resources in this operator rely on Kubernetes' owner-reference garbage
+ * collector (kube-controller-manager) to be cleaned up, and the Fabric8 CRUD mock server does not
+ * implement a garbage collector - it only stores/serves objects. This test asserts that
+ * explicitly: the Deployment is still present immediately after the primary CR is gone. Real
+ * cascade cleanup remains covered by the real-cluster IT suite.
+ */
+@QuarkusTest
+public class DeleteLifecycleReconcileTest extends MockServerTestBase {
+
+    @Test
+    void finalizerAddedOnCreate() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getMetadata().setName("delete-finalizer");
+        createRegistry(registry);
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var cr = client.resources(ApicurioRegistry3.class).inNamespace(namespace)
+                    .withName("delete-finalizer").get();
+            assertThat(cr).isNotNull();
+            assertThat(cr.getMetadata().getFinalizers())
+                    .as("JOSDK's Cleaner contract must register a finalizer on the primary CR")
+                    .isNotEmpty()
+                    .allSatisfy(f -> assertThat(f).endsWith("/finalizer"));
+        });
+    }
+
+    @Test
+    void crDeletionCompletesOnlyAfterCleanup() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getMetadata().setName("delete-cleanup");
+        createRegistry(registry);
+
+        String deploymentName = deploymentName(registry, COMPONENT_APP);
+        awaitDeploymentExists(deploymentName);
+
+        client.resources(ApicurioRegistry3.class).inNamespace(namespace).withName("delete-cleanup").delete();
+
+        // The CR can only disappear from the API once JOSDK's cleanup control loop has run
+        // cleanup() and removed the finalizer - so eventual absence here is proof cleanup
+        // completed, not just that a delete request was accepted.
+        awaitResourceAbsent(() -> client.resources(ApicurioRegistry3.class).inNamespace(namespace)
+                .withName("delete-cleanup").get());
+
+        // The mock server has no garbage collector: dependent resources are not cascade-deleted
+        // just because the primary is gone. This is expected and is why cascade-cleanup coverage
+        // stays in the real-cluster IT suite.
+        assertThat(client.apps().deployments().inNamespace(namespace).withName(deploymentName).get())
+                .as("the CRUD mock server does not run a garbage collector, so dependents are not "
+                        + "cascade-deleted by primary CR deletion; real cascade cleanup is covered "
+                        + "by the IT suite")
+                .isNotNull();
+    }
+
+    @Test
+    void dependentResourcesCarryCompleteOwnerReference() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getMetadata().setName("delete-owner-ref");
+        createRegistry(registry);
+
+        Deployment deployment = awaitResourceExists(deploymentName(registry, COMPONENT_APP),
+                () -> client.apps().deployments().inNamespace(namespace)
+                        .withName(deploymentName(registry, COMPONENT_APP)).get());
+        var createdRegistry = client.resources(ApicurioRegistry3.class).inNamespace(namespace)
+                .withName("delete-owner-ref").get();
+
+        assertOwnerReference(deployment, createdRegistry);
+
+        var service = awaitResourceExists(serviceName(registry, COMPONENT_APP),
+                () -> client.services().inNamespace(namespace)
+                        .withName(serviceName(registry, COMPONENT_APP)).get());
+        assertOwnerReference(service, createdRegistry);
+
+        String networkPolicyName = registry.getMetadata().getName() + "-" + COMPONENT_APP + "-networkpolicy";
+        var networkPolicy = awaitResourceExists(networkPolicyName,
+                () -> client.network().v1().networkPolicies().inNamespace(namespace)
+                        .withName(networkPolicyName).get());
+        assertOwnerReference(networkPolicy, createdRegistry);
+    }
+
+    /**
+     * Asserts the ownerReference fields this operator actually populates. JOSDK's
+     * {@code KubernetesDependentResource#addReferenceHandlingMetadata} delegates to Fabric8's
+     * default {@code HasMetadata#addOwnerReference(HasMetadata)}, which only sets
+     * {@code apiVersion}/{@code kind}/{@code name}/{@code uid} - it does not set
+     * {@code controller} or {@code blockOwnerDeletion} (both are left {@code null}), which this
+     * test confirms empirically rather than assumes.
+     */
+    private static void assertOwnerReference(HasMetadata dependent, ApicurioRegistry3 owner) {
+        assertThat(dependent.getMetadata().getOwnerReferences()).singleElement()
+                .satisfies((OwnerReference ref) -> {
+                    assertThat(ref.getApiVersion()).isEqualTo(owner.getApiVersion());
+                    assertThat(ref.getKind()).isEqualTo(owner.getKind());
+                    assertThat(ref.getName()).isEqualTo(owner.getMetadata().getName());
+                    assertThat(ref.getUid()).isEqualTo(owner.getMetadata().getUid());
+                    assertThat(ref.getController()).isNull();
+                    assertThat(ref.getBlockOwnerDeletion()).isNull();
+                });
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/DisableUIReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/DisableUIReconcileTest.java
@@ -1,0 +1,53 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_UI;
+
+/**
+ * Mock-server equivalent of {@code DisableUIITTest}.
+ */
+@QuarkusTest
+public class DisableUIReconcileTest extends MockServerTestBase {
+
+    @Test
+    void disableUI() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getSpec().getApp().getIngress().setHost("app.example.com");
+        registry.getSpec().getUi().getIngress().setHost("ui.example.com");
+        createRegistry(registry);
+
+        // Everything should be created
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_UI));
+        awaitServiceExists(serviceName(registry, COMPONENT_APP));
+        awaitServiceExists(serviceName(registry, COMPONENT_UI));
+        awaitIngressExists(ingressName(registry, COMPONENT_APP));
+        awaitIngressExists(ingressName(registry, COMPONENT_UI));
+
+        // Disable UI
+        updateRegistry(registry, r -> r.getSpec().getUi().setEnabled(false));
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+        awaitDeploymentAbsent(deploymentName(registry, COMPONENT_UI));
+        awaitServiceExists(serviceName(registry, COMPONENT_APP));
+        awaitServiceAbsent(serviceName(registry, COMPONENT_UI));
+        awaitIngressExists(ingressName(registry, COMPONENT_APP));
+        awaitIngressAbsent(ingressName(registry, COMPONENT_UI));
+
+        // Re-enable UI
+        updateRegistry(registry, r -> r.getSpec().getUi().setEnabled(true));
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_UI));
+        awaitServiceExists(serviceName(registry, COMPONENT_APP));
+        awaitServiceExists(serviceName(registry, COMPONENT_UI));
+        awaitIngressExists(ingressName(registry, COMPONENT_APP));
+        awaitIngressExists(ingressName(registry, COMPONENT_UI));
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/EnvReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/EnvReconcileTest.java
@@ -1,0 +1,131 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.apicurio.registry.operator.api.v1.ContainerNames.REGISTRY_APP_CONTAINER_NAME;
+import static io.apicurio.registry.operator.api.v1.ContainerNames.REGISTRY_UI_CONTAINER_NAME;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_UI;
+import static io.apicurio.registry.operator.resource.app.AppDeploymentResource.getContainerFromDeployment;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Mock-server equivalent of {@code EnvITTest}: verifies env var propagation and ordering.
+ */
+@QuarkusTest
+public class EnvReconcileTest extends MockServerTestBase {
+
+    private static final String[] DEFAULT_APP_ENV = {
+            "QUARKUS_PROFILE",
+            "QUARKUS_HTTP_ACCESS_LOG_ENABLED",
+            "QUARKUS_HTTP_CORS_ORIGINS"
+    };
+
+    private static final String[] DEFAULT_UI_ENV = {"REGISTRY_API_URL"};
+
+    @Test
+    void envVars() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getSpec().getApp().getIngress().setHost("app.example.com");
+        registry.getSpec().getUi().getIngress().setHost("ui.example.com");
+        createRegistry(registry);
+
+        // Default env vars are set exactly once
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var appEnv = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_APP)).get(),
+                    REGISTRY_APP_CONTAINER_NAME).getEnv();
+            assertThat(appEnv).map(EnvVar::getName).containsOnlyOnce(DEFAULT_APP_ENV);
+
+            var uiEnv = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_UI)).get(),
+                    REGISTRY_UI_CONTAINER_NAME).getEnv();
+            assertThat(uiEnv).map(EnvVar::getName).containsOnlyOnce(DEFAULT_UI_ENV);
+        });
+
+        // Add custom env vars and override a default one
+        updateRegistry(registry, r -> {
+            r.getSpec().getApp().setEnv(List.of(
+                    new EnvVarBuilder().withName("APP_VAR_1_NAME").withValue("APP_VAR_1_VALUE").build(),
+                    new EnvVarBuilder().withName("QUARKUS_HTTP_ACCESS_LOG_ENABLED").withValue("false").build(),
+                    new EnvVarBuilder().withName("APP_VAR_2_NAME").withValue("APP_VAR_2_VALUE").build()
+            ));
+            r.getSpec().getUi().setEnv(List.of(
+                    new EnvVarBuilder().withName("UI_VAR_1_NAME").withValue("UI_VAR_1_VALUE").build(),
+                    new EnvVarBuilder().withName("REGISTRY_API_URL").withValue("FOO").build(),
+                    new EnvVarBuilder().withName("UI_VAR_2_NAME").withValue("UI_VAR_2_VALUE").build()
+            ));
+        });
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var appEnv = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_APP)).get(),
+                    REGISTRY_APP_CONTAINER_NAME).getEnv();
+            assertThat(appEnv).map(EnvVar::getName).containsOnlyOnce(DEFAULT_APP_ENV);
+            assertThat(appEnv.stream().filter(e -> "QUARKUS_HTTP_ACCESS_LOG_ENABLED".equals(e.getName()))
+                    .map(EnvVar::getValue).findAny()).hasValue("false");
+            assertThat(appEnv).containsSubsequence(
+                    new EnvVarBuilder().withName("APP_VAR_1_NAME").withValue("APP_VAR_1_VALUE").build(),
+                    new EnvVarBuilder().withName("APP_VAR_2_NAME").withValue("APP_VAR_2_VALUE").build()
+            );
+
+            var uiEnv = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_UI)).get(),
+                    REGISTRY_UI_CONTAINER_NAME).getEnv();
+            assertThat(uiEnv).map(EnvVar::getName).containsOnlyOnce(DEFAULT_UI_ENV);
+            assertThat(uiEnv.stream().filter(e -> "REGISTRY_API_URL".equals(e.getName()))
+                    .map(EnvVar::getValue).findAny()).hasValue("FOO");
+            assertThat(uiEnv).containsSubsequence(
+                    new EnvVarBuilder().withName("UI_VAR_1_NAME").withValue("UI_VAR_1_VALUE").build(),
+                    new EnvVarBuilder().withName("UI_VAR_2_NAME").withValue("UI_VAR_2_VALUE").build()
+            );
+        });
+
+        // Change order: verify ordering is respected
+        updateRegistry(registry, r -> {
+            r.getSpec().getApp().setEnv(List.of(
+                    new EnvVarBuilder().withName("APP_VAR_2_NAME").withValue("APP_VAR_2_VALUE").build(),
+                    new EnvVarBuilder().withName("QUARKUS_HTTP_ACCESS_LOG_ENABLED").withValue("false").build(),
+                    new EnvVarBuilder().withName("APP_VAR_1_NAME").withValue("APP_VAR_1_VALUE").build()
+            ));
+            r.getSpec().getUi().setEnv(List.of(
+                    new EnvVarBuilder().withName("UI_VAR_2_NAME").withValue("UI_VAR_2_VALUE").build(),
+                    new EnvVarBuilder().withName("REGISTRY_API_URL").withValue("FOO").build(),
+                    new EnvVarBuilder().withName("UI_VAR_1_NAME").withValue("UI_VAR_1_VALUE").build()
+            ));
+        });
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var appEnv = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_APP)).get(),
+                    REGISTRY_APP_CONTAINER_NAME).getEnv();
+            assertThat(appEnv).containsSubsequence(
+                    new EnvVarBuilder().withName("APP_VAR_2_NAME").withValue("APP_VAR_2_VALUE").build(),
+                    new EnvVarBuilder().withName("APP_VAR_1_NAME").withValue("APP_VAR_1_VALUE").build()
+            );
+
+            var uiEnv = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_UI)).get(),
+                    REGISTRY_UI_CONTAINER_NAME).getEnv();
+            assertThat(uiEnv).containsSubsequence(
+                    new EnvVarBuilder().withName("UI_VAR_2_NAME").withValue("UI_VAR_2_VALUE").build(),
+                    new EnvVarBuilder().withName("UI_VAR_1_NAME").withValue("UI_VAR_1_VALUE").build()
+            );
+        });
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/GitOpsSshServiceReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/GitOpsSshServiceReconcileTest.java
@@ -1,0 +1,70 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.spec.StorageType;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Mock-server coverage for {@code GitOpsSshServiceResource}, a plain CRUD dependent resource
+ * (activated only when GitOps push mode is configured) that is not migrated in the mock-server
+ * test tier. Only resource create/remove/recreate is verified here - the actual SSH git push
+ * flow requires a running sidecar and remains functional-test territory, not covered by this
+ * class.
+ */
+@QuarkusTest
+public class GitOpsSshServiceReconcileTest extends MockServerTestBase {
+
+    @Test
+    void sshServiceLifecycleFollowsPushMode() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/gitops/example-push.yaml",
+                ApicurioRegistry3.class);
+        createRegistry(registry);
+
+        String sshServiceName = registry.getMetadata().getName() + "-gitops-ssh-service";
+
+        // Push mode: the SSH service is created alongside the app deployment/service.
+        awaitDeploymentExists(deploymentName(registry, "app"));
+        var sshService = awaitResourceExists(sshServiceName,
+                () -> client.services().inNamespace(namespace).withName(sshServiceName).get());
+        assertThat(sshService.getSpec().getPorts()).extracting(
+                io.fabric8.kubernetes.api.model.ServicePort::getPort).contains(2222);
+
+        // Switch away from GitOps storage: the SSH service must be removed.
+        updateRegistry(registry, r -> {
+            r.getSpec().getApp().getStorage().setType(null);
+            r.getSpec().getApp().getStorage().setGitops(null);
+        });
+        awaitResourceAbsent(() -> client.services().inNamespace(namespace).withName(sshServiceName).get());
+
+        // Switch back to GitOps push mode: the SSH service must be recreated.
+        var pushSpec = ResourceFactory.deserialize("/k8s/examples/gitops/example-push.yaml",
+                ApicurioRegistry3.class).getSpec().getApp().getStorage();
+        updateRegistry(registry, r -> {
+            r.getSpec().getApp().getStorage().setType(StorageType.GITOPS);
+            r.getSpec().getApp().getStorage().setGitops(pushSpec.getGitops());
+        });
+        awaitResourceExists(sshServiceName,
+                () -> client.services().inNamespace(namespace).withName(sshServiceName).get());
+    }
+
+    @Test
+    void sshServiceNotCreatedInPullMode() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/gitops/example-push.yaml",
+                ApicurioRegistry3.class);
+        registry.getMetadata().setName("gitops-pull");
+        registry.getSpec().getApp().getStorage().getGitops().setMode(
+                io.apicurio.registry.operator.api.v1.spec.GitOpsMode.PULL);
+        createRegistry(registry);
+
+        awaitDeploymentExists(deploymentName(registry, "app"));
+
+        String sshServiceName = registry.getMetadata().getName() + "-gitops-ssh-service";
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() ->
+                assertThat(client.services().inNamespace(namespace).withName(sshServiceName).get()).isNull());
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/HorizontalPodAutoscalerReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/HorizontalPodAutoscalerReconcileTest.java
@@ -1,0 +1,81 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.spec.AutoscalingSpec;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Mock-server equivalents of {@code HorizontalPodAutoscalerITTest}.
+ */
+@QuarkusTest
+public class HorizontalPodAutoscalerReconcileTest extends MockServerTestBase {
+
+    @Test
+    void hpaCreated() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        var autoscaling = new AutoscalingSpec();
+        autoscaling.setEnabled(true);
+        autoscaling.setMinReplicas(1);
+        autoscaling.setMaxReplicas(3);
+        autoscaling.setTargetCPUUtilizationPercentage(70);
+        registry.getSpec().getApp().setAutoscaling(autoscaling);
+        createRegistry(registry);
+
+        String hpaName = registry.getMetadata().getName() + "-" + COMPONENT_APP + "-horizontalpodautoscaler";
+        HorizontalPodAutoscaler hpa = awaitResourceExists(hpaName,
+                () -> client.autoscaling().v2().horizontalPodAutoscalers()
+                        .inNamespace(namespace).withName(hpaName).get());
+
+        assertThat(hpa.getSpec().getScaleTargetRef().getName())
+                .isEqualTo(deploymentName(registry, COMPONENT_APP));
+        assertThat(hpa.getSpec().getMinReplicas()).isEqualTo(1);
+        assertThat(hpa.getSpec().getMaxReplicas()).isEqualTo(3);
+        assertThat(hpa.getSpec().getMetrics()).hasSize(1);
+        assertThat(hpa.getSpec().getMetrics().get(0).getResource().getName()).isEqualTo("cpu");
+        assertThat(hpa.getSpec().getMetrics().get(0).getResource().getTarget()
+                .getAverageUtilization()).isEqualTo(70);
+    }
+
+    @Test
+    void hpaCreatedWithMemory() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        var autoscaling = new AutoscalingSpec();
+        autoscaling.setEnabled(true);
+        autoscaling.setMinReplicas(2);
+        autoscaling.setMaxReplicas(5);
+        autoscaling.setTargetCPUUtilizationPercentage(60);
+        autoscaling.setTargetMemoryUtilizationPercentage(75);
+        registry.getSpec().getApp().setAutoscaling(autoscaling);
+        createRegistry(registry);
+
+        String hpaName = registry.getMetadata().getName() + "-" + COMPONENT_APP + "-horizontalpodautoscaler";
+        HorizontalPodAutoscaler hpa = awaitResourceExists(hpaName,
+                () -> client.autoscaling().v2().horizontalPodAutoscalers()
+                        .inNamespace(namespace).withName(hpaName).get());
+
+        assertThat(hpa.getSpec().getMinReplicas()).isEqualTo(2);
+        assertThat(hpa.getSpec().getMaxReplicas()).isEqualTo(5);
+        assertThat(hpa.getSpec().getMetrics()).hasSize(2);
+    }
+
+    @Test
+    void hpaNotCreatedWhenDisabled() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        createRegistry(registry);
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+
+        String hpaName = registry.getMetadata().getName() + "-" + COMPONENT_APP + "-horizontalpodautoscaler";
+        awaitResourceAbsent(() -> client.autoscaling().v2().horizontalPodAutoscalers()
+                .inNamespace(namespace).withName(hpaName).get());
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/IngressReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/IngressReconcileTest.java
@@ -1,0 +1,67 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_UI;
+import static io.apicurio.registry.operator.resource.ResourceFactory.deserialize;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Mock-server equivalent of the spec-propagation part of {@code IngressITTest}.
+ *
+ * <p>
+ * The {@code ingressAnnotations()} test from the IT suite exercises SSA field-manager semantics
+ * (non-managed annotations are preserved across reconciliations) and is not migrated here.
+ */
+@QuarkusTest
+public class IngressReconcileTest extends MockServerTestBase {
+
+    @Test
+    void ingressClassName() {
+        var primary = deserialize("/k8s/examples/ingress/ingress-class-name.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        primary.getSpec().getApp().getIngress().setHost("app.example.com");
+        primary.getSpec().getUi().getIngress().setHost("ui.example.com");
+        createRegistry(primary);
+
+        // Initial class names from the CR
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                    .withName(ingressName(primary, COMPONENT_APP)).get()).isNotNull();
+            assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                    .withName(ingressName(primary, COMPONENT_APP)).get()
+                    .getSpec().getIngressClassName()).isEqualTo("haproxy-app");
+
+            assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                    .withName(ingressName(primary, COMPONENT_UI)).get()).isNotNull();
+            assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                    .withName(ingressName(primary, COMPONENT_UI)).get()
+                    .getSpec().getIngressClassName()).isEqualTo("haproxy-ui");
+        });
+
+        // Update app class name
+        updateRegistry(primary, p -> p.getSpec().getApp().getIngress().setIngressClassName("test---nginx"));
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() ->
+                assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                        .withName(ingressName(primary, COMPONENT_APP)).get()
+                        .getSpec().getIngressClassName()).isEqualTo("test---nginx"));
+
+        // UI class name unchanged
+        assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                .withName(ingressName(primary, COMPONENT_UI)).get()
+                .getSpec().getIngressClassName()).isEqualTo("haproxy-ui");
+
+        // Clear app class name
+        updateRegistry(primary, p -> p.getSpec().getApp().getIngress().setIngressClassName(""));
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() ->
+                assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                        .withName(ingressName(primary, COMPONENT_APP)).get()
+                        .getSpec().getIngressClassName()).isNotEqualTo("test---nginx"));
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/KubernetesOpsRbacReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/KubernetesOpsRbacReconcileTest.java
@@ -1,0 +1,116 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.spec.KubernetesOpsSpec;
+import io.apicurio.registry.operator.api.v1.spec.StorageType;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Mock-server equivalents of {@code KubernetesOpsRbacITTest}.
+ */
+@QuarkusTest
+public class KubernetesOpsRbacReconcileTest extends MockServerTestBase {
+
+    @Test
+    void rbacResourcesCreatedForKubernetesOps() {
+        var registry = registryWithKubernetesOps("rbac-create");
+        createRegistry(registry);
+
+        String saName = registry.getMetadata().getName() + "-kubeops";
+
+        // ServiceAccount
+        awaitResourceExists(saName,
+                () -> client.serviceAccounts().inNamespace(namespace).withName(saName).get());
+
+        // Role with correct permissions
+        var role = awaitResourceExists(saName,
+                () -> client.rbac().roles().inNamespace(namespace).withName(saName).get());
+        assertThat(role.getRules()).hasSize(1);
+        assertThat(role.getRules().get(0).getApiGroups()).containsExactly("");
+        assertThat(role.getRules().get(0).getResources()).containsExactly("configmaps");
+        assertThat(role.getRules().get(0).getVerbs()).containsExactlyInAnyOrder("get", "list", "watch");
+
+        // RoleBinding linking SA to Role
+        var rb = awaitResourceExists(saName,
+                () -> client.rbac().roleBindings().inNamespace(namespace).withName(saName).get());
+        assertThat(rb.getRoleRef().getKind()).isEqualTo("Role");
+        assertThat(rb.getRoleRef().getName()).isEqualTo(saName);
+        assertThat(rb.getSubjects()).hasSize(1);
+        assertThat(rb.getSubjects().get(0).getKind()).isEqualTo("ServiceAccount");
+        assertThat(rb.getSubjects().get(0).getName()).isEqualTo(saName);
+        assertThat(rb.getSubjects().get(0).getNamespace()).isEqualTo(namespace);
+
+        // Deployment has serviceAccountName set
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var deployment = client.apps().deployments().inNamespace(namespace)
+                    .withName(deploymentName(registry, COMPONENT_APP)).get();
+            assertThat(deployment).isNotNull();
+            assertThat(deployment.getSpec().getTemplate().getSpec().getServiceAccountName())
+                    .isEqualTo(saName);
+        });
+    }
+
+    @Test
+    void rbacResourcesNotCreatedWithoutKubernetesOps() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getMetadata().setName("rbac-absent");
+        createRegistry(registry);
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+
+        String saName = registry.getMetadata().getName() + "-kubeops";
+        assertThat(client.serviceAccounts().inNamespace(namespace).withName(saName).get()).isNull();
+        assertThat(client.rbac().roles().inNamespace(namespace).withName(saName).get()).isNull();
+        assertThat(client.rbac().roleBindings().inNamespace(namespace).withName(saName).get()).isNull();
+
+        var deployment = client.apps().deployments().inNamespace(namespace)
+                .withName(deploymentName(registry, COMPONENT_APP)).get();
+        assertThat(deployment.getSpec().getTemplate().getSpec().getServiceAccountName())
+                .isNotEqualTo(saName);
+    }
+
+    @Test
+    void rbacResourcesCleanedUpOnStorageTypeChange() {
+        var registry = registryWithKubernetesOps("rbac-cleanup");
+        createRegistry(registry);
+
+        String saName = registry.getMetadata().getName() + "-kubeops";
+
+        // Wait for RBAC resources
+        awaitResourceExists(saName,
+                () -> client.serviceAccounts().inNamespace(namespace).withName(saName).get());
+        awaitResourceExists(saName,
+                () -> client.rbac().roles().inNamespace(namespace).withName(saName).get());
+        awaitResourceExists(saName,
+                () -> client.rbac().roleBindings().inNamespace(namespace).withName(saName).get());
+
+        // Switch to in-memory storage
+        updateRegistry(registry, r -> {
+            r.getSpec().getApp().getStorage().setType(null);
+            r.getSpec().getApp().getStorage().setKubernetesops(null);
+        });
+
+        // RBAC resources should be removed
+        awaitResourceAbsent(() -> client.serviceAccounts().inNamespace(namespace).withName(saName).get());
+        awaitResourceAbsent(() -> client.rbac().roles().inNamespace(namespace).withName(saName).get());
+        awaitResourceAbsent(() -> client.rbac().roleBindings().inNamespace(namespace).withName(saName).get());
+    }
+
+    private ApicurioRegistry3 registryWithKubernetesOps(String name) {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getMetadata().setName(name);
+        registry.getSpec().getApp().withStorage().setType(StorageType.KUBERNETESOPS);
+        var k8sOps = new KubernetesOpsSpec();
+        k8sOps.setRegistryId("test-registry");
+        registry.getSpec().getApp().getStorage().setKubernetesops(k8sOps);
+        return registry;
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/MockServerTestBase.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/MockServerTestBase.java
@@ -1,0 +1,192 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.App;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.utils.Cell;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static io.apicurio.registry.utils.Cell.cell;
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Base class for operator reconciliation tests that run against a Fabric8 CRUD mock Kubernetes
+ * API server instead of a real cluster. Each test method gets a fresh namespace; the operator is
+ * started before every method and stopped after.
+ *
+ * <p>
+ * <b>SSA coverage disclaimer:</b> the Fabric8 CRUD mock server does not implement Server-Side
+ * Apply. All dependent resource classes in this operator already extend
+ * {@code CRUDKubernetesDependentResource}, so CRUD semantics match the mock. However, any
+ * SSA-specific behavior (field-manager ownership, conflict resolution, annotation merge) requires
+ * the real-cluster IT suite.
+ *
+ * <p>
+ * Tests that verify pod readiness, real HTTP endpoints, or external infrastructure (Kafka,
+ * Keycloak, databases) must remain in the IT suite.
+ */
+@WithKubernetesTestServer(crud = true)
+public abstract class MockServerTestBase {
+
+    protected static final Duration MOCK_TIMEOUT = ofSeconds(10);
+    protected static final Duration MOCK_POLL = ofMillis(50);
+    protected static final Duration MOCK_STABILITY = ofSeconds(3);
+
+    @Inject
+    protected KubernetesClient client;
+
+    protected String namespace;
+
+    private App app;
+
+    @BeforeEach
+    void setUpMockBase() {
+        namespace = "test-" + UUID.randomUUID().toString().substring(0, 7);
+        client.resource(new NamespaceBuilder().withNewMetadata().withName(namespace).endMetadata().build())
+                .create();
+
+        app = CDI.current().select(App.class).get();
+        app.start(configOverride -> {
+            configOverride.withKubernetesClient(client);
+            configOverride.withUseSSAToPatchPrimaryResource(false);
+            // Safety: disable SSA for all resource types the operator manages, in case the
+            // mock server ever encounters a PATCH-upsert path.
+            configOverride.withDefaultNonSSAResource(Set.of(
+                    Deployment.class, io.fabric8.kubernetes.api.model.Service.class, Ingress.class,
+                    HorizontalPodAutoscaler.class, NetworkPolicy.class, PodDisruptionBudget.class,
+                    ServiceAccount.class, Role.class, RoleBinding.class
+            ));
+            // The injected KubernetesClient is a CDI-managed singleton owned by the
+            // quarkus-test-kubernetes-client extension. Prevent the operator from closing it on
+            // stop, since the client is shared across test methods.
+            configOverride.withCloseClientOnStop(false);
+        });
+    }
+
+    @AfterEach
+    void tearDownMockBase() {
+        // Stop the JOSDK ControllerManager so informers/watches registered by this test's
+        // App instance are torn down. Without this, each test would accumulate a new live
+        // reconciler watching all namespaces on the shared mock server.
+        app.stop();
+    }
+
+    // ---- Assertion helpers ---------------------------------------------------------------
+
+    protected void awaitDeploymentExists(String name) {
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() ->
+                assertThat(client.apps().deployments().inNamespace(namespace).withName(name).get())
+                        .isNotNull());
+    }
+
+    protected void awaitDeploymentSpecReplicas(String name, int replicas) {
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() ->
+                assertThat(client.apps().deployments().inNamespace(namespace).withName(name).get()
+                        .getSpec().getReplicas()).isEqualTo(replicas));
+    }
+
+    protected void awaitDeploymentAbsent(String name) {
+        await().during(MOCK_STABILITY).atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions()
+                .untilAsserted(() ->
+                        assertThat(client.apps().deployments().inNamespace(namespace).withName(name).get())
+                                .isNull());
+    }
+
+    protected void awaitServiceExists(String name) {
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() ->
+                assertThat(client.services().inNamespace(namespace).withName(name).get()).isNotNull());
+    }
+
+    protected void awaitServiceAbsent(String name) {
+        await().during(MOCK_STABILITY).atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions()
+                .untilAsserted(() ->
+                        assertThat(client.services().inNamespace(namespace).withName(name).get()).isNull());
+    }
+
+    protected void awaitIngressExists(String name) {
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() ->
+                assertThat(client.network().v1().ingresses().inNamespace(namespace).withName(name).get())
+                        .isNotNull());
+    }
+
+    protected void awaitIngressAbsent(String name) {
+        await().during(MOCK_STABILITY).atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions()
+                .untilAsserted(() ->
+                        assertThat(client.network().v1().ingresses().inNamespace(namespace).withName(name).get())
+                                .isNull());
+    }
+
+    protected <T extends HasMetadata> T awaitResourceExists(
+            String name, Supplier<T> fetcher) {
+        Cell<T> result = cell();
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            T resource = fetcher.get();
+            assertThat(resource).isNotNull();
+            result.set(resource);
+        });
+        return result.get();
+    }
+
+    protected <T extends HasMetadata> void awaitResourceAbsent(Supplier<T> fetcher) {
+        await().during(MOCK_STABILITY).atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions()
+                .untilAsserted(() -> assertThat(fetcher.get()).isNull());
+    }
+
+    protected ApicurioRegistry3 createRegistry(ApicurioRegistry3 registry) {
+        registry.getMetadata().setNamespace(namespace);
+        return client.resource(registry).inNamespace(namespace).create();
+    }
+
+    protected ApicurioRegistry3 updateRegistry(ApicurioRegistry3 registry, Consumer<ApicurioRegistry3> updater) {
+        await().atMost(ofSeconds(30)).until(() -> {
+            try {
+                updater.accept(registry);
+                client.resource(registry).inNamespace(namespace).update();
+                return true;
+            } catch (Exception ex) {
+                if (ex.getMessage() != null && ex.getMessage().contains("modified")) {
+                    var fresh = client.resource(registry).inNamespace(namespace).get();
+                    registry.setMetadata(fresh.getMetadata());
+                    return false;
+                }
+                throw ex;
+            }
+        });
+        return client.resource(registry).inNamespace(namespace).get();
+    }
+
+    protected String deploymentName(ApicurioRegistry3 registry, String component) {
+        return registry.getMetadata().getName() + "-" + component + "-deployment";
+    }
+
+    protected String serviceName(ApicurioRegistry3 registry, String component) {
+        return registry.getMetadata().getName() + "-" + component + "-service";
+    }
+
+    protected String ingressName(ApicurioRegistry3 registry, String component) {
+        return registry.getMetadata().getName() + "-" + component + "-ingress";
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/NetworkPolicyReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/NetworkPolicyReconcileTest.java
@@ -1,0 +1,62 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_UI;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Mock-server equivalent of {@code NetworkPolicyITTest}.
+ */
+@QuarkusTest
+public class NetworkPolicyReconcileTest extends MockServerTestBase {
+
+    @Test
+    void networkPoliciesCreated() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        createRegistry(registry);
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+
+        String appPolicyName = registry.getMetadata().getName() + "-" + COMPONENT_APP + "-networkpolicy";
+        String uiPolicyName = registry.getMetadata().getName() + "-" + COMPONENT_UI + "-networkpolicy";
+
+        NetworkPolicy appPolicy = awaitResourceExists(appPolicyName,
+                () -> client.network().v1().networkPolicies().inNamespace(namespace).withName(appPolicyName).get());
+        NetworkPolicy uiPolicy = awaitResourceExists(uiPolicyName,
+                () -> client.network().v1().networkPolicies().inNamespace(namespace).withName(uiPolicyName).get());
+
+        assertLabelsContains(appPolicy.getMetadata().getLabels(),
+                "app.kubernetes.io/component=app",
+                "app.kubernetes.io/managed-by=apicurio-registry-operator",
+                "app.kubernetes.io/name=apicurio-registry");
+        assertLabelsContains(appPolicy.getSpec().getPodSelector().getMatchLabels(),
+                "app.kubernetes.io/component=app",
+                "app.kubernetes.io/name=apicurio-registry",
+                "app.kubernetes.io/instance=" + registry.getMetadata().getName());
+
+        assertLabelsContains(uiPolicy.getMetadata().getLabels(),
+                "app.kubernetes.io/component=ui",
+                "app.kubernetes.io/managed-by=apicurio-registry-operator",
+                "app.kubernetes.io/name=apicurio-registry");
+        assertLabelsContains(uiPolicy.getSpec().getPodSelector().getMatchLabels(),
+                "app.kubernetes.io/component=ui",
+                "app.kubernetes.io/name=apicurio-registry",
+                "app.kubernetes.io/instance=" + registry.getMetadata().getName());
+    }
+
+    private static void assertLabelsContains(Map<String, String> labels, String... expected) {
+        assertThat(labels.entrySet().stream()
+                .map(e -> e.getKey() + "=" + e.getValue())
+                .collect(Collectors.toSet())).contains(expected);
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/PodDisruptionBudgetReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/PodDisruptionBudgetReconcileTest.java
@@ -1,0 +1,70 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_UI;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Mock-server equivalent of {@code PodDisruptionBudgetITTest}.
+ *
+ * <p>
+ * The PDB spec (labels, selectors) is verified here. The {@code status.expectedPods} and
+ * {@code status.disruptionsAllowed} fields are set asynchronously by the real Kubernetes PDB
+ * controller and are not available in the mock; those assertions remain in the IT suite.
+ */
+@QuarkusTest
+public class PodDisruptionBudgetReconcileTest extends MockServerTestBase {
+
+    @Test
+    void podDisruptionBudgetsCreated() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getSpec().getApp().setReplicas(2);
+        createRegistry(registry);
+
+        awaitDeploymentSpecReplicas(deploymentName(registry, COMPONENT_APP), 2);
+
+        String appPdbName = registry.getMetadata().getName() + "-" + COMPONENT_APP + "-poddisruptionbudget";
+        String uiPdbName = registry.getMetadata().getName() + "-" + COMPONENT_UI + "-poddisruptionbudget";
+
+        PodDisruptionBudget appPdb = awaitResourceExists(appPdbName,
+                () -> client.policy().v1().podDisruptionBudget()
+                        .inNamespace(namespace).withName(appPdbName).get());
+        PodDisruptionBudget uiPdb = awaitResourceExists(uiPdbName,
+                () -> client.policy().v1().podDisruptionBudget()
+                        .inNamespace(namespace).withName(uiPdbName).get());
+
+        assertLabelsContains(appPdb.getMetadata().getLabels(),
+                "app.kubernetes.io/component=app",
+                "app.kubernetes.io/managed-by=apicurio-registry-operator",
+                "app.kubernetes.io/name=apicurio-registry");
+        assertLabelsContains(appPdb.getSpec().getSelector().getMatchLabels(),
+                "app.kubernetes.io/component=app",
+                "app.kubernetes.io/name=apicurio-registry",
+                "app.kubernetes.io/instance=" + registry.getMetadata().getName());
+
+        assertLabelsContains(uiPdb.getMetadata().getLabels(),
+                "app.kubernetes.io/component=ui",
+                "app.kubernetes.io/managed-by=apicurio-registry-operator",
+                "app.kubernetes.io/name=apicurio-registry");
+        assertLabelsContains(uiPdb.getSpec().getSelector().getMatchLabels(),
+                "app.kubernetes.io/component=ui",
+                "app.kubernetes.io/name=apicurio-registry",
+                "app.kubernetes.io/instance=" + registry.getMetadata().getName());
+    }
+
+    private static void assertLabelsContains(Map<String, String> labels, String... expected) {
+        assertThat(labels.entrySet().stream()
+                .map(e -> e.getKey() + "=" + e.getValue())
+                .collect(Collectors.toSet())).contains(expected);
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/SmokeReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/SmokeReconcileTest.java
@@ -1,0 +1,158 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.EnvironmentVariables;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.apicurio.registry.operator.api.v1.ContainerNames.REGISTRY_APP_CONTAINER_NAME;
+import static io.apicurio.registry.operator.api.v1.ContainerNames.REGISTRY_UI_CONTAINER_NAME;
+import static io.apicurio.registry.operator.resource.Labels.getSelectorLabels;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_UI;
+import static io.apicurio.registry.operator.resource.app.AppDeploymentResource.getContainerFromDeployment;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Mock-server variants of the spec-output-only tests from {@code SmokeITTest}.
+ * Tests that require running pods ({@code testService}, {@code testIngress}) remain in the IT suite.
+ */
+@QuarkusTest
+public class SmokeReconcileTest extends MockServerTestBase {
+
+    @Test
+    void smoke() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        createRegistry(registry);
+
+        var expectedSelectorApp = getSelectorLabels(registry, COMPONENT_APP);
+        var expectedSelectorUi = getSelectorLabels(registry, COMPONENT_UI);
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            // App Deployment exists with correct replica count and image
+            var appDeployment = client.apps().deployments().inNamespace(namespace)
+                    .withName(deploymentName(registry, COMPONENT_APP)).get();
+            assertThat(appDeployment).isNotNull();
+            assertThat(appDeployment.getSpec().getReplicas()).isEqualTo(1);
+            assertThat(appDeployment.getSpec().getTemplate().getMetadata().getLabels())
+                    .containsAllEntriesOf(expectedSelectorApp);
+
+            // UI Deployment
+            var uiDeployment = client.apps().deployments().inNamespace(namespace)
+                    .withName(deploymentName(registry, COMPONENT_UI)).get();
+            assertThat(uiDeployment).isNotNull();
+            assertThat(uiDeployment.getSpec().getReplicas()).isEqualTo(1);
+            assertThat(uiDeployment.getSpec().getTemplate().getMetadata().getLabels())
+                    .containsAllEntriesOf(expectedSelectorUi);
+
+            // Services
+            assertThat(client.services().inNamespace(namespace)
+                    .withName(serviceName(registry, COMPONENT_APP)).get()).isNotNull();
+            assertThat(client.services().inNamespace(namespace)
+                    .withName(serviceName(registry, COMPONENT_UI)).get()).isNotNull();
+
+            // Ingresses
+            assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                    .withName(ingressName(registry, COMPONENT_APP)).get()).isNotNull();
+            assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                    .withName(ingressName(registry, COMPONENT_UI)).get()).isNotNull();
+        });
+
+        // CORS: allowed origins set from the UI ingress host
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            String uiHost = client.network().v1().ingresses().inNamespace(namespace)
+                    .withName(ingressName(registry, COMPONENT_UI)).get()
+                    .getSpec().getRules().get(0).getHost();
+            String expectedCors = "http://" + uiHost + "," + "https://" + uiHost;
+            var appEnv = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_APP)).get(),
+                    REGISTRY_APP_CONTAINER_NAME).getEnv();
+            assertThat(appEnv).map(ev -> ev.getName() + "=" + ev.getValue())
+                    .contains(EnvironmentVariables.QUARKUS_HTTP_CORS_ORIGINS + "=" + expectedCors);
+        });
+    }
+
+    @Test
+    void replicas() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        createRegistry(registry);
+
+        // Initial: 1 replica each
+        awaitDeploymentSpecReplicas(deploymentName(registry, COMPONENT_APP), 1);
+        awaitDeploymentSpecReplicas(deploymentName(registry, COMPONENT_UI), 1);
+
+        // Scale up
+        updateRegistry(registry, r -> {
+            r.getSpec().getApp().setReplicas(3);
+            r.getSpec().getUi().setReplicas(3);
+        });
+        awaitDeploymentSpecReplicas(deploymentName(registry, COMPONENT_APP), 3);
+        awaitDeploymentSpecReplicas(deploymentName(registry, COMPONENT_UI), 3);
+
+        // Scale down
+        updateRegistry(registry, r -> {
+            r.getSpec().getApp().setReplicas(2);
+            r.getSpec().getUi().setReplicas(2);
+        });
+        awaitDeploymentSpecReplicas(deploymentName(registry, COMPONENT_APP), 2);
+        awaitDeploymentSpecReplicas(deploymentName(registry, COMPONENT_UI), 2);
+    }
+
+    @Test
+    void emptyHostDisablesIngress() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getSpec().getApp().getIngress().setHost("app.example.com");
+        registry.getSpec().getUi().getIngress().setHost("ui.example.com");
+        createRegistry(registry);
+
+        awaitIngressExists(ingressName(registry, COMPONENT_APP));
+        awaitIngressExists(ingressName(registry, COMPONENT_UI));
+
+        // Check that REGISTRY_API_URL is set while ingress is enabled
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var uiDeployment = client.apps().deployments().inNamespace(namespace)
+                    .withName(deploymentName(registry, COMPONENT_UI)).get();
+            assertThat(uiDeployment).isNotNull();
+            assertThat(uiDeployment.getSpec().getTemplate().getSpec().getContainers())
+                    .filteredOn(c -> REGISTRY_UI_CONTAINER_NAME.equals(c.getName()))
+                    .flatMap(io.fabric8.kubernetes.api.model.Container::getEnv)
+                    .filteredOn(e -> "REGISTRY_API_URL".equals(e.getName()))
+                    .hasSize(1);
+        });
+
+        // Disable ingresses
+        updateRegistry(registry, r -> {
+            r.getSpec().getApp().getIngress().setHost("");
+            r.getSpec().getUi().getIngress().setHost("");
+        });
+
+        awaitIngressAbsent(ingressName(registry, COMPONENT_APP));
+        awaitIngressAbsent(ingressName(registry, COMPONENT_UI));
+
+        // REGISTRY_API_URL should be gone
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var uiDeployment = client.apps().deployments().inNamespace(namespace)
+                    .withName(deploymentName(registry, COMPONENT_UI)).get();
+            assertThat(uiDeployment).isNotNull();
+            assertThat(uiDeployment.getSpec().getTemplate().getSpec().getContainers())
+                    .filteredOn(c -> REGISTRY_UI_CONTAINER_NAME.equals(c.getName()))
+                    .flatMap(io.fabric8.kubernetes.api.model.Container::getEnv)
+                    .filteredOn(e -> "REGISTRY_API_URL".equals(e.getName()))
+                    .isEmpty();
+        });
+
+        // Re-enable
+        updateRegistry(registry, r -> {
+            r.getSpec().getApp().getIngress().setHost("app.example.com");
+            r.getSpec().getUi().getIngress().setHost("ui.example.com");
+        });
+        awaitIngressExists(ingressName(registry, COMPONENT_APP));
+        awaitIngressExists(ingressName(registry, COMPONENT_UI));
+    }
+}

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogDiscovery.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogDiscovery.java
@@ -104,6 +104,15 @@ public class CatalogDiscovery {
                     entries.add(new ChannelEntry(csvName, parseVersion(versionRaw)));
                 }
 
+                var hasCurrentCsv = entries.stream()
+                        .anyMatch(e -> e.getCsvName().equals(currentCSV));
+                if (!hasCurrentCsv) {
+                    log.warn("Channel {} entries do not include currentCSV {}. Adding it as head.",
+                            name, currentCSV);
+                    entries.add(new ChannelEntry(currentCSV,
+                            parseVersion(extractVersionString(currentCSV))));
+                }
+
                 if (!entries.get(0).getCsvName().equals(currentCSV)) {
                     log.warn("Channel {} entries are not head-first: first entry is {} but "
                                     + "currentCSV is {}. Reordering.", name,


### PR DESCRIPTION

## Summary

Follow-up to #9695. This PR adds a mock Kubernetes API server test covering deletion of an `ApicurioRegistry3` resource and the operator's cleanup/finalizer path.

The test verifies that dependent resources created during reconciliation have the expected Kubernetes owner references and that deleting the Registry CR allows the operator's cleanup process to complete successfully.

## What this tests

- Creates an `ApicurioRegistry3` resource using the Fabric8 mock Kubernetes API server.
- Waits for the operator to reconcile the resource and create its Deployment and Service.
- Verifies that both dependent resources have the expected owner reference:
  - `kind`: `ApicurioRegistry3`
  - `name`: the Registry CR name
  - `uid`: the Registry CR UID
- Deletes the Registry CR.
- Waits for the operator's finalizer/cleanup process to complete.
- Verifies that the Registry CR is removed from the mock Kubernetes API.

## Mock-server limitation

The Deployment and Service are `GarbageCollected` dependent resources rather than `Deleter` resources. Their deletion relies on Kubernetes' native owner-reference garbage collector in a real cluster.

The Fabric8 CRUD mock server does not implement Kubernetes garbage collection, so this test does not assert that the Deployment and Service are cascade-deleted by the mock server.

Instead, the test verifies the owner references that enable Kubernetes garbage collection in a real cluster and separately verifies that the operator's own cleanup/finalizer path completes successfully.

No sleeps or production-code workarounds are used.

## Scope

- Test-only change.
- No production code changes.
- Follow-up to the mock-server reconciliation POC in #9695
- Existing real-cluster integration tests remain responsible for validating actual Kubernetes garbage-collection behavior.

