### PR TITLE
Fix startup error messages for unreachable storage dependencies

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/RegistryStorageProducer.java
+++ b/app/src/main/java/io/apicurio/registry/storage/RegistryStorageProducer.java
@@ -80,6 +80,12 @@ public class RegistryStorageProducer {
         return cachedCurrent;
     }
 
+    @ConfigProperty(name = "apicurio.datasource.url", defaultValue = "unknown")
+    String jdbcUrl;
+
+    @ConfigProperty(name = "apicurio.kafkasql.bootstrap.servers", defaultValue = "unknown")
+    String kafkaBootstrapServers;
+
     @Produces
     @ApplicationScoped
     @Raw
@@ -98,11 +104,50 @@ public class RegistryStorageProducer {
                         .format("No Registry storage variant defined for value %s", registryStorageType));
             }
 
-            cachedRaw.initialize();
+            try {
+                cachedRaw.initialize();
+            } catch (Exception e) {
+                if ("sql".equals(registryStorageType) && isSqlExceptionInCause(e)) {
+                    log.debug("Database connection failure", e);
+                    throw new RuntimeException(String.format(
+                            "ERROR: PostgreSQL not reachable at %s. Check that the database is running and the connection URL is correct.",
+                            jdbcUrl), e);
+                }
+                if ("kafkasql".equals(registryStorageType) && isTimeoutExceptionInCause(e)) {
+                    log.debug("Kafka connection failure", e);
+                    throw new RuntimeException(String.format(
+                            "ERROR: Kafka not reachable at %s. Check that Kafka is running and the bootstrap servers are correct.",
+                            kafkaBootstrapServers), e);
+                }
+                throw e;
+            }
+
             log.info("Using the following RegistryStorage implementation: {}",
                     cachedRaw.getClass().getName());
         }
         return cachedRaw;
+    }
+
+    private boolean isSqlExceptionInCause(Throwable e) {
+        Throwable current = e;
+        while (current != null) {
+            if (current instanceof java.sql.SQLException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private boolean isTimeoutExceptionInCause(Throwable e) {
+        Throwable current = e;
+        while (current != null) {
+            if (current instanceof java.util.concurrent.TimeoutException || current.getClass().getSimpleName().contains("TimeoutException")) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     @Produces

--- a/app/src/test/java/io/apicurio/registry/storage/RegistryStorageProducerTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/RegistryStorageProducerTest.java
@@ -1,0 +1,90 @@
+package io.apicurio.registry.storage;
+
+import io.apicurio.registry.storage.error.RegistryStorageException;
+import io.apicurio.registry.storage.impl.kafkasql.KafkaSqlRegistryStorage;
+import io.apicurio.registry.storage.impl.sql.SqlRegistryStorage;
+import jakarta.enterprise.inject.Instance;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+public class RegistryStorageProducerTest {
+
+    private RegistryStorageProducer producer;
+    private SqlRegistryStorage sqlRegistryStorageMock;
+    private KafkaSqlRegistryStorage kafkaSqlRegistryStorageMock;
+
+    @BeforeEach
+    public void setup() {
+        producer = new RegistryStorageProducer();
+        producer.log = Mockito.mock(org.slf4j.Logger.class);
+
+        sqlRegistryStorageMock = Mockito.mock(SqlRegistryStorage.class);
+        Instance<SqlRegistryStorage> sqlInstance = Mockito.mock(Instance.class);
+        when(sqlInstance.get()).thenReturn(sqlRegistryStorageMock);
+        producer.sqlRegistryStorage = sqlInstance;
+
+        kafkaSqlRegistryStorageMock = Mockito.mock(KafkaSqlRegistryStorage.class);
+        Instance<KafkaSqlRegistryStorage> kafkaSqlInstance = Mockito.mock(Instance.class);
+        when(kafkaSqlInstance.get()).thenReturn(kafkaSqlRegistryStorageMock);
+        producer.kafkaSqlRegistryStorage = kafkaSqlInstance;
+    }
+
+    @Test
+    public void testSqlStorageConnectionFailure() {
+        producer.registryStorageType = "sql";
+        producer.jdbcUrl = "jdbc:postgresql://invalid-db:5432/registry";
+        
+        SQLException sqlException = new SQLException("Connection refused");
+        RegistryStorageException wrapperException = new RegistryStorageException(sqlException);
+        
+        doThrow(wrapperException).when(sqlRegistryStorageMock).initialize();
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
+            producer.raw();
+        });
+
+        assertEquals("ERROR: PostgreSQL not reachable at jdbc:postgresql://invalid-db:5432/registry. Check that the database is running and the connection URL is correct.", thrown.getMessage());
+        assertEquals(wrapperException, thrown.getCause());
+    }
+
+    @Test
+    public void testKafkaSqlStorageConnectionFailure() {
+        producer.registryStorageType = "kafkasql";
+        producer.kafkaBootstrapServers = "invalid-broker:9092";
+        
+        TimeoutException timeoutException = new TimeoutException("Timed out waiting for a node assignment.");
+        
+        doThrow(timeoutException).when(kafkaSqlRegistryStorageMock).initialize();
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
+            producer.raw();
+        });
+
+        assertEquals("ERROR: Kafka not reachable at invalid-broker:9092. Check that Kafka is running and the bootstrap servers are correct.", thrown.getMessage());
+        assertEquals(timeoutException, thrown.getCause());
+    }
+
+    @Test
+    public void testOtherExceptionsAreNotWrapped() {
+        producer.registryStorageType = "sql";
+        producer.jdbcUrl = "jdbc:postgresql://db:5432/registry";
+        
+        IllegalArgumentException otherException = new IllegalArgumentException("Some other error");
+        doThrow(otherException).when(sqlRegistryStorageMock).initialize();
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
+            producer.raw();
+        });
+
+        assertEquals("Some other error", thrown.getMessage());
+    }
+}


### PR DESCRIPTION
Fixes #9679 
- SQL/PostgreSQL connection failures now produce an actionable message containing the configured JDBC URL.
- KafkaSQL timeout failures now produce an actionable message containing the configured bootstrap servers.
- Original exceptions are preserved as causes.
- Tests cover SQL failure, KafkaSQL timeout, and unrelated exceptions.
- Focused tests passed: 3 tests, 0 failures, 0 errors, 0 skipped.