### PR TITLE
test(operator): add mock Kubernetes API server test tier

### DIFF
--- a/operator/controller/pom.xml
+++ b/operator/controller/pom.xml
@@ -72,6 +72,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-kubernetes-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/AppFeaturesReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/AppFeaturesReconcileTest.java
@@ -1,0 +1,106 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.EnvironmentVariables;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.spec.AppFeaturesSpec;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.apicurio.registry.operator.api.v1.ContainerNames.REGISTRY_APP_CONTAINER_NAME;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static io.apicurio.registry.operator.resource.app.AppDeploymentResource.getContainerFromDeployment;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Mock-server equivalents of {@code AppFeaturesITTest}.
+ * All tests verify only env var presence/absence on the Deployment spec.
+ */
+@QuarkusTest
+public class AppFeaturesReconcileTest extends MockServerTestBase {
+
+    @Test
+    void allowDeletesTrue() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getSpec().getApp().setFeatures(AppFeaturesSpec.builder().resourceDeleteEnabled(true).build());
+        createRegistry(registry);
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var env = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_APP)).get(),
+                    REGISTRY_APP_CONTAINER_NAME).getEnv();
+            assertThat(env).map(EnvVar::getName).contains(
+                    EnvironmentVariables.APICURIO_REST_DELETION_ARTIFACT_ENABLED,
+                    EnvironmentVariables.APICURIO_REST_DELETION_ARTIFACT_VERSION_ENABLED,
+                    EnvironmentVariables.APICURIO_REST_DELETION_GROUP_ENABLED);
+        });
+    }
+
+    @Test
+    void allowDeletesDefault() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        createRegistry(registry);
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var env = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_APP)).get(),
+                    REGISTRY_APP_CONTAINER_NAME).getEnv();
+            assertThat(env).map(EnvVar::getName).doesNotContain(
+                    EnvironmentVariables.APICURIO_REST_DELETION_ARTIFACT_ENABLED,
+                    EnvironmentVariables.APICURIO_REST_DELETION_ARTIFACT_VERSION_ENABLED,
+                    EnvironmentVariables.APICURIO_REST_DELETION_GROUP_ENABLED);
+        });
+    }
+
+    @Test
+    void versionMutabilityEnabledTrue() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getSpec().getApp().setFeatures(AppFeaturesSpec.builder().versionMutabilityEnabled(true).build());
+        createRegistry(registry);
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var env = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_APP)).get(),
+                    REGISTRY_APP_CONTAINER_NAME).getEnv();
+            assertThat(env)
+                    .filteredOn(e -> e.getName().equals(
+                            EnvironmentVariables.APICURIO_REST_MUTABILITY_ARTIFACT_VERSION_CONTENT_ENABLED))
+                    .hasSize(1)
+                    .first()
+                    .extracting(EnvVar::getValue)
+                    .isEqualTo("true");
+        });
+    }
+
+    @Test
+    void versionMutabilityEnabledDefault() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        createRegistry(registry);
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var env = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_APP)).get(),
+                    REGISTRY_APP_CONTAINER_NAME).getEnv();
+            assertThat(env).map(EnvVar::getName)
+                    .doesNotContain(EnvironmentVariables.APICURIO_REST_MUTABILITY_ARTIFACT_VERSION_CONTENT_ENABLED);
+        });
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/CRUpdateReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/CRUpdateReconcileTest.java
@@ -1,0 +1,41 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Mock-server equivalent of {@code CRUpdateITTest}: verifies that a deprecated CR spec is
+ * automatically migrated to the current form on creation.
+ */
+@QuarkusTest
+public class CRUpdateReconcileTest extends MockServerTestBase {
+
+    @Test
+    void crSpecMigrated() {
+        var deprecated = ResourceFactory.deserialize(
+                "/k8s/examples/simple-deprecated.apicurioregistry3.yaml", ApicurioRegistry3.class);
+        var expectedSpec = ResourceFactory.deserialize(
+                "/k8s/examples/simple.apicurioregistry3.yaml", ApicurioRegistry3.class).getSpec();
+
+        createRegistry(deprecated);
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL)
+                .ignoreExceptionsInstanceOf(KubernetesClientException.class)
+                .untilAsserted(() -> {
+                    var updated = client.resources(ApicurioRegistry3.class)
+                            .inNamespace(namespace).list().getItems().stream()
+                            .filter(r -> r.getMetadata().getName().equals(deprecated.getMetadata().getName()))
+                            .toList();
+                    assertThat(updated).hasSize(1);
+                    assertThat(updated.get(0).getSpec())
+                            .usingRecursiveComparison()
+                            .isEqualTo(expectedSpec);
+                });
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/DisableUIReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/DisableUIReconcileTest.java
@@ -1,0 +1,53 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_UI;
+
+/**
+ * Mock-server equivalent of {@code DisableUIITTest}.
+ */
+@QuarkusTest
+public class DisableUIReconcileTest extends MockServerTestBase {
+
+    @Test
+    void disableUI() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getSpec().getApp().getIngress().setHost("app.example.com");
+        registry.getSpec().getUi().getIngress().setHost("ui.example.com");
+        createRegistry(registry);
+
+        // Everything should be created
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_UI));
+        awaitServiceExists(serviceName(registry, COMPONENT_APP));
+        awaitServiceExists(serviceName(registry, COMPONENT_UI));
+        awaitIngressExists(ingressName(registry, COMPONENT_APP));
+        awaitIngressExists(ingressName(registry, COMPONENT_UI));
+
+        // Disable UI
+        updateRegistry(registry, r -> r.getSpec().getUi().setEnabled(false));
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+        awaitDeploymentAbsent(deploymentName(registry, COMPONENT_UI));
+        awaitServiceExists(serviceName(registry, COMPONENT_APP));
+        awaitServiceAbsent(serviceName(registry, COMPONENT_UI));
+        awaitIngressExists(ingressName(registry, COMPONENT_APP));
+        awaitIngressAbsent(ingressName(registry, COMPONENT_UI));
+
+        // Re-enable UI
+        updateRegistry(registry, r -> r.getSpec().getUi().setEnabled(true));
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_UI));
+        awaitServiceExists(serviceName(registry, COMPONENT_APP));
+        awaitServiceExists(serviceName(registry, COMPONENT_UI));
+        awaitIngressExists(ingressName(registry, COMPONENT_APP));
+        awaitIngressExists(ingressName(registry, COMPONENT_UI));
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/EnvReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/EnvReconcileTest.java
@@ -1,0 +1,131 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.apicurio.registry.operator.api.v1.ContainerNames.REGISTRY_APP_CONTAINER_NAME;
+import static io.apicurio.registry.operator.api.v1.ContainerNames.REGISTRY_UI_CONTAINER_NAME;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_UI;
+import static io.apicurio.registry.operator.resource.app.AppDeploymentResource.getContainerFromDeployment;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Mock-server equivalent of {@code EnvITTest}: verifies env var propagation and ordering.
+ */
+@QuarkusTest
+public class EnvReconcileTest extends MockServerTestBase {
+
+    private static final String[] DEFAULT_APP_ENV = {
+            "QUARKUS_PROFILE",
+            "QUARKUS_HTTP_ACCESS_LOG_ENABLED",
+            "QUARKUS_HTTP_CORS_ORIGINS"
+    };
+
+    private static final String[] DEFAULT_UI_ENV = {"REGISTRY_API_URL"};
+
+    @Test
+    void envVars() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getSpec().getApp().getIngress().setHost("app.example.com");
+        registry.getSpec().getUi().getIngress().setHost("ui.example.com");
+        createRegistry(registry);
+
+        // Default env vars are set exactly once
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var appEnv = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_APP)).get(),
+                    REGISTRY_APP_CONTAINER_NAME).getEnv();
+            assertThat(appEnv).map(EnvVar::getName).containsOnlyOnce(DEFAULT_APP_ENV);
+
+            var uiEnv = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_UI)).get(),
+                    REGISTRY_UI_CONTAINER_NAME).getEnv();
+            assertThat(uiEnv).map(EnvVar::getName).containsOnlyOnce(DEFAULT_UI_ENV);
+        });
+
+        // Add custom env vars and override a default one
+        updateRegistry(registry, r -> {
+            r.getSpec().getApp().setEnv(List.of(
+                    new EnvVarBuilder().withName("APP_VAR_1_NAME").withValue("APP_VAR_1_VALUE").build(),
+                    new EnvVarBuilder().withName("QUARKUS_HTTP_ACCESS_LOG_ENABLED").withValue("false").build(),
+                    new EnvVarBuilder().withName("APP_VAR_2_NAME").withValue("APP_VAR_2_VALUE").build()
+            ));
+            r.getSpec().getUi().setEnv(List.of(
+                    new EnvVarBuilder().withName("UI_VAR_1_NAME").withValue("UI_VAR_1_VALUE").build(),
+                    new EnvVarBuilder().withName("REGISTRY_API_URL").withValue("FOO").build(),
+                    new EnvVarBuilder().withName("UI_VAR_2_NAME").withValue("UI_VAR_2_VALUE").build()
+            ));
+        });
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var appEnv = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_APP)).get(),
+                    REGISTRY_APP_CONTAINER_NAME).getEnv();
+            assertThat(appEnv).map(EnvVar::getName).containsOnlyOnce(DEFAULT_APP_ENV);
+            assertThat(appEnv.stream().filter(e -> "QUARKUS_HTTP_ACCESS_LOG_ENABLED".equals(e.getName()))
+                    .map(EnvVar::getValue).findAny()).hasValue("false");
+            assertThat(appEnv).containsSubsequence(
+                    new EnvVarBuilder().withName("APP_VAR_1_NAME").withValue("APP_VAR_1_VALUE").build(),
+                    new EnvVarBuilder().withName("APP_VAR_2_NAME").withValue("APP_VAR_2_VALUE").build()
+            );
+
+            var uiEnv = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_UI)).get(),
+                    REGISTRY_UI_CONTAINER_NAME).getEnv();
+            assertThat(uiEnv).map(EnvVar::getName).containsOnlyOnce(DEFAULT_UI_ENV);
+            assertThat(uiEnv.stream().filter(e -> "REGISTRY_API_URL".equals(e.getName()))
+                    .map(EnvVar::getValue).findAny()).hasValue("FOO");
+            assertThat(uiEnv).containsSubsequence(
+                    new EnvVarBuilder().withName("UI_VAR_1_NAME").withValue("UI_VAR_1_VALUE").build(),
+                    new EnvVarBuilder().withName("UI_VAR_2_NAME").withValue("UI_VAR_2_VALUE").build()
+            );
+        });
+
+        // Change order: verify ordering is respected
+        updateRegistry(registry, r -> {
+            r.getSpec().getApp().setEnv(List.of(
+                    new EnvVarBuilder().withName("APP_VAR_2_NAME").withValue("APP_VAR_2_VALUE").build(),
+                    new EnvVarBuilder().withName("QUARKUS_HTTP_ACCESS_LOG_ENABLED").withValue("false").build(),
+                    new EnvVarBuilder().withName("APP_VAR_1_NAME").withValue("APP_VAR_1_VALUE").build()
+            ));
+            r.getSpec().getUi().setEnv(List.of(
+                    new EnvVarBuilder().withName("UI_VAR_2_NAME").withValue("UI_VAR_2_VALUE").build(),
+                    new EnvVarBuilder().withName("REGISTRY_API_URL").withValue("FOO").build(),
+                    new EnvVarBuilder().withName("UI_VAR_1_NAME").withValue("UI_VAR_1_VALUE").build()
+            ));
+        });
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var appEnv = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_APP)).get(),
+                    REGISTRY_APP_CONTAINER_NAME).getEnv();
+            assertThat(appEnv).containsSubsequence(
+                    new EnvVarBuilder().withName("APP_VAR_2_NAME").withValue("APP_VAR_2_VALUE").build(),
+                    new EnvVarBuilder().withName("APP_VAR_1_NAME").withValue("APP_VAR_1_VALUE").build()
+            );
+
+            var uiEnv = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_UI)).get(),
+                    REGISTRY_UI_CONTAINER_NAME).getEnv();
+            assertThat(uiEnv).containsSubsequence(
+                    new EnvVarBuilder().withName("UI_VAR_2_NAME").withValue("UI_VAR_2_VALUE").build(),
+                    new EnvVarBuilder().withName("UI_VAR_1_NAME").withValue("UI_VAR_1_VALUE").build()
+            );
+        });
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/HorizontalPodAutoscalerReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/HorizontalPodAutoscalerReconcileTest.java
@@ -1,0 +1,81 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.spec.AutoscalingSpec;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Mock-server equivalents of {@code HorizontalPodAutoscalerITTest}.
+ */
+@QuarkusTest
+public class HorizontalPodAutoscalerReconcileTest extends MockServerTestBase {
+
+    @Test
+    void hpaCreated() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        var autoscaling = new AutoscalingSpec();
+        autoscaling.setEnabled(true);
+        autoscaling.setMinReplicas(1);
+        autoscaling.setMaxReplicas(3);
+        autoscaling.setTargetCPUUtilizationPercentage(70);
+        registry.getSpec().getApp().setAutoscaling(autoscaling);
+        createRegistry(registry);
+
+        String hpaName = registry.getMetadata().getName() + "-" + COMPONENT_APP + "-horizontalpodautoscaler";
+        HorizontalPodAutoscaler hpa = awaitResourceExists(hpaName,
+                () -> client.autoscaling().v2().horizontalPodAutoscalers()
+                        .inNamespace(namespace).withName(hpaName).get());
+
+        assertThat(hpa.getSpec().getScaleTargetRef().getName())
+                .isEqualTo(deploymentName(registry, COMPONENT_APP));
+        assertThat(hpa.getSpec().getMinReplicas()).isEqualTo(1);
+        assertThat(hpa.getSpec().getMaxReplicas()).isEqualTo(3);
+        assertThat(hpa.getSpec().getMetrics()).hasSize(1);
+        assertThat(hpa.getSpec().getMetrics().get(0).getResource().getName()).isEqualTo("cpu");
+        assertThat(hpa.getSpec().getMetrics().get(0).getResource().getTarget()
+                .getAverageUtilization()).isEqualTo(70);
+    }
+
+    @Test
+    void hpaCreatedWithMemory() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        var autoscaling = new AutoscalingSpec();
+        autoscaling.setEnabled(true);
+        autoscaling.setMinReplicas(2);
+        autoscaling.setMaxReplicas(5);
+        autoscaling.setTargetCPUUtilizationPercentage(60);
+        autoscaling.setTargetMemoryUtilizationPercentage(75);
+        registry.getSpec().getApp().setAutoscaling(autoscaling);
+        createRegistry(registry);
+
+        String hpaName = registry.getMetadata().getName() + "-" + COMPONENT_APP + "-horizontalpodautoscaler";
+        HorizontalPodAutoscaler hpa = awaitResourceExists(hpaName,
+                () -> client.autoscaling().v2().horizontalPodAutoscalers()
+                        .inNamespace(namespace).withName(hpaName).get());
+
+        assertThat(hpa.getSpec().getMinReplicas()).isEqualTo(2);
+        assertThat(hpa.getSpec().getMaxReplicas()).isEqualTo(5);
+        assertThat(hpa.getSpec().getMetrics()).hasSize(2);
+    }
+
+    @Test
+    void hpaNotCreatedWhenDisabled() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        createRegistry(registry);
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+
+        String hpaName = registry.getMetadata().getName() + "-" + COMPONENT_APP + "-horizontalpodautoscaler";
+        awaitResourceAbsent(() -> client.autoscaling().v2().horizontalPodAutoscalers()
+                .inNamespace(namespace).withName(hpaName).get());
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/IngressReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/IngressReconcileTest.java
@@ -1,0 +1,67 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_UI;
+import static io.apicurio.registry.operator.resource.ResourceFactory.deserialize;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Mock-server equivalent of the spec-propagation part of {@code IngressITTest}.
+ *
+ * <p>
+ * The {@code ingressAnnotations()} test from the IT suite exercises SSA field-manager semantics
+ * (non-managed annotations are preserved across reconciliations) and is not migrated here.
+ */
+@QuarkusTest
+public class IngressReconcileTest extends MockServerTestBase {
+
+    @Test
+    void ingressClassName() {
+        var primary = deserialize("/k8s/examples/ingress/ingress-class-name.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        primary.getSpec().getApp().getIngress().setHost("app.example.com");
+        primary.getSpec().getUi().getIngress().setHost("ui.example.com");
+        createRegistry(primary);
+
+        // Initial class names from the CR
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                    .withName(ingressName(primary, COMPONENT_APP)).get()).isNotNull();
+            assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                    .withName(ingressName(primary, COMPONENT_APP)).get()
+                    .getSpec().getIngressClassName()).isEqualTo("haproxy-app");
+
+            assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                    .withName(ingressName(primary, COMPONENT_UI)).get()).isNotNull();
+            assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                    .withName(ingressName(primary, COMPONENT_UI)).get()
+                    .getSpec().getIngressClassName()).isEqualTo("haproxy-ui");
+        });
+
+        // Update app class name
+        updateRegistry(primary, p -> p.getSpec().getApp().getIngress().setIngressClassName("test---nginx"));
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() ->
+                assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                        .withName(ingressName(primary, COMPONENT_APP)).get()
+                        .getSpec().getIngressClassName()).isEqualTo("test---nginx"));
+
+        // UI class name unchanged
+        assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                .withName(ingressName(primary, COMPONENT_UI)).get()
+                .getSpec().getIngressClassName()).isEqualTo("haproxy-ui");
+
+        // Clear app class name
+        updateRegistry(primary, p -> p.getSpec().getApp().getIngress().setIngressClassName(""));
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() ->
+                assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                        .withName(ingressName(primary, COMPONENT_APP)).get()
+                        .getSpec().getIngressClassName()).isNotEqualTo("test---nginx"));
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/KubernetesOpsRbacReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/KubernetesOpsRbacReconcileTest.java
@@ -1,0 +1,116 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.spec.KubernetesOpsSpec;
+import io.apicurio.registry.operator.api.v1.spec.StorageType;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Mock-server equivalents of {@code KubernetesOpsRbacITTest}.
+ */
+@QuarkusTest
+public class KubernetesOpsRbacReconcileTest extends MockServerTestBase {
+
+    @Test
+    void rbacResourcesCreatedForKubernetesOps() {
+        var registry = registryWithKubernetesOps("rbac-create");
+        createRegistry(registry);
+
+        String saName = registry.getMetadata().getName() + "-kubeops";
+
+        // ServiceAccount
+        awaitResourceExists(saName,
+                () -> client.serviceAccounts().inNamespace(namespace).withName(saName).get());
+
+        // Role with correct permissions
+        var role = awaitResourceExists(saName,
+                () -> client.rbac().roles().inNamespace(namespace).withName(saName).get());
+        assertThat(role.getRules()).hasSize(1);
+        assertThat(role.getRules().get(0).getApiGroups()).containsExactly("");
+        assertThat(role.getRules().get(0).getResources()).containsExactly("configmaps");
+        assertThat(role.getRules().get(0).getVerbs()).containsExactlyInAnyOrder("get", "list", "watch");
+
+        // RoleBinding linking SA to Role
+        var rb = awaitResourceExists(saName,
+                () -> client.rbac().roleBindings().inNamespace(namespace).withName(saName).get());
+        assertThat(rb.getRoleRef().getKind()).isEqualTo("Role");
+        assertThat(rb.getRoleRef().getName()).isEqualTo(saName);
+        assertThat(rb.getSubjects()).hasSize(1);
+        assertThat(rb.getSubjects().get(0).getKind()).isEqualTo("ServiceAccount");
+        assertThat(rb.getSubjects().get(0).getName()).isEqualTo(saName);
+        assertThat(rb.getSubjects().get(0).getNamespace()).isEqualTo(namespace);
+
+        // Deployment has serviceAccountName set
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var deployment = client.apps().deployments().inNamespace(namespace)
+                    .withName(deploymentName(registry, COMPONENT_APP)).get();
+            assertThat(deployment).isNotNull();
+            assertThat(deployment.getSpec().getTemplate().getSpec().getServiceAccountName())
+                    .isEqualTo(saName);
+        });
+    }
+
+    @Test
+    void rbacResourcesNotCreatedWithoutKubernetesOps() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getMetadata().setName("rbac-absent");
+        createRegistry(registry);
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+
+        String saName = registry.getMetadata().getName() + "-kubeops";
+        assertThat(client.serviceAccounts().inNamespace(namespace).withName(saName).get()).isNull();
+        assertThat(client.rbac().roles().inNamespace(namespace).withName(saName).get()).isNull();
+        assertThat(client.rbac().roleBindings().inNamespace(namespace).withName(saName).get()).isNull();
+
+        var deployment = client.apps().deployments().inNamespace(namespace)
+                .withName(deploymentName(registry, COMPONENT_APP)).get();
+        assertThat(deployment.getSpec().getTemplate().getSpec().getServiceAccountName())
+                .isNotEqualTo(saName);
+    }
+
+    @Test
+    void rbacResourcesCleanedUpOnStorageTypeChange() {
+        var registry = registryWithKubernetesOps("rbac-cleanup");
+        createRegistry(registry);
+
+        String saName = registry.getMetadata().getName() + "-kubeops";
+
+        // Wait for RBAC resources
+        awaitResourceExists(saName,
+                () -> client.serviceAccounts().inNamespace(namespace).withName(saName).get());
+        awaitResourceExists(saName,
+                () -> client.rbac().roles().inNamespace(namespace).withName(saName).get());
+        awaitResourceExists(saName,
+                () -> client.rbac().roleBindings().inNamespace(namespace).withName(saName).get());
+
+        // Switch to in-memory storage
+        updateRegistry(registry, r -> {
+            r.getSpec().getApp().getStorage().setType(null);
+            r.getSpec().getApp().getStorage().setKubernetesops(null);
+        });
+
+        // RBAC resources should be removed
+        awaitResourceAbsent(() -> client.serviceAccounts().inNamespace(namespace).withName(saName).get());
+        awaitResourceAbsent(() -> client.rbac().roles().inNamespace(namespace).withName(saName).get());
+        awaitResourceAbsent(() -> client.rbac().roleBindings().inNamespace(namespace).withName(saName).get());
+    }
+
+    private ApicurioRegistry3 registryWithKubernetesOps(String name) {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getMetadata().setName(name);
+        registry.getSpec().getApp().withStorage().setType(StorageType.KUBERNETESOPS);
+        var k8sOps = new KubernetesOpsSpec();
+        k8sOps.setRegistryId("test-registry");
+        registry.getSpec().getApp().getStorage().setKubernetesops(k8sOps);
+        return registry;
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/MockServerTestBase.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/MockServerTestBase.java
@@ -1,0 +1,192 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.App;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.utils.Cell;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static io.apicurio.registry.utils.Cell.cell;
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Base class for operator reconciliation tests that run against a Fabric8 CRUD mock Kubernetes
+ * API server instead of a real cluster. Each test method gets a fresh namespace; the operator is
+ * started before every method and stopped after.
+ *
+ * <p>
+ * <b>SSA coverage disclaimer:</b> the Fabric8 CRUD mock server does not implement Server-Side
+ * Apply. All dependent resource classes in this operator already extend
+ * {@code CRUDKubernetesDependentResource}, so CRUD semantics match the mock. However, any
+ * SSA-specific behavior (field-manager ownership, conflict resolution, annotation merge) requires
+ * the real-cluster IT suite.
+ *
+ * <p>
+ * Tests that verify pod readiness, real HTTP endpoints, or external infrastructure (Kafka,
+ * Keycloak, databases) must remain in the IT suite.
+ */
+@WithKubernetesTestServer(crud = true)
+public abstract class MockServerTestBase {
+
+    protected static final Duration MOCK_TIMEOUT = ofSeconds(10);
+    protected static final Duration MOCK_POLL = ofMillis(50);
+    protected static final Duration MOCK_STABILITY = ofSeconds(3);
+
+    @Inject
+    protected KubernetesClient client;
+
+    protected String namespace;
+
+    private App app;
+
+    @BeforeEach
+    void setUpMockBase() {
+        namespace = "test-" + UUID.randomUUID().toString().substring(0, 7);
+        client.resource(new NamespaceBuilder().withNewMetadata().withName(namespace).endMetadata().build())
+                .create();
+
+        app = CDI.current().select(App.class).get();
+        app.start(configOverride -> {
+            configOverride.withKubernetesClient(client);
+            configOverride.withUseSSAToPatchPrimaryResource(false);
+            // Safety: disable SSA for all resource types the operator manages, in case the
+            // mock server ever encounters a PATCH-upsert path.
+            configOverride.withDefaultNonSSAResource(Set.of(
+                    Deployment.class, io.fabric8.kubernetes.api.model.Service.class, Ingress.class,
+                    HorizontalPodAutoscaler.class, NetworkPolicy.class, PodDisruptionBudget.class,
+                    ServiceAccount.class, Role.class, RoleBinding.class
+            ));
+            // The injected KubernetesClient is a CDI-managed singleton owned by the
+            // quarkus-test-kubernetes-client extension. Prevent the operator from closing it on
+            // stop, since the client is shared across test methods.
+            configOverride.withCloseClientOnStop(false);
+        });
+    }
+
+    @AfterEach
+    void tearDownMockBase() {
+        // Stop the JOSDK ControllerManager so informers/watches registered by this test's
+        // App instance are torn down. Without this, each test would accumulate a new live
+        // reconciler watching all namespaces on the shared mock server.
+        app.stop();
+    }
+
+    // ---- Assertion helpers ---------------------------------------------------------------
+
+    protected void awaitDeploymentExists(String name) {
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() ->
+                assertThat(client.apps().deployments().inNamespace(namespace).withName(name).get())
+                        .isNotNull());
+    }
+
+    protected void awaitDeploymentSpecReplicas(String name, int replicas) {
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() ->
+                assertThat(client.apps().deployments().inNamespace(namespace).withName(name).get()
+                        .getSpec().getReplicas()).isEqualTo(replicas));
+    }
+
+    protected void awaitDeploymentAbsent(String name) {
+        await().during(MOCK_STABILITY).atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions()
+                .untilAsserted(() ->
+                        assertThat(client.apps().deployments().inNamespace(namespace).withName(name).get())
+                                .isNull());
+    }
+
+    protected void awaitServiceExists(String name) {
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() ->
+                assertThat(client.services().inNamespace(namespace).withName(name).get()).isNotNull());
+    }
+
+    protected void awaitServiceAbsent(String name) {
+        await().during(MOCK_STABILITY).atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions()
+                .untilAsserted(() ->
+                        assertThat(client.services().inNamespace(namespace).withName(name).get()).isNull());
+    }
+
+    protected void awaitIngressExists(String name) {
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() ->
+                assertThat(client.network().v1().ingresses().inNamespace(namespace).withName(name).get())
+                        .isNotNull());
+    }
+
+    protected void awaitIngressAbsent(String name) {
+        await().during(MOCK_STABILITY).atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions()
+                .untilAsserted(() ->
+                        assertThat(client.network().v1().ingresses().inNamespace(namespace).withName(name).get())
+                                .isNull());
+    }
+
+    protected <T extends HasMetadata> T awaitResourceExists(
+            String name, Supplier<T> fetcher) {
+        Cell<T> result = cell();
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            T resource = fetcher.get();
+            assertThat(resource).isNotNull();
+            result.set(resource);
+        });
+        return result.get();
+    }
+
+    protected <T extends HasMetadata> void awaitResourceAbsent(Supplier<T> fetcher) {
+        await().during(MOCK_STABILITY).atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions()
+                .untilAsserted(() -> assertThat(fetcher.get()).isNull());
+    }
+
+    protected ApicurioRegistry3 createRegistry(ApicurioRegistry3 registry) {
+        registry.getMetadata().setNamespace(namespace);
+        return client.resource(registry).inNamespace(namespace).create();
+    }
+
+    protected ApicurioRegistry3 updateRegistry(ApicurioRegistry3 registry, Consumer<ApicurioRegistry3> updater) {
+        await().atMost(ofSeconds(30)).until(() -> {
+            try {
+                updater.accept(registry);
+                client.resource(registry).inNamespace(namespace).update();
+                return true;
+            } catch (Exception ex) {
+                if (ex.getMessage() != null && ex.getMessage().contains("modified")) {
+                    var fresh = client.resource(registry).inNamespace(namespace).get();
+                    registry.setMetadata(fresh.getMetadata());
+                    return false;
+                }
+                throw ex;
+            }
+        });
+        return client.resource(registry).inNamespace(namespace).get();
+    }
+
+    protected String deploymentName(ApicurioRegistry3 registry, String component) {
+        return registry.getMetadata().getName() + "-" + component + "-deployment";
+    }
+
+    protected String serviceName(ApicurioRegistry3 registry, String component) {
+        return registry.getMetadata().getName() + "-" + component + "-service";
+    }
+
+    protected String ingressName(ApicurioRegistry3 registry, String component) {
+        return registry.getMetadata().getName() + "-" + component + "-ingress";
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/NetworkPolicyReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/NetworkPolicyReconcileTest.java
@@ -1,0 +1,62 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_UI;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Mock-server equivalent of {@code NetworkPolicyITTest}.
+ */
+@QuarkusTest
+public class NetworkPolicyReconcileTest extends MockServerTestBase {
+
+    @Test
+    void networkPoliciesCreated() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        createRegistry(registry);
+
+        awaitDeploymentExists(deploymentName(registry, COMPONENT_APP));
+
+        String appPolicyName = registry.getMetadata().getName() + "-" + COMPONENT_APP + "-networkpolicy";
+        String uiPolicyName = registry.getMetadata().getName() + "-" + COMPONENT_UI + "-networkpolicy";
+
+        NetworkPolicy appPolicy = awaitResourceExists(appPolicyName,
+                () -> client.network().v1().networkPolicies().inNamespace(namespace).withName(appPolicyName).get());
+        NetworkPolicy uiPolicy = awaitResourceExists(uiPolicyName,
+                () -> client.network().v1().networkPolicies().inNamespace(namespace).withName(uiPolicyName).get());
+
+        assertLabelsContains(appPolicy.getMetadata().getLabels(),
+                "app.kubernetes.io/component=app",
+                "app.kubernetes.io/managed-by=apicurio-registry-operator",
+                "app.kubernetes.io/name=apicurio-registry");
+        assertLabelsContains(appPolicy.getSpec().getPodSelector().getMatchLabels(),
+                "app.kubernetes.io/component=app",
+                "app.kubernetes.io/name=apicurio-registry",
+                "app.kubernetes.io/instance=" + registry.getMetadata().getName());
+
+        assertLabelsContains(uiPolicy.getMetadata().getLabels(),
+                "app.kubernetes.io/component=ui",
+                "app.kubernetes.io/managed-by=apicurio-registry-operator",
+                "app.kubernetes.io/name=apicurio-registry");
+        assertLabelsContains(uiPolicy.getSpec().getPodSelector().getMatchLabels(),
+                "app.kubernetes.io/component=ui",
+                "app.kubernetes.io/name=apicurio-registry",
+                "app.kubernetes.io/instance=" + registry.getMetadata().getName());
+    }
+
+    private static void assertLabelsContains(Map<String, String> labels, String... expected) {
+        assertThat(labels.entrySet().stream()
+                .map(e -> e.getKey() + "=" + e.getValue())
+                .collect(Collectors.toSet())).contains(expected);
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/PodDisruptionBudgetReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/PodDisruptionBudgetReconcileTest.java
@@ -1,0 +1,70 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_UI;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Mock-server equivalent of {@code PodDisruptionBudgetITTest}.
+ *
+ * <p>
+ * The PDB spec (labels, selectors) is verified here. The {@code status.expectedPods} and
+ * {@code status.disruptionsAllowed} fields are set asynchronously by the real Kubernetes PDB
+ * controller and are not available in the mock; those assertions remain in the IT suite.
+ */
+@QuarkusTest
+public class PodDisruptionBudgetReconcileTest extends MockServerTestBase {
+
+    @Test
+    void podDisruptionBudgetsCreated() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getSpec().getApp().setReplicas(2);
+        createRegistry(registry);
+
+        awaitDeploymentSpecReplicas(deploymentName(registry, COMPONENT_APP), 2);
+
+        String appPdbName = registry.getMetadata().getName() + "-" + COMPONENT_APP + "-poddisruptionbudget";
+        String uiPdbName = registry.getMetadata().getName() + "-" + COMPONENT_UI + "-poddisruptionbudget";
+
+        PodDisruptionBudget appPdb = awaitResourceExists(appPdbName,
+                () -> client.policy().v1().podDisruptionBudget()
+                        .inNamespace(namespace).withName(appPdbName).get());
+        PodDisruptionBudget uiPdb = awaitResourceExists(uiPdbName,
+                () -> client.policy().v1().podDisruptionBudget()
+                        .inNamespace(namespace).withName(uiPdbName).get());
+
+        assertLabelsContains(appPdb.getMetadata().getLabels(),
+                "app.kubernetes.io/component=app",
+                "app.kubernetes.io/managed-by=apicurio-registry-operator",
+                "app.kubernetes.io/name=apicurio-registry");
+        assertLabelsContains(appPdb.getSpec().getSelector().getMatchLabels(),
+                "app.kubernetes.io/component=app",
+                "app.kubernetes.io/name=apicurio-registry",
+                "app.kubernetes.io/instance=" + registry.getMetadata().getName());
+
+        assertLabelsContains(uiPdb.getMetadata().getLabels(),
+                "app.kubernetes.io/component=ui",
+                "app.kubernetes.io/managed-by=apicurio-registry-operator",
+                "app.kubernetes.io/name=apicurio-registry");
+        assertLabelsContains(uiPdb.getSpec().getSelector().getMatchLabels(),
+                "app.kubernetes.io/component=ui",
+                "app.kubernetes.io/name=apicurio-registry",
+                "app.kubernetes.io/instance=" + registry.getMetadata().getName());
+    }
+
+    private static void assertLabelsContains(Map<String, String> labels, String... expected) {
+        assertThat(labels.entrySet().stream()
+                .map(e -> e.getKey() + "=" + e.getValue())
+                .collect(Collectors.toSet())).contains(expected);
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/mock/SmokeReconcileTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/mock/SmokeReconcileTest.java
@@ -1,0 +1,158 @@
+package io.apicurio.registry.operator.mock;
+
+import io.apicurio.registry.operator.EnvironmentVariables;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.apicurio.registry.operator.api.v1.ContainerNames.REGISTRY_APP_CONTAINER_NAME;
+import static io.apicurio.registry.operator.api.v1.ContainerNames.REGISTRY_UI_CONTAINER_NAME;
+import static io.apicurio.registry.operator.resource.Labels.getSelectorLabels;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_UI;
+import static io.apicurio.registry.operator.resource.app.AppDeploymentResource.getContainerFromDeployment;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Mock-server variants of the spec-output-only tests from {@code SmokeITTest}.
+ * Tests that require running pods ({@code testService}, {@code testIngress}) remain in the IT suite.
+ */
+@QuarkusTest
+public class SmokeReconcileTest extends MockServerTestBase {
+
+    @Test
+    void smoke() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        createRegistry(registry);
+
+        var expectedSelectorApp = getSelectorLabels(registry, COMPONENT_APP);
+        var expectedSelectorUi = getSelectorLabels(registry, COMPONENT_UI);
+
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            // App Deployment exists with correct replica count and image
+            var appDeployment = client.apps().deployments().inNamespace(namespace)
+                    .withName(deploymentName(registry, COMPONENT_APP)).get();
+            assertThat(appDeployment).isNotNull();
+            assertThat(appDeployment.getSpec().getReplicas()).isEqualTo(1);
+            assertThat(appDeployment.getSpec().getTemplate().getMetadata().getLabels())
+                    .containsAllEntriesOf(expectedSelectorApp);
+
+            // UI Deployment
+            var uiDeployment = client.apps().deployments().inNamespace(namespace)
+                    .withName(deploymentName(registry, COMPONENT_UI)).get();
+            assertThat(uiDeployment).isNotNull();
+            assertThat(uiDeployment.getSpec().getReplicas()).isEqualTo(1);
+            assertThat(uiDeployment.getSpec().getTemplate().getMetadata().getLabels())
+                    .containsAllEntriesOf(expectedSelectorUi);
+
+            // Services
+            assertThat(client.services().inNamespace(namespace)
+                    .withName(serviceName(registry, COMPONENT_APP)).get()).isNotNull();
+            assertThat(client.services().inNamespace(namespace)
+                    .withName(serviceName(registry, COMPONENT_UI)).get()).isNotNull();
+
+            // Ingresses
+            assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                    .withName(ingressName(registry, COMPONENT_APP)).get()).isNotNull();
+            assertThat(client.network().v1().ingresses().inNamespace(namespace)
+                    .withName(ingressName(registry, COMPONENT_UI)).get()).isNotNull();
+        });
+
+        // CORS: allowed origins set from the UI ingress host
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            String uiHost = client.network().v1().ingresses().inNamespace(namespace)
+                    .withName(ingressName(registry, COMPONENT_UI)).get()
+                    .getSpec().getRules().get(0).getHost();
+            String expectedCors = "http://" + uiHost + "," + "https://" + uiHost;
+            var appEnv = getContainerFromDeployment(
+                    client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(registry, COMPONENT_APP)).get(),
+                    REGISTRY_APP_CONTAINER_NAME).getEnv();
+            assertThat(appEnv).map(ev -> ev.getName() + "=" + ev.getValue())
+                    .contains(EnvironmentVariables.QUARKUS_HTTP_CORS_ORIGINS + "=" + expectedCors);
+        });
+    }
+
+    @Test
+    void replicas() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        createRegistry(registry);
+
+        // Initial: 1 replica each
+        awaitDeploymentSpecReplicas(deploymentName(registry, COMPONENT_APP), 1);
+        awaitDeploymentSpecReplicas(deploymentName(registry, COMPONENT_UI), 1);
+
+        // Scale up
+        updateRegistry(registry, r -> {
+            r.getSpec().getApp().setReplicas(3);
+            r.getSpec().getUi().setReplicas(3);
+        });
+        awaitDeploymentSpecReplicas(deploymentName(registry, COMPONENT_APP), 3);
+        awaitDeploymentSpecReplicas(deploymentName(registry, COMPONENT_UI), 3);
+
+        // Scale down
+        updateRegistry(registry, r -> {
+            r.getSpec().getApp().setReplicas(2);
+            r.getSpec().getUi().setReplicas(2);
+        });
+        awaitDeploymentSpecReplicas(deploymentName(registry, COMPONENT_APP), 2);
+        awaitDeploymentSpecReplicas(deploymentName(registry, COMPONENT_UI), 2);
+    }
+
+    @Test
+    void emptyHostDisablesIngress() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        registry.getSpec().getApp().getIngress().setHost("app.example.com");
+        registry.getSpec().getUi().getIngress().setHost("ui.example.com");
+        createRegistry(registry);
+
+        awaitIngressExists(ingressName(registry, COMPONENT_APP));
+        awaitIngressExists(ingressName(registry, COMPONENT_UI));
+
+        // Check that REGISTRY_API_URL is set while ingress is enabled
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var uiDeployment = client.apps().deployments().inNamespace(namespace)
+                    .withName(deploymentName(registry, COMPONENT_UI)).get();
+            assertThat(uiDeployment).isNotNull();
+            assertThat(uiDeployment.getSpec().getTemplate().getSpec().getContainers())
+                    .filteredOn(c -> REGISTRY_UI_CONTAINER_NAME.equals(c.getName()))
+                    .flatMap(io.fabric8.kubernetes.api.model.Container::getEnv)
+                    .filteredOn(e -> "REGISTRY_API_URL".equals(e.getName()))
+                    .hasSize(1);
+        });
+
+        // Disable ingresses
+        updateRegistry(registry, r -> {
+            r.getSpec().getApp().getIngress().setHost("");
+            r.getSpec().getUi().getIngress().setHost("");
+        });
+
+        awaitIngressAbsent(ingressName(registry, COMPONENT_APP));
+        awaitIngressAbsent(ingressName(registry, COMPONENT_UI));
+
+        // REGISTRY_API_URL should be gone
+        await().atMost(MOCK_TIMEOUT).pollInterval(MOCK_POLL).ignoreExceptions().untilAsserted(() -> {
+            var uiDeployment = client.apps().deployments().inNamespace(namespace)
+                    .withName(deploymentName(registry, COMPONENT_UI)).get();
+            assertThat(uiDeployment).isNotNull();
+            assertThat(uiDeployment.getSpec().getTemplate().getSpec().getContainers())
+                    .filteredOn(c -> REGISTRY_UI_CONTAINER_NAME.equals(c.getName()))
+                    .flatMap(io.fabric8.kubernetes.api.model.Container::getEnv)
+                    .filteredOn(e -> "REGISTRY_API_URL".equals(e.getName()))
+                    .isEmpty();
+        });
+
+        // Re-enable
+        updateRegistry(registry, r -> {
+            r.getSpec().getApp().getIngress().setHost("app.example.com");
+            r.getSpec().getUi().getIngress().setHost("ui.example.com");
+        });
+        awaitIngressExists(ingressName(registry, COMPONENT_APP));
+        awaitIngressExists(ingressName(registry, COMPONENT_UI));
+    }
+}

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogDiscovery.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogDiscovery.java
@@ -104,6 +104,15 @@ public class CatalogDiscovery {
                     entries.add(new ChannelEntry(csvName, parseVersion(versionRaw)));
                 }
 
+                var hasCurrentCsv = entries.stream()
+                        .anyMatch(e -> e.getCsvName().equals(currentCSV));
+                if (!hasCurrentCsv) {
+                    log.warn("Channel {} entries do not include currentCSV {}. Adding it as head.",
+                            name, currentCSV);
+                    entries.add(new ChannelEntry(currentCSV,
+                            parseVersion(extractVersionString(currentCSV))));
+                }
+
                 if (!entries.get(0).getCsvName().equals(currentCSV)) {
                     log.warn("Channel {} entries are not head-first: first entry is {} but "
                                     + "currentCSV is {}. Reordering.", name,


### PR DESCRIPTION
## What

Introduces a mock-server reconciliation test tier that exercises the operator's desired-state output without requiring a real cluster or Minikube. Tests run against the Fabric8 CRUD mock server via `quarkus-test-kubernetes-client` and complete in seconds.

## Why

The operator test pyramid is currently inverted: almost all coverage lives in the slow cluster-dependent IT suite (22-29 min per shard). This PR adds the missing middle tier — fast tests that verify the reconciler produces the correct Kubernetes resource specs without needing running pods.

**What is covered here:**
- Does the reconciler create the right Deployments, Services, Ingresses with the right spec?
- Are env vars propagated correctly from the CR spec?
- Are conditional resources (HPA, NetworkPolicy, PDB, RBAC for KubernetesOps) created/deleted at the right times?
- Does CR spec migration (deprecated → current) work?

**What stays in the IT suite (intentionally not migrated):**
- `SmokeITTest#testService/testIngress` — port-forward + real HTTP to a running pod
- `StatusConditionsTest` — kills a real pod and watches kubelet reschedule
- `IngressITTest#ingressAnnotations` — SSA field-manager merge semantics
- `PodDisruptionBudgetITTest` status assertions — requires real PDB controller
- All AUTH, KAFKA, DATABASE, FEATURE_SETUP tests — require real infrastructure

## Changes

- Add `io.quarkus:quarkus-test-kubernetes-client` test dependency
- Add `MockServerTestBase` — base class wiring the JOSDK ControllerManager against the mock server per test method
- Add 10 test classes (19 tests total) migrated from the FEATURE/SMOKE IT shards:
  - `SmokeReconcileTest` (3 tests)
  - `AppFeaturesReconcileTest` (4 tests)
  - `EnvReconcileTest` (1 test)
  - `DisableUIReconcileTest` (1 test)
  - `HorizontalPodAutoscalerReconcileTest` (3 tests)
  - `NetworkPolicyReconcileTest` (1 test)
  - `PodDisruptionBudgetReconcileTest` (1 test — spec only; status assertions stay in IT)
  - `KubernetesOpsRbacReconcileTest` (3 tests)
  - `IngressReconcileTest` (1 test — className only)
  - `CRUpdateReconcileTest` (1 test)

The original IT tests are **not removed** — they continue to provide SSA coverage, pod-readiness checks, and real-cluster validation.

## SSA disclaimer

The Fabric8 CRUD mock server does not implement Server-Side Apply. All dependent resource classes in this operator already extend `CRUDKubernetesDependentResource`, so CRUD semantics match the mock. SSA-specific behavior (field-manager ownership, conflict resolution, merge semantics) continues to be covered only by the real-cluster IT suite.
