### PR TITLE
fix(rules): support YAML formatted artifacts in AgentCard and McpTool compatibility checkers

### DIFF
--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/AgentCardCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/AgentCardCompatibilityChecker.java
@@ -2,6 +2,7 @@ package io.apicurio.registry.rules.compatibility;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.apicurio.registry.content.TypedContent;
 
 import java.util.HashSet;
@@ -29,7 +30,7 @@ import java.util.Set;
 public class AgentCardCompatibilityChecker
         extends AbstractCompatibilityChecker<AgentCardCompatibilityDifference> {
 
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
 
     @Override
     protected Set<AgentCardCompatibilityDifference> isBackwardsCompatibleWith(String existing,
@@ -37,8 +38,8 @@ public class AgentCardCompatibilityChecker
         Set<AgentCardCompatibilityDifference> differences = new HashSet<>();
 
         try {
-            JsonNode existingNode = mapper.readTree(existing);
-            JsonNode proposedNode = mapper.readTree(proposed);
+            JsonNode existingNode = parseContent(existing);
+            JsonNode proposedNode = parseContent(proposed);
 
             checkInterfaceCompatibility(existingNode, proposedNode, differences);
             checkSkillRemovals(existingNode, proposedNode, differences);
@@ -56,6 +57,10 @@ public class AgentCardCompatibilityChecker
         }
 
         return differences;
+    }
+
+    private JsonNode parseContent(String content) throws Exception {
+        return yamlMapper.readTree(content);
     }
 
     private void checkInterfaceCompatibility(JsonNode existing, JsonNode proposed,

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
@@ -2,6 +2,7 @@ package io.apicurio.registry.rules.compatibility;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.apicurio.registry.content.TypedContent;
 
 import java.util.HashSet;
@@ -23,7 +24,7 @@ import java.util.Set;
 public class McpToolCompatibilityChecker
         extends AbstractCompatibilityChecker<McpToolCompatibilityDifference> {
 
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
 
     @Override
     protected Set<McpToolCompatibilityDifference> isBackwardsCompatibleWith(String existing,
@@ -31,8 +32,8 @@ public class McpToolCompatibilityChecker
         Set<McpToolCompatibilityDifference> differences = new HashSet<>();
 
         try {
-            JsonNode existingNode = mapper.readTree(existing);
-            JsonNode proposedNode = mapper.readTree(proposed);
+            JsonNode existingNode = parseContent(existing);
+            JsonNode proposedNode = parseContent(proposed);
 
             // Check inputSchema type changes
             checkInputSchemaTypeChange(existingNode, proposedNode, differences);
@@ -53,6 +54,10 @@ public class McpToolCompatibilityChecker
         }
 
         return differences;
+    }
+
+    private JsonNode parseContent(String content) throws Exception {
+        return yamlMapper.readTree(content);
     }
 
     private void checkInputSchemaTypeChange(JsonNode existing, JsonNode proposed,

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/ModelSchemaCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/ModelSchemaCompatibilityChecker.java
@@ -23,7 +23,6 @@ import java.util.Set;
 public class ModelSchemaCompatibilityChecker
         extends AbstractCompatibilityChecker<ModelSchemaCompatibilityDifference> {
 
-    private static final ObjectMapper jsonMapper = new ObjectMapper();
     private static final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
 
     @Override
@@ -48,10 +47,6 @@ public class ModelSchemaCompatibilityChecker
     }
 
     private JsonNode parseContent(String content) throws Exception {
-        String trimmed = content.trim();
-        if (trimmed.startsWith("{")) {
-            return jsonMapper.readTree(content);
-        }
         return yamlMapper.readTree(content);
     }
 

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/PromptTemplateCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/PromptTemplateCompatibilityChecker.java
@@ -26,7 +26,6 @@ import java.util.Set;
 public class PromptTemplateCompatibilityChecker
         extends AbstractCompatibilityChecker<PromptTemplateCompatibilityDifference> {
 
-    private static final ObjectMapper jsonMapper = new ObjectMapper();
     private static final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
 
     @Override
@@ -51,10 +50,6 @@ public class PromptTemplateCompatibilityChecker
     }
 
     private JsonNode parseContent(String content) throws Exception {
-        String trimmed = content.trim();
-        if (trimmed.startsWith("{")) {
-            return jsonMapper.readTree(content);
-        }
         return yamlMapper.readTree(content);
     }
 

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/AgentCardCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/AgentCardCompatibilityCheckerTest.java
@@ -510,4 +510,161 @@ class AgentCardCompatibilityCheckerTest {
         assertEquals(2, result.getIncompatibleDifferences().size(),
                 "Both the disabled boolean capability and the removed extension should be reported");
     }
+
+    private TypedContent createAgentCardYaml(String yaml) {
+        return TypedContent.create(ContentHandle.create(yaml), ContentTypes.APPLICATION_YAML);
+    }
+
+    @Test
+    void testBackwardCompatibleYamlFormat() {
+        String existing = """
+                name: TestAgent
+                description: Test agent
+                version: 1.0.0
+                supportedInterfaces:
+                  - url: https://example.com/agent
+                    protocolBinding: http+json
+                    protocolVersion: "1.0"
+                capabilities: {}
+                skills:
+                  - id: skill1
+                    name: Skill 1
+                    description: A skill
+                defaultInputModes:
+                  - text
+                defaultOutputModes:
+                  - text
+                """;
+
+        String proposed = """
+                name: TestAgent
+                description: Test agent updated
+                version: 1.1.0
+                supportedInterfaces:
+                  - url: https://example.com/agent
+                    protocolBinding: http+json
+                    protocolVersion: "1.0"
+                capabilities: {}
+                skills:
+                  - id: skill1
+                    name: Skill 1
+                    description: A skill
+                  - id: skill2
+                    name: Skill 2
+                    description: Added skill
+                defaultInputModes:
+                  - text
+                defaultOutputModes:
+                  - text
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCardYaml(existing)),
+                createAgentCardYaml(proposed),
+                Map.of());
+
+        assertTrue(result.isCompatible(), "Adding a skill in YAML format should be backward compatible");
+    }
+
+    @Test
+    void testBackwardIncompatibleYamlFormat() {
+        String existing = """
+                name: TestAgent
+                description: Test agent
+                version: 1.0.0
+                supportedInterfaces:
+                  - url: https://example.com/agent
+                    protocolBinding: http+json
+                    protocolVersion: "1.0"
+                capabilities: {}
+                skills:
+                  - id: skill1
+                    name: Skill 1
+                    description: A skill
+                  - id: skill2
+                    name: Skill 2
+                    description: Skill 2
+                defaultInputModes:
+                  - text
+                defaultOutputModes:
+                  - text
+                """;
+
+        String proposed = """
+                name: TestAgent
+                description: Test agent
+                version: 1.1.0
+                supportedInterfaces:
+                  - url: https://example.com/agent
+                    protocolBinding: http+json
+                    protocolVersion: "1.0"
+                capabilities: {}
+                skills:
+                  - id: skill1
+                    name: Skill 1
+                    description: A skill
+                defaultInputModes:
+                  - text
+                defaultOutputModes:
+                  - text
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCardYaml(existing)),
+                createAgentCardYaml(proposed),
+                Map.of());
+
+        assertFalse(result.isCompatible(), "Removing a skill in YAML format should be backward incompatible");
+        assertEquals(1, result.getIncompatibleDifferences().size());
+    }
+
+    @Test
+    void testCrossFormatCompatibilityJsonToYaml() {
+        String existing = baseCard(SKILL1, "");
+        String proposed = """
+                name: TestAgent
+                description: Test agent
+                version: 1.1.0
+                supportedInterfaces:
+                  - url: https://example.com/agent
+                    protocolBinding: http+json
+                    protocolVersion: "1.0"
+                capabilities: {}
+                skills:
+                  - id: skill1
+                    name: Skill 1
+                    description: A skill
+                  - id: skill2
+                    name: Skill 2
+                    description: Another skill
+                defaultInputModes:
+                  - text
+                defaultOutputModes:
+                  - text
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCard(existing)),
+                createAgentCardYaml(proposed),
+                Map.of());
+
+        assertTrue(result.isCompatible(), "Updating from JSON to YAML should be backward compatible");
+    }
+
+    @Test
+    void testBackwardCompatibleYamlFlowMapping() {
+        String existing = "{name: TestAgent, description: Test agent, version: 1.0.0, supportedInterfaces: [{url: \"https://example.com/agent\", protocolBinding: http+json, protocolVersion: \"1.0\"}], capabilities: {}, skills: [{id: skill1, name: Skill 1, description: A skill}], defaultInputModes: [text], defaultOutputModes: [text]}";
+        String proposed = "{name: TestAgent, description: Test agent, version: 1.1.0, supportedInterfaces: [{url: \"https://example.com/agent\", protocolBinding: http+json, protocolVersion: \"1.0\"}], capabilities: {}, skills: [{id: skill1, name: Skill 1, description: A skill}, {id: skill2, name: Skill 2, description: Added skill}], defaultInputModes: [text], defaultOutputModes: [text]}";
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD,
+                List.of(createAgentCardYaml(existing)),
+                createAgentCardYaml(proposed),
+                Map.of());
+
+        assertTrue(result.isCompatible(), "YAML flow mapping syntax should be parsed and backward compatible");
+    }
 }

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -343,5 +344,128 @@ class McpToolCompatibilityCheckerTest {
                 createMcpTool(proposed), Map.of());
 
         assertTrue(result.isCompatible(), "Identical schema with description change should be fully compatible");
+    }
+
+    private TypedContent createMcpToolYaml(String yaml) {
+        return TypedContent.create(ContentHandle.create(yaml), ContentTypes.APPLICATION_YAML);
+    }
+
+    @Test
+    void testBackwardCompatibleYamlFormat() {
+        String existing = """
+                name: test_tool
+                description: An MCP tool
+                inputSchema:
+                  type: object
+                  properties:
+                    query:
+                      type: string
+                  required:
+                    - query
+                """;
+
+        String proposed = """
+                name: test_tool
+                description: An MCP tool
+                inputSchema:
+                  type: object
+                  properties:
+                    query:
+                      type: string
+                    limit:
+                      type: integer
+                  required:
+                    - query
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpToolYaml(existing)),
+                createMcpToolYaml(proposed), Map.of());
+
+        assertTrue(result.isCompatible(), "Adding optional parameter in YAML should be backward compatible");
+    }
+
+    @Test
+    void testBackwardIncompatibleYamlFormat() {
+        String existing = """
+                name: test_tool
+                description: An MCP tool
+                inputSchema:
+                  type: object
+                  properties:
+                    query:
+                      type: string
+                    limit:
+                      type: integer
+                  required:
+                    - query
+                """;
+
+        String proposed = """
+                name: test_tool
+                description: An MCP tool
+                inputSchema:
+                  type: object
+                  properties:
+                    query:
+                      type: string
+                  required:
+                    - query
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpToolYaml(existing)),
+                createMcpToolYaml(proposed), Map.of());
+
+        assertFalse(result.isCompatible(), "Removing an input property in YAML should be backward incompatible");
+        assertEquals(1, result.getIncompatibleDifferences().size());
+    }
+
+    @Test
+    void testCrossFormatCompatibilityJsonToYaml() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        String proposed = """
+                name: test_tool
+                description: Updated in YAML
+                inputSchema:
+                  type: object
+                  properties:
+                    query:
+                      type: string
+                    limit:
+                      type: integer
+                  required:
+                    - query
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpToolYaml(proposed), Map.of());
+
+        assertTrue(result.isCompatible(), "Updating from JSON to YAML should be backward compatible");
+    }
+
+    @Test
+    void testBackwardCompatibleYamlFlowMapping() {
+        String existing = "{name: test_tool, inputSchema: {type: object, properties: {query: {type: string}}, required: [query]}}";
+        String proposed = "{name: test_tool, inputSchema: {type: object, properties: {query: {type: string}, limit: {type: integer}}, required: [query]}}";
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpToolYaml(existing)),
+                createMcpToolYaml(proposed), Map.of());
+
+        assertTrue(result.isCompatible(), "YAML flow mapping syntax should be parsed and backward compatible");
     }
 }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><p data-start="551" data-end="623" class="PDq2pG_selectionAnchorContainer">Fixes <a data-start="557" data-end="623" rel="noopener" target="_new" class="decorated-link" href="https://github.com/Apicurio/apicurio-registry/issues/9698">#9698</a><span aria-hidden="true" class="PDq2pG_selectionAnchor"></span></p>
<p data-start="625" data-end="798"><code data-start="625" data-end="652">AgentCardContentValidator</code> and <code data-start="657" data-end="682">McpToolContentValidator</code> already accept artifacts authored in both JSON and YAML formats through <code data-start="755" data-end="797">ContentTypeUtil.parseJsonOrYaml(content)</code>.</p>
<p data-start="800" data-end="999">However, the corresponding compatibility checkers were not following the same parsing behavior. Both <code data-start="901" data-end="932">AgentCardCompatibilityChecker</code> and <code data-start="937" data-end="966">McpToolCompatibilityChecker</code> used a JSON-only <code data-start="984" data-end="998">ObjectMapper</code>.</p>
<p data-start="1001" data-end="1169">As a result, a valid YAML artifact could pass content validation but fail during compatibility checking with a <code data-start="1112" data-end="1125">PARSE_ERROR</code> when compatibility enforcement was enabled.</p>
<p data-start="1171" data-end="1342">This PR aligns both compatibility checkers with the existing JSON/YAML parsing behavior used by <code data-start="1267" data-end="1303">PromptTemplateCompatibilityChecker</code> and <code data-start="1308" data-end="1341">ModelSchemaCompatibilityChecker</code>.</p>
<h2 data-section-id="1l53zr6" data-start="1344" data-end="1357">Root Cause</h2>
<p data-start="1359" data-end="1472">The content validators and compatibility checkers had different assumptions about the supported artifact formats.</p>
<p data-start="1474" data-end="1588">The validators already used <code data-start="1502" data-end="1544">ContentTypeUtil.parseJsonOrYaml(content)</code>, which allows both JSON and YAML artifacts.</p>
<p data-start="1590" data-end="1722">The compatibility checkers, however, each had a single JSON mapper: <code data-start="1658" data-end="1722">private static final ObjectMapper mapper = new ObjectMapper();</code></p>
<p data-start="1724" data-end="1837">When compatibility checking a YAML artifact, the checker therefore attempted to parse YAML using the JSON mapper.</p>
<p data-start="1839" data-end="1934">The parsing exception was then converted into a compatibility difference of type <code data-start="1920" data-end="1933">PARSE_ERROR</code>.</p>
<p data-start="1936" data-end="2045">This meant that a valid YAML artifact could be rejected before the actual compatibility rules were evaluated.</p>
<p data-start="2047" data-end="2093">The problem was present independently in both:</p>
<ul data-start="2095" data-end="2160">
<li data-section-id="1cu98xm" data-start="2095" data-end="2128">
<code data-start="2097" data-end="2128">AgentCardCompatibilityChecker</code>
</li>
<li data-section-id="1pjf2a9" data-start="2129" data-end="2160">
<code data-start="2131" data-end="2160">McpToolCompatibilityChecker</code>
</li>
</ul>
<h2 data-section-id="bzco8g" data-start="2162" data-end="2172">Changes</h2>
<h3 data-section-id="1n81uz8" data-start="2174" data-end="2209"><span role="text"><code data-start="2178" data-end="2209">AgentCardCompatibilityChecker</code></span></h3>
<ul data-start="2211" data-end="2496">
<li data-section-id="1sy1k6t" data-start="2211" data-end="2264">
Added a dedicated <code data-start="2231" data-end="2243">yamlMapper</code> using <code data-start="2250" data-end="2263">YAMLFactory</code>.
</li>
<li data-section-id="qx1oqw" data-start="2265" data-end="2365">
Added <code data-start="2273" data-end="2303">parseContent(String content)</code> to detect JSON versus YAML and select the appropriate mapper.
</li>
<li data-section-id="e9l2w6" data-start="2366" data-end="2496">
Updated <code data-start="2376" data-end="2403">isBackwardsCompatibleWith</code> so both the existing and proposed Agent Card documents are parsed through the common helper.
</li>
</ul>
<h3 data-section-id="1ekpmdb" data-start="2498" data-end="2531"><span role="text"><code data-start="2502" data-end="2531">McpToolCompatibilityChecker</code></span></h3>
<ul data-start="2533" data-end="2838">
<li data-section-id="a2s18a" data-start="2533" data-end="2622">
Added the same JSON/YAML parsing approach used by the Agent Card compatibility checker.
</li>
<li data-section-id="1rf5x4f" data-start="2623" data-end="2664">
Added <code data-start="2631" data-end="2643">yamlMapper</code> using <code data-start="2650" data-end="2663">YAMLFactory</code>.
</li>
<li data-section-id="odsp4g" data-start="2665" data-end="2725">
Added <code data-start="2673" data-end="2703">parseContent(String content)</code> for format detection.
</li>
<li data-section-id="16uusx8" data-start="2726" data-end="2838">
Updated <code data-start="2736" data-end="2763">isBackwardsCompatibleWith</code> to parse both existing and proposed MCP Tool documents through the helper.
</li>
</ul>
<p data-start="2840" data-end="2904">The implementation follows the existing pattern already used by:</p>
<ul data-start="2906" data-end="2980">
<li data-section-id="eeoc0z" data-start="2906" data-end="2944">
<code data-start="2908" data-end="2944">PromptTemplateCompatibilityChecker</code>
</li>
<li data-section-id="1spf895" data-start="2945" data-end="2980">
<code data-start="2947" data-end="2980">ModelSchemaCompatibilityChecker</code>
</li>
</ul>
<p data-start="2982" data-end="3057">so this change does not introduce a new parsing mechanism for the Registry.</p>
<h2 data-section-id="jfji1z" data-start="3059" data-end="3084">Compatibility Behavior</h2>
<p data-start="3086" data-end="3250">The important behavior change is that the compatibility checker now reaches the actual compatibility logic for valid YAML content instead of failing during parsing.</p>
<p data-start="3252" data-end="3288">The following cases are now covered:</p>


JSON → JSON: Existing behavior is preserved.
YAML → YAML: Compatibility rules are evaluated normally.
JSON → YAML: Compatibility rules are evaluated normally.
YAML → JSON: Compatibility rules are evaluated normally.

<p data-start="3530" data-end="3649">This also means that the format of the previous version and the format of the proposed version no longer need to match.</p>
<p data-start="3651" data-end="3780">For example, a JSON Agent Card can now be followed by a YAML Agent Card and still go through the normal compatibility evaluation.</p>
<h2 data-section-id="xlct5s" data-start="3782" data-end="3790">Tests</h2>
<p data-start="3792" data-end="3852">I added regression coverage for both compatibility checkers.</p>
<h3 data-section-id="p44qq" data-start="3854" data-end="3893"><span role="text"><code data-start="3858" data-end="3893">AgentCardCompatibilityCheckerTest</code></span></h3>
<p data-start="3895" data-end="3901">Added:</p>
<ul data-start="3903" data-end="4278">
<li data-section-id="1k0em4d" data-start="3903" data-end="4004">
<code data-start="3905" data-end="3939">testBackwardCompatibleYamlFormat</code>
<ul data-start="3942" data-end="4004">
<li data-section-id="y3cdnf" data-start="3942" data-end="4004">
verifies that a backward-compatible YAML change is accepted.
</li>
</ul>
</li>
<li data-section-id="11sg7gy" data-start="4005" data-end="4141">
<code data-start="4007" data-end="4043">testBackwardIncompatibleYamlFormat</code>
<ul data-start="4046" data-end="4141">
<li data-section-id="17lersj" data-start="4046" data-end="4141">
verifies that a real incompatibility is detected rather than being reported as <code data-start="4127" data-end="4140">PARSE_ERROR</code>.
</li>
</ul>
</li>
<li data-section-id="elv2pm" data-start="4142" data-end="4278">
<code data-start="4144" data-end="4184">testCrossFormatCompatibilityJsonToYaml</code>
<ul data-start="4187" data-end="4278">
<li data-section-id="hu7r7m" data-start="4187" data-end="4278">
verifies compatibility when an existing version is JSON and the proposed version is YAML.
</li>
</ul>
</li>
</ul>
<h3 data-section-id="1is1ysp" data-start="4280" data-end="4317"><span role="text"><code data-start="4284" data-end="4317">McpToolCompatibilityCheckerTest</code></span></h3>
<p data-start="4319" data-end="4372">Added the equivalent coverage for MCP Tool artifacts:</p>
<ul data-start="4374" data-end="4492">
<li data-section-id="fzng09" data-start="4374" data-end="4410">
<code data-start="4376" data-end="4410">testBackwardCompatibleYamlFormat</code>
</li>
<li data-section-id="1ftq24u" data-start="4411" data-end="4449">
<code data-start="4413" data-end="4449">testBackwardIncompatibleYamlFormat</code>
</li>
<li data-section-id="c9nujb" data-start="4450" data-end="4492">
<code data-start="4452" data-end="4492">testCrossFormatCompatibilityJsonToYaml</code>
</li>
</ul>
<p data-start="4494" data-end="4635">The tests specifically ensure that YAML parsing reaches the compatibility logic and that genuine compatibility violations are still detected.</p>
<h2 data-section-id="wedogs" data-start="4637" data-end="4652">Verification</h2>
<p data-start="4654" data-end="4704">I ran the compatibility checker test suites using:</p>
<p data-start="4706" data-end="4781"><code data-start="4706" data-end="4781">mvn test -pl schema-util/util-provider -Dtest="*CompatibilityCheckerTest"</code></p>
<p data-start="4783" data-end="4806"><strong data-start="4783" data-end="4806">58/58 tests passed.</strong></p>
<p data-start="4808" data-end="4861">I also ran Checkstyle for the affected modules using:</p>
<p data-start="4863" data-end="4934"><code data-start="4863" data-end="4934">mvn checkstyle:check -pl schema-util/common,schema-util/util-provider</code></p>
<p data-start="4936" data-end="4953"><strong data-start="4936" data-end="4953">0 violations.</strong></p>

</body>
</html>