### PR TITLE
fix(rest): return 400 instead of 500 when a required request body is absent

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/AdminResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/AdminResourceImpl.java
@@ -214,6 +214,8 @@ public class AdminResourceImpl implements AdminResource {
     @Audited
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Admin)
     public void createGlobalRule(CreateRule data) {
+        ParameterValidationUtils.requireParameter("data", data);
+
         RuleType ruleType = data.getRuleType();
         ParameterValidationUtils.requireParameter("ruleType", ruleType);
 
@@ -267,6 +269,8 @@ public class AdminResourceImpl implements AdminResource {
     @Audited
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Admin)
     public Rule updateGlobalRuleConfig(RuleType ruleType, Rule data) {
+        ParameterValidationUtils.requireParameter("data", data);
+
         if (data.getConfig() == null || data.getConfig().trim().isEmpty()) {
             throw new MissingRequiredParameterException("config");
         }
@@ -427,6 +431,8 @@ public class AdminResourceImpl implements AdminResource {
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Admin)
     @RoleBasedAccessApiOperation
     public void createRoleMapping(RoleMapping data) {
+        ParameterValidationUtils.requireParameter("data", data);
+
         storage.createRoleMapping(data.getPrincipalId(), data.getRole().name(), data.getPrincipalName());
     }
 
@@ -470,6 +476,7 @@ public class AdminResourceImpl implements AdminResource {
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Admin)
     @RoleBasedAccessApiOperation
     public void updateRoleMapping(String principalId, UpdateRole data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("principalId", principalId);
         ParameterValidationUtils.requireParameter("role", data.getRole());
         storage.updateRoleMapping(principalId, data.getRole().name());
@@ -537,6 +544,8 @@ public class AdminResourceImpl implements AdminResource {
     @Audited
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Admin)
     public void updateConfigProperty(String propertyName, UpdateConfigurationProperty data) {
+        ParameterValidationUtils.requireParameter("data", data);
+
         DynamicConfigPropertyDef propertyDef = resolveConfigProperty(propertyName);
         validateConfigPropertyValue(propertyDef, data.getValue());
 
@@ -651,6 +660,8 @@ public class AdminResourceImpl implements AdminResource {
     @Override
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Admin)
     public GitOpsValidateTask createGitOpsValidateTask(GitOpsValidateRequest data) {
+        ParameterValidationUtils.requireParameter("data", data);
+
         requireGitOpsStorage();
         return requireValidationTaskManager().createTask(data);
     }
@@ -899,6 +910,8 @@ public class AdminResourceImpl implements AdminResource {
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Admin)
     public io.apicurio.registry.rest.v3.beans.ContractRuleSet setGlobalContractRuleset(
             io.apicurio.registry.rest.v3.beans.ContractRuleSet data) {
+        ParameterValidationUtils.requireParameter("data", data);
+
         io.apicurio.registry.storage.dto.ContractRuleSetDto dto = ContractRuleSetMapper.toDto(data);
         storage.setGlobalContractRuleset(dto);
         return data;

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/ContentResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/ContentResourceImpl.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import io.apicurio.registry.rest.ParameterValidationUtils;
 
 /**
  * Implementation of the /content sub-resource.
@@ -55,6 +56,8 @@ public class ContentResourceImpl implements ContentResource {
     @Override
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
     public List<ArtifactReference> detectContentReferences(String artifactType, VersionContent body) {
+        ParameterValidationUtils.requireParameter("data", body);
+
         ContentHandle content = ContentHandle.create(body.getContent());
         String contentType = body.getContentType();
         TypedContent typedContent = TypedContent.create(content, contentType);

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
@@ -643,6 +643,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void updateArtifactMetaData(String groupId, String artifactId, EditableArtifactMetaData data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
@@ -695,6 +696,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public void updateGroupById(String groupId, EditableGroupMetaData data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("groupId", groupId);
 
         String rawGroupId = new GroupId(groupId).getRawGroupIdWithNull();
@@ -745,6 +747,8 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Write)
     public GroupMetaData createGroup(CreateGroup data) {
+        ParameterValidationUtils.requireParameter("data", data);
+
         // Validate that the user is not trying to create the reserved "default" group
         if (new GroupId(data.getGroupId()).isDefaultGroup()) {
             throw new BadRequestException("The group name 'default' is reserved and cannot be used.");
@@ -774,6 +778,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public void createGroupRule(String groupId, CreateRule data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("ruleType", data.getRuleType());
         ParameterValidationUtils.requireParameter("config", data.getConfig());
@@ -801,6 +806,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public Rule updateGroupRuleConfig(String groupId, RuleType ruleType, Rule data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("ruleType", ruleType);
         ParameterValidationUtils.requireParameter("config", data.getConfig());
@@ -872,6 +878,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void createArtifactRule(String groupId, String artifactId, CreateRule data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
         ParameterValidationUtils.requireParameter("ruleType", data.getRuleType());
@@ -936,6 +943,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public Rule updateArtifactRuleConfig(String groupId, String artifactId, RuleType ruleType, Rule data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
         ParameterValidationUtils.requireParameter("ruleType", ruleType);
@@ -1047,6 +1055,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void updateArtifactVersionContent(String groupId, String artifactId, String versionExpression,
             VersionContent data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
         ParameterValidationUtils.requireParameter("versionExpression", versionExpression);
@@ -1151,6 +1160,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void updateArtifactVersionMetaData(String groupId, String artifactId, String versionExpression,
             EditableVersionMetaData data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
         ParameterValidationUtils.requireParameter("versionExpression", versionExpression);
@@ -1188,6 +1198,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write, dryRunParam = 3)
     public void updateArtifactVersionState(String groupId, String artifactId, String versionExpression,
             Boolean dryRun, WrappedVersionState data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
         ParameterValidationUtils.requireParameter("versionExpression", versionExpression);
@@ -1241,6 +1252,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public Comment addArtifactVersionComment(String groupId, String artifactId, String versionExpression,
             NewComment data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
         ParameterValidationUtils.requireParameter("versionExpression", versionExpression);
@@ -1306,6 +1318,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write)
     public void updateArtifactVersionComment(String groupId, String artifactId, String versionExpression,
             String commentId, NewComment data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
         ParameterValidationUtils.requireParameter("versionExpression", versionExpression);
@@ -1371,6 +1384,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupOnly, level = AuthorizedLevel.Write, dryRunParam = 3)
     public CreateArtifactResponse createArtifact(String groupId, IfArtifactExists ifExists, Boolean canonical,
             Boolean dryRun, CreateArtifact data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("groupId", groupId);
         if (data.getFirstVersion() != null) {
             boolean contentRequired = true;
@@ -1586,6 +1600,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write, dryRunParam = 2)
     public VersionMetaData createArtifactVersion(String groupId, String artifactId, Boolean dryRun,
             CreateVersion data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
 
@@ -1675,6 +1690,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Audited
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public BranchMetaData createBranch(String groupId, String artifactId, CreateBranch data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
         ParameterValidationUtils.requireParameter("branchId", data.getBranchId());
@@ -1722,6 +1738,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void updateBranchMetaData(String groupId, String artifactId, String branchId,
             EditableBranchMetaData data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
         ParameterValidationUtils.requireParameter("branchId", branchId);
@@ -1775,6 +1792,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void replaceBranchVersions(String groupId, String artifactId, String branchId,
             ReplaceBranchVersions data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
         ParameterValidationUtils.requireParameter("branchId", branchId);
@@ -1795,6 +1813,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public void addVersionToBranch(String groupId, String artifactId, String branchId,
             AddVersionToBranch data) {
+        ParameterValidationUtils.requireParameter("data", data);
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
         ParameterValidationUtils.requireParameter("branchId", branchId);
@@ -2063,6 +2082,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public ContractMetadata updateContractMetadata(String groupId, String artifactId,
             EditableContractMetadata data) {
+        ParameterValidationUtils.requireParameter("data", data);
 
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
@@ -2126,6 +2146,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public ContractRuleSet setArtifactContractRuleset(String groupId, String artifactId,
             ContractRuleSet data) {
+        ParameterValidationUtils.requireParameter("data", data);
 
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
@@ -2170,6 +2191,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public ContractRuleSet setVersionContractRuleset(String groupId, String artifactId,
             String versionExpression, ContractRuleSet data) {
+        ParameterValidationUtils.requireParameter("data", data);
 
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);
@@ -2206,6 +2228,7 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write)
     public ContractMetadata transitionContractStatus(String groupId, String artifactId,
             ContractStatusTransition data) {
+        ParameterValidationUtils.requireParameter("data", data);
 
         ParameterValidationUtils.requireParameter("groupId", groupId);
         ParameterValidationUtils.requireParameter("artifactId", artifactId);

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -67,6 +67,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import io.apicurio.registry.rest.ParameterValidationUtils;
 
 /**
  * Implementation of the well-known endpoint resource for A2A agents and MCP tools.
@@ -205,6 +206,8 @@ public class WellKnownResourceImpl implements WellKnownResource {
     @Override
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
     public AgentSearchResults searchAgentsAdvanced(AgentSearchRequest request) {
+        ParameterValidationUtils.requireParameter("data", request);
+
         if (!a2aConfig.isEnabled()) {
             throw new NotFoundException("A2A support is disabled");
         }

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/EmptyRequestBodyTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/EmptyRequestBodyTest.java
@@ -1,0 +1,82 @@
+package io.apicurio.registry.noprofile.rest.v3;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The v3 API declares every request body as required, and the generated JAX-RS interfaces carry a
+ * matching {@code @NotNull}. No Bean Validation implementation is on the classpath, so those
+ * constraints are never enforced: a request with an absent or literal-null body used to reach the
+ * resource method with {@code data == null} and fail with a NullPointerException, which the
+ * exception mapper turned into a 500 whose body echoed the internal bean class name.
+ *
+ * These endpoints must answer 400 instead, and must not disclose internal types.
+ */
+@QuarkusTest
+public class EmptyRequestBodyTest extends AbstractResourceTestBase {
+
+    private static final String GROUP = "EmptyRequestBodyTest";
+    private static final String ARTIFACT = "empty-body-artifact";
+
+    /**
+     * Endpoints that take a required request body and are reachable in the default (no-auth)
+     * profile. The roleMapping endpoints are excluded because they are gated behind RBAC and answer
+     * 403 before the body is ever examined.
+     */
+    private static String[][] endpoints() {
+        String a = "/groups/" + GROUP + "/artifacts/" + ARTIFACT;
+        return new String[][] { { "POST", "/admin/rules" }, { "PUT", "/admin/rules/VALIDITY" },
+                { "PUT", "/admin/config/properties/apicurio.rest.deletion.artifact.enabled" },
+                { "POST", "/groups" }, { "PUT", "/groups/" + GROUP },
+                { "POST", "/groups/" + GROUP + "/rules" }, { "POST", "/groups/" + GROUP + "/artifacts" },
+                { "PUT", a }, { "POST", a + "/versions" }, { "POST", a + "/rules" },
+                { "POST", a + "/branches" }, { "PUT", a + "/versions/1" },
+                { "PUT", a + "/versions/1/state" }, { "POST", a + "/versions/1/comments" },
+                { "POST", "/content/references" } };
+    }
+
+    @Test
+    public void testMissingRequestBodyIsRejectedWithBadRequest() throws Exception {
+        createArtifact(GROUP, ARTIFACT, ArtifactType.JSON, "{\"type\":\"object\"}",
+                ContentTypes.APPLICATION_JSON);
+
+        List<Executable> checks = new ArrayList<>();
+        for (String[] endpoint : endpoints()) {
+            // An absent body and a literal JSON null both deserialize to null.
+            for (String payload : new String[] { "", "null" }) {
+                checks.add(() -> assertRejected(endpoint[0], endpoint[1], payload));
+            }
+        }
+        assertAll(checks);
+    }
+
+    private void assertRejected(String verb, String path, String payload) {
+        ExtractableResponse<Response> response = given().when().contentType("application/json")
+                .body(payload).request(verb, registryV3ApiUrl + path).then().extract();
+        String body = response.body().asString();
+        String where = verb + " " + path + " [body=" + (payload.isEmpty() ? "absent" : payload) + "]";
+
+        assertEquals(400, response.statusCode(), where + " must be rejected as a bad request: " + body);
+        // The API reports registry exceptions as "<SimpleName>: <message>"; assert the message part.
+        String detail = response.jsonPath().getString("detail");
+        assertTrue(detail != null && detail.endsWith("Request is missing a required parameter: data"),
+                where + " must report the missing body, got: " + detail);
+        assertFalse(body.contains("NullPointerException"), where + " must not disclose the exception type: " + body);
+        assertFalse(body.contains("io.apicurio.registry"), where + " must not disclose internal class names: " + body);
+    }
+}


### PR DESCRIPTION
Fixes #9710.

## What

Every v3 operation that takes a request body declares it `required: true` in `openapi.json`, and the
code generator emits a matching `@NotNull` onto the entity parameter of the generated JAX-RS
interface:

```java
CreateArtifactResponse createArtifact(@PathParam("groupId") @Pattern(regexp = "^.{1,512}$") String groupId,
    @QueryParam("ifExists") IfArtifactExists ifExists, @QueryParam("canonical") Boolean canonical,
    @QueryParam("dryRun") Boolean dryRun, @NotNull CreateArtifact data);
```

Nothing enforces those constraints. `jakarta.validation-api` is on the classpath so the annotations
compile, but no Bean Validation implementation is:

```
$ ./mvnw dependency:list -pl app -DincludeScope=runtime | grep -i valid
   jakarta.validation:jakarta.validation-api:jar:3.1.1:compile
   commons-validator:commons-validator:jar:1.9.0:compile
```

So an absent body — or a literal JSON `null` — reaches the resource method with `data == null` and
fails on the first dereference. The exception mapper turns that NullPointerException into a **500**
that echoes the internal bean class in both `detail` and `title`:

```json
{"detail":"NullPointerException: Cannot invoke \"io.apicurio.registry.rest.v3.beans.CreateArtifact.getFirstVersion()\" because \"data\" is null"}
```

That is a server error for a malformed client request, and it discloses internal type names in an
API response.

## Why this fix

Guard the entity parameter with the existing `ParameterValidationUtils.requireParameter`, which
raises `MissingRequiredParameterException` — already mapped to `HTTP_BAD_REQUEST` in
`HttpStatusCodeMap`. This is the guard `submitContract` and `updateContract` already use, so the
`ProblemDetails` error shape the API contract promises is preserved.

**Scope.** 31 operations whose body deserializes to an object. `InputStream` parameters are
deliberately left alone: RESTEasy supplies an empty stream rather than null, so a guard there could
never fire — which is why `POST /search/artifacts` already answered 400 before this change.

**Why not just add a Bean Validation implementation?** I tried that first, since it looks like the
root-cause fix. Adding `quarkus-hibernate-validator` does turn every one of these into a 400, but it
answers with Hibernate Validator's own payload instead of `ProblemDetails`:

```json
{"exception":null,"propertyViolations":[],"classViolations":[],
 "parameterViolations":[{"constraintType":"PARAMETER","path":"createGlobalRule.arg0",
                         "message":"must not be null","value":""}],"returnValueViolations":[]}
```

That breaks the documented error contract for every SDK client, leaks internal method/argument names
in its own way, and would simultaneously activate every generated `@Pattern` constraint on path
parameters. It may be the right long-term direction, but it needs an
`ExceptionMapper<ConstraintViolationException>` and a full regression pass, so it is out of scope
here. The inert `@Pattern` constraints are noted in #9710 for separate tracking.

## Testing

`EmptyRequestBodyTest` covers 15 reachable endpoints against both an absent body and a literal
`null` (30 requests). For each it asserts the status is exactly 400, that `detail` reports the
missing body, and that the response contains neither `NullPointerException` nor
`io.apicurio.registry`.

Before this change all 30 requests returned 500; the test fails with **90 assertion errors** on an
unpatched tree and passes with the guard, so it is not vacuous.

The `roleMapping` endpoints are excluded because they are gated behind RBAC and answer 403 before
the body is examined.

I also ran the full `io.apicurio.registry.noprofile.rest.v3.**` suite (264 tests). Two fail —
`ImportExportTest.testExportImport` and
`ContractRuleImportExportTest.testContractRulesSurviveExportImport` — but they fail identically on a
clean `main` checkout with my changes stashed, so they are pre-existing and unrelated. Noted at the
bottom of #9710.
