### PR TITLE
fix(ci): collect current test artifacts

### DIFF
--- a/.github/scripts/collect_logs.sh
+++ b/.github/scripts/collect_logs.sh
@@ -1,19 +1,23 @@
-#!/bin/bash
-set -e
-echo "Collecting tests logs"
-mkdir -p artifacts/logs
-mkdir -p artifacts/failsafe-reports
+#!/bin/sh
+set -eu
 
-DIR="integration-tests/testsuite/target"
-if [ -d "$DIR" ]; then
-    echo "Collecting testsuite logs"
-    cp -r ${DIR}/logs artifacts
-    cp -r ${DIR}/failsafe-reports artifacts
-fi
+ARTIFACTS_DIR="${ARTIFACTS_DIR:-artifacts}"
 
-mkdir -p artifacts/legacy
-DIR="integration-tests/legacy-tests/target"
-if [ -d "$DIR" ]; then
-  echo "Collecting testsuite logs"
-  cp -r ${DIR}/logs artifacts/legacy | true
-fi
+copy_artifacts() {
+    source_dir="$1"
+    destination_dir="$ARTIFACTS_DIR/$source_dir"
+
+    if [ -d "$source_dir" ]; then
+        mkdir -p "$destination_dir"
+        cp -R "$source_dir"/. "$destination_dir"/
+        echo "Collected $source_dir"
+    fi
+}
+
+echo "Collecting test logs and reports"
+
+for module in integration-tests utils/extra-tests; do
+    for artifact in target/failsafe-reports target/surefire-reports target/logs; do
+        copy_artifacts "$module/$artifact"
+    done
+done

--- a/.github/workflows/verify-extras.yaml
+++ b/.github/workflows/verify-extras.yaml
@@ -133,6 +133,13 @@ jobs:
         with:
           ref: 2.6.x
 
+      - name: Checkout log collector
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: .github/scripts/collect_logs.sh
+          path: .current-revision
+
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
@@ -157,7 +164,7 @@ jobs:
 
       - name: Collect logs
         if: failure()
-        run: sh ./.github/scripts/collect_logs.sh
+        run: sh ./.current-revision/.github/scripts/collect_logs.sh
 
       - name: Upload tests logs artifacts
         if: failure()


### PR DESCRIPTION
## Problem / root cause

`.github/scripts/collect_logs.sh` used stale paths under `integration-tests/testsuite/target` and `integration-tests/legacy-tests/target`. Current Maven Failsafe/Surefire output is written under the module `target` directories, so failed jobs often uploaded no diagnostic artifacts.

## What changed

- Collect current Failsafe reports, Surefire reports, and optional logs from `integration-tests` and `utils/extra-tests`.
- Preserve the module-relative paths under the uploaded `artifacts` directory.
- Ignore missing optional report/log directories without failing the collector.
- Update the Legacy V2 workflow job to use the collector from the current workflow revision, because that job checks out `2.6.x` and would otherwise continue using its stale collector.

## Validation

- `sh -n .github/scripts/collect_logs.sh`
- YAML parsing for `verify-extras.yaml` and `verify-integration-tests.yaml`
- `git diff --check`
- Fixture validation covering current Failsafe, Surefire, and log directories
- Fixture validation covering missing optional directories

`shellcheck` and `actionlint` were not available in the local environment.

This PR intentionally does **not** address the nested retry or timeout changes described in #9589.

Refs #9589