### PR TITLE
feat(ccompat): implement getSubjectMetadata endpoint in v7 API

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
@@ -473,9 +473,11 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
     }
 
     @Override
+    @Authorized(style = AuthorizedStyle.ArtifactOnly, level = AuthorizedLevel.Read)
     public Schema getSubjectMetadata(String subject, String key, String value, String format, Boolean deleted, String xRegistryGroupId) {
-        //TODO not implemented
-        return null;
+        GA ga = getGA(xRegistryGroupId, subject);
+        return getSchema(ga.getRawGroupIdWithNull(), ga.getRawArtifactId(), "latest",
+                deleted != null && deleted, format);
     }
 
     protected Schema getSchema(String groupId, String artifactId, String versionString, boolean deleted) {

--- a/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/SubjectsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/SubjectsResourceTest.java
@@ -1,11 +1,16 @@
 package io.apicurio.registry.noprofile.ccompat.rest.v7;
 
 import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.TestUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.anything;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 
 @QuarkusTest
 public class SubjectsResourceTest extends AbstractResourceTestBase {
@@ -13,5 +18,20 @@ public class SubjectsResourceTest extends AbstractResourceTestBase {
     public void testListSubjectsEndpoint() {
         given().when().contentType(CT_JSON).get("/ccompat/v7/subjects").then().statusCode(200)
                 .body(anything());
+    }
+
+    @Test
+    public void testGetSubjectMetadata() throws Exception {
+        final String artifactId = TestUtils.generateArtifactId();
+        final String content = "{\"type\":\"record\",\"name\":\"TestRecord\",\"fields\":[{\"name\":\"field1\",\"type\":\"string\"}]}";
+
+        createArtifact("default", artifactId, ArtifactType.AVRO, content, ContentTypes.APPLICATION_JSON);
+
+        given().when().contentType(CT_JSON).get("/ccompat/v7/subjects/" + artifactId + "/metadata")
+                .then().statusCode(200)
+                .body("subject", equalTo(artifactId))
+                .body("version", equalTo(1))
+                .body("id", notNullValue())
+                .body("schema", notNullValue());
     }
 }


### PR DESCRIPTION
## Summary
Implements the Confluent-compatible v7 endpoint `GET /subjects/{subject}/metadata`, which previously returned `null` with a `// TODO not implemented` comment.

close #9708 
## Problem
`SubjectsResourceImpl.getSubjectMetadata` was unimplemented, returning `null` for any request to `/apis/ccompat/v7/subjects/{subject}/metadata`.

## Solution
- Added `@Authorized(style = ArtifactOnly, level = Read)` to the method.
- Resolves the subject to a group/artifact using `getGA`, then fetches the latest schema via the existing `getSchema` helper.
- Converts the stored artifact version to the ccompat `Schema` bean using `ApiConverter`.

## Files changed
- `app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java`
- `app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/SubjectsResourceTest.java`

## Testing
- Added `testGetSubjectMetadata` which creates an Avro artifact and verifies:
  - `GET /apis/ccompat/v7/subjects/{subject}/metadata` returns `200`
  - the response contains `subject`, `version` = `1`, a non-null `id`, and a non-null `schema`
- Existing `testListSubjectsEndpoint` still passes.

## Verification
```bash
./mvnw -T 1 test -pl app -am -Dtest=SubjectsResourceTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false
./mvnw -T 1 test -pl app -am -Dtest=VersionNumberingTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false