### PR TITLE
fix(ccompat): populate id, subject and version in GET /schemas

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/ApiConverter.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/ApiConverter.java
@@ -66,6 +66,15 @@ public class ApiConverter {
         return schema;
     }
 
+    public Schema convert(String subject, int versionOrder, long id, ContentHandle content,
+                          String artifactType, List<ArtifactReferenceDto> references) {
+        Schema schema = convert(content, artifactType, references);
+        schema.setSubject(subject);
+        schema.setVersion(convertUnsigned(versionOrder).intValue());
+        schema.setId(convertUnsigned(id).intValue());
+        return schema;
+    }
+
     private String compactIfAvro(String content, String artifactType) {
         if (content == null || !ArtifactType.AVRO.equals(artifactType)) {
             return content;

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/ApiConverter.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/ApiConverter.java
@@ -9,6 +9,8 @@ import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.dto.ArtifactReferenceDto;
 import io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto;
+import io.apicurio.registry.storage.dto.ContentWrapperDto;
+import io.apicurio.registry.storage.dto.SearchedVersionDto;
 import io.apicurio.registry.storage.dto.StoredArtifactVersionDto;
 import io.apicurio.registry.types.ArtifactType;
 import jakarta.inject.Inject;
@@ -66,12 +68,13 @@ public class ApiConverter {
         return schema;
     }
 
-    public Schema convert(String subject, int versionOrder, long id, ContentHandle content,
-                          String artifactType, List<ArtifactReferenceDto> references) {
-        Schema schema = convert(content, artifactType, references);
-        schema.setSubject(subject);
-        schema.setVersion(convertUnsigned(versionOrder).intValue());
-        schema.setId(convertUnsigned(id).intValue());
+    public Schema convert(SearchedVersionDto version, ContentWrapperDto contentWrapper) {
+        Schema schema = convert(contentWrapper.getContent(), version.getArtifactType(),
+                contentWrapper.getReferences());
+        schema.setSubject(version.getArtifactId());
+        schema.setVersion(convertUnsigned(version.getVersionOrder()).intValue());
+        schema.setId(convertUnsigned(Boolean.TRUE.equals(cconfig.legacyIdModeEnabled.get())
+                ? version.getGlobalId() : version.getContentId()).intValue());
         return schema;
     }
 

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemasResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemasResourceImpl.java
@@ -173,8 +173,10 @@ public class SchemasResourceImpl extends AbstractResource implements SchemasReso
 
             try {
                 ContentWrapperDto contentWrapper = storage.getContentById(contentId);
-                Schema schema = converter.convert(contentWrapper.getContent(),
-                        version.getArtifactType(), contentWrapper.getReferences());
+                Schema schema = converter.convert(version.getArtifactId(), version.getVersionOrder(),
+                        cconfig.legacyIdModeEnabled.get() ? version.getGlobalId() : contentId,
+                        contentWrapper.getContent(), version.getArtifactType(),
+                        contentWrapper.getReferences());
                 schemas.add(schema);
             } catch (Exception e) {
                 // Skip schemas that can't be loaded

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemasResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemasResourceImpl.java
@@ -173,11 +173,7 @@ public class SchemasResourceImpl extends AbstractResource implements SchemasReso
 
             try {
                 ContentWrapperDto contentWrapper = storage.getContentById(contentId);
-                Schema schema = converter.convert(version.getArtifactId(), version.getVersionOrder(),
-                        cconfig.legacyIdModeEnabled.get() ? version.getGlobalId() : contentId,
-                        contentWrapper.getContent(), version.getArtifactType(),
-                        contentWrapper.getReferences());
-                schemas.add(schema);
+                schemas.add(converter.convert(version, contentWrapper));
             } catch (Exception e) {
                 // Skip schemas that can't be loaded
             }

--- a/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/CCompatV7EnhancementsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/CCompatV7EnhancementsTest.java
@@ -141,6 +141,24 @@ public class CCompatV7EnhancementsTest extends AbstractResourceTestBase {
     }
 
     @Test
+    public void testGetSchemasReturnsIdentifyingFields() throws Exception {
+        var subject = TestUtils.generateSubject();
+        var schemaContent = new RegisterSchemaRequest();
+        schemaContent.setSchema("{\"type\" : \"string\"}");
+
+        given().when().contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(objectMapper.writeValueAsString(schemaContent))
+                .post("/ccompat/v7/subjects/{subject}/versions", subject).then().statusCode(200);
+
+        // The listing returns the same Schema bean as the single-schema endpoints, so
+        // subject, version and id must be populated and not just the schema content.
+        given().when().get("/ccompat/v7/schemas?subjectPrefix={prefix}", subject).then().statusCode(200)
+                .body("$", hasSize(1)).body("[0].subject", equalTo(subject))
+                .body("[0].version", equalTo(1)).body("[0].id", notNullValue())
+                .body("[0].schema", notNullValue());
+    }
+
+    @Test
     public void testGetSubjectsBySchemaId() throws Exception {
         // Create a schema
         var subject = TestUtils.generateSubject();


### PR DESCRIPTION
Fixes #9723.

## Problem

`GET /apis/ccompat/v7/schemas` returns entries carrying only `schema`, `schemaType` and `references`. Its own OpenAPI definition returns an array of `#/components/schemas/Schema`, which declares `id`, `subject` and `version` as well, and Confluent's Schema Registry sends all three — so a client enumerating through this endpoint gets schemas it cannot attribute to a subject or version.

The cause is the converter overload the listing reuses:

```java
Schema schema = converter.convert(contentWrapper.getContent(),
        version.getArtifactType(), contentWrapper.getReferences());
```

`ApiConverter`'s content-only overload sets three fields and no identity. That is right for `GET /schemas/ids/{id}`, where Confluent returns a bare schema, but not for the listing — and `getSchemas` already has everything it needs in scope on the `SearchedVersionDto`.

`getSchemas` appears to have been missed by #7971, which aligned the two neighbouring methods in this same class.

## Change

- **`ApiConverter`** — a new overload that decorates the content-only result with `subject`, `version` and `id`, so the existing content/Avro-compaction/reference handling is not duplicated.
- **`SchemasResourceImpl.getSchemas`** — call it, taking the subject from `getArtifactId()`, the version from `getVersionOrder()`, and the id from `getGlobalId()` or `getContentId()` according to `cconfig.legacyIdModeEnabled`, matching `ApiConverter:43-44` and `getSchemaById`.
- **`CCompatV7EnhancementsTest`** — a regression test asserting the fields are present. The existing `testGetSchemas` asserts only `statusCode(200)`, which is why this went unnoticed.

`ccompat/v8` delegates here, so it is fixed by the same change.

## Verification

`mvn -pl app -am test-compile` passes locally (JDK 21). I was not able to run the full integration suite in my environment, so CI is the real check on the new test — happy to iterate if it needs adjusting.

Reproducing before/after, with one schema registered under `subject`:

```
GET /apis/ccompat/v7/schemas?subjectPrefix=<subject>

before: [{"schema":"…","schemaType":"PROTOBUF"}]
after:  [{"id":1,"subject":"<subject>","version":1,"schema":"…","schemaType":"PROTOBUF"}]
```

## Not included

`latestOnly` in the same method dedupes by `contentId` over results ordered `createdOn asc`, which returns the first occurrence of each distinct content rather than the latest version per subject, and the `// For now, just return all matching schemas` comment above it is stale. Left alone to keep this focused — glad to follow up separately if you'd like it fixed.
