### PR TITLE
docs: fix response samples to match response schema

### DIFF
--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -10057,10 +10057,10 @@
             "examples": {
               "NotFoundExample": {
                 "value": {
-                    "detail": "ArtifactNotFoundException: No artifact with ID 'artifact-ID' in group 'group-ID' was found.",
-                    "title": "No artifact with ID 'artifact-ID' in group 'group-ID' was found.",
-                    "status": 404,
-                    "name": "ArtifactNotFoundException"
+                  "detail": "ArtifactNotFoundException: No artifact with ID 'artifact-ID' in group 'group-ID' was found.",
+                  "title": "No artifact with ID 'artifact-ID' in group 'group-ID' was found.",
+                  "status": 404,
+                  "name": "ArtifactNotFoundException"
                 }
               }
             }
@@ -10077,10 +10077,10 @@
             "examples": {
               "MethodNotAllowedExample": {
                 "value": {
-                    "detail": "The requested HTTP method is not allowed for this resource.",
-                    "title": "Method Not Allowed",
-                    "status": 405,
-                    "name": "NotAllowedException"
+                  "detail": "NotAllowedException: The requested HTTP method is not allowed for this resource.",
+                  "title": "Method Not Allowed.",
+                  "status": 405,
+                  "name": "NotAllowedException"
                 }
               }
             }
@@ -10093,6 +10093,16 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/ProblemDetails"
+            },
+            "examples": {
+              "ServerErrorExample": {
+                "value": {
+                  "detail": "StorageException: Lost connection to the database.",
+                  "title": "Lost connection to the database.",
+                  "status": 500,
+                  "name": "StorageException"
+                }
+              }
             }
           }
         },
@@ -10107,10 +10117,10 @@
             "examples": {
               "BadRequestExample": {
                 "value": {
-                    "detail": "BadRequestException: The request contains invalid or missing parameters.",
-                    "title": "Bad Request",
-                    "status": 400,
-                    "name": "BadRequestException"
+                  "detail": "BadRequestException: The request contains invalid or missing parameters.",
+                  "title": "Bad Request.",
+                  "status": 400,
+                  "name": "BadRequestException"
                 }
               }
             }
@@ -10232,9 +10242,10 @@
             "examples": {
               "UnprocessableEntityExample": {
                 "value": {
-                  "title": "The artifact content is invalid: Schema validation failed",
+                  "detail": "UnprocessableSchemaException: Could not execute compatibility rule on invalid Avro schema.",
+                  "title": "The artifact content is invalid: Schema validation failed.",
                   "status": 422,
-                  "name": "SchemaValidationException"
+                  "name": "UnprocessableSchemaException"
                 }
               }
             }

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -7653,8 +7653,8 @@
           }
         ],
         "example": {
-          "error_code": 409,
-          "message": "Artifact failed validation",
+          "status": 409,
+          "title": "Artifact failed validation",
           "causes": [
             {
               "description": "API is missing a title",
@@ -10057,8 +10057,10 @@
             "examples": {
               "NotFoundExample": {
                 "value": {
-                  "error_code": 404,
-                  "message": "No artifact with id 'Topic-1/Inbound' could be found."
+                    "detail": "ArtifactNotFoundException: No artifact with ID 'artifact-ID' in group 'group-ID' was found.",
+                    "title": "No artifact with ID 'artifact-ID' in group 'group-ID' was found.",
+                    "status": 404,
+                    "name": "ArtifactNotFoundException"
                 }
               }
             }
@@ -10075,8 +10077,10 @@
             "examples": {
               "MethodNotAllowedExample": {
                 "value": {
-                  "error_code": 405,
-                  "message": "Method is currently not supported or disabled."
+                    "detail": "The requested HTTP method is not allowed for this resource.",
+                    "title": "Method Not Allowed",
+                    "status": 405,
+                    "name": "NotAllowedException"
                 }
               }
             }
@@ -10089,14 +10093,6 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/ProblemDetails"
-            },
-            "examples": {
-              "ErrorExample": {
-                "value": {
-                  "error_code": 500,
-                  "message": "Lost connection to the database."
-                }
-              }
             }
           }
         },
@@ -10107,6 +10103,16 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/ProblemDetails"
+            },
+            "examples": {
+              "BadRequestExample": {
+                "value": {
+                    "detail": "BadRequestException: The request contains invalid or missing parameters.",
+                    "title": "Bad Request",
+                    "status": 400,
+                    "name": "BadRequestException"
+                }
+              }
             }
           }
         },
@@ -10121,8 +10127,10 @@
             "examples": {
               "ConflictExample": {
                 "value": {
-                  "error_code": 409,
-                  "message": "The artifact content was invalid."
+                  "detail": "ArtifactAlreadyExistsException: An artifact with ID 'artifact-ID' in group 'group-ID' already exists.",
+                  "title": "An artifact with ID 'artifact-ID' in group 'group-ID' already exists.",
+                  "status": 409,
+                  "name": "ArtifactAlreadyExistsException"
                 }
               }
             }
@@ -10139,8 +10147,8 @@
             "examples": {
               "RuleViolationConflictExample": {
                 "value": {
-                  "error_code": 409,
-                  "message": "The artifact content was invalid",
+                  "status": 409,
+                  "title": "The artifact content was invalid",
                   "causes": [
                     {
                       "description": "API is missing a title",
@@ -10167,8 +10175,8 @@
             "examples": {
               "RuleViolationBadRequestExample": {
                 "value": {
-                  "error_code": 400,
-                  "message": "The artifact content was invalid",
+                  "status": 400,
+                  "title": "The artifact content was invalid",
                   "causes": [
                     {
                       "description": "API is missing a title",
@@ -10224,8 +10232,8 @@
             "examples": {
               "UnprocessableEntityExample": {
                 "value": {
-                  "error_code": 422,
-                  "message": "The artifact content is invalid: Schema validation failed",
+                  "title": "The artifact content is invalid: Schema validation failed",
+                  "status": 422,
                   "name": "SchemaValidationException"
                 }
               }


### PR DESCRIPTION
## Description

Fixes  #9725

Fix the error response samples in the Registry API v3 documentation so they match the documented Response Schema.

Some response samples, including 400, 409, 422, and 500, were using error_code and message properties, which are not defined in the Response Schema.

The samples have been updated to use the properties defined by the schema, such as detail, title, status, and name