### PR TITLE
Olm v1 upgrade tests

### DIFF
--- a/operator/olm-tests/README.md
+++ b/operator/olm-tests/README.md
@@ -74,10 +74,19 @@ checked without a cluster; the live OLM v1 smoke run is the end-to-end backstop,
   install modes and the SingleNamespace boundary, neither of which v1 exposes today.
 - **`ChannelValidationOLMITTest`** validates channel metadata (names, heads, default channel) against
   the live catalog.
-- **`UpgradeOLMITTest`** installs an older version from the catalog and verifies OLM upgrades it to the
-  current version. It discovers available versions from the live `PackageManifest` at runtime rather than
-  hardcoding version strings, so it works with both upstream catalogs (built from `catalog.template.yaml`)
-  and downstream IIB images (where CSV names have productized suffixes like `-r1`).
+- **`UpgradeOLMITTest`** (OLM v0 only) installs an older version from the catalog and verifies OLM upgrades
+  it to the current version, driven by a `Subscription`/`InstallPlan`. It discovers available versions from
+  the live catalog at runtime rather than hardcoding version strings, so it works with both upstream
+  catalogs (built from `catalog.template.yaml`) and downstream IIB images (where CSV names have
+  productized suffixes like `-r1`).
+- **`UpgradeOLMv1ITTest`** (OLM v1 only) is the `ClusterExtension` counterpart of `UpgradeOLMITTest`,
+  covering the same scenarios except manual-approval upgrade (see below). OLM v1 has no `Subscription`
+  auto-resolve-to-newest-in-channel behavior, so "upgrading" means patching
+  `spec.source.catalog.version`/`channels` on the `ClusterExtension` directly and waiting for the operator
+  deployment to follow. Catalog discovery (channels, versions, heads) is shared with `UpgradeOLMITTest` via
+  `CatalogDiscovery`, which under OLM v1 reads File-Based Catalog content from catalogd (via
+  `CatalogdClient`, extracted from `ChannelValidationOLMITTest`) instead of exec'ing into the catalog pod,
+  and feeds it through the same FBC parser used by OLM v0.
 
 ## OLM upgrade test scenarios
 
@@ -138,11 +147,29 @@ The version goes into `3.2.x` only, not `3.x`. Tests involving the rolling chann
 | Downgrade rejected | No | Version is not in `3.x` |
 | Channel switch noop | No | Version is not in `3.x` |
 
+### OLM v1 coverage and its limits
+
+`UpgradeOLMv1ITTest` covers upgrade within a minor channel, cross-minor upgrade, channel switch
+(rolling→minor, and the noop case at channel head), minor channel isolation, fresh install on a minor
+channel, and rejected downgrade — the same scenarios `UpgradeOLMITTest` covers, minus manual-approval
+upgrade. OLM v1's `ClusterExtension` has no `InstallPlan`/approval concept: resolution is either automatic
+(whatever version satisfies the constraint at reconcile time) or explicit user-driven (edit the constraint
+yourself), with no intermediate "pending approval" object to approve. `testManualApprovalUpgrade` therefore
+stays OLM v0-only, gated off entirely for v1 the same way the rest of `UpgradeOLMITTest` already is.
+
+For "fresh install on a minor channel," `UpgradeOLMv1ITTest` pins `spec.source.catalog.version` explicitly
+to the discovered channel head, rather than omitting the field the way OLM v0's `startingCSV`-less
+Subscription does. Whether an unset `version` field reliably resolves to the channel head under OLM v1
+could not be verified against a live cluster in the environment this was developed in, so the test
+validates the pinned-head-install path instead of relying on that unconfirmed default.
+
 ### How tests determine applicability
 
-Tests query the live `PackageManifest` (OLM v0) or catalog pod (OLM v1) after the `CatalogSource` is
-created. The discovery result is cached for the duration of the test run. Each test checks its
-preconditions and logs the reason when skipping:
+Tests query the live catalog after the `CatalogSource`/`ClusterCatalog` is created: OLM v0 reads FBC
+content by exec'ing into the catalog pod, OLM v1 reads the same FBC format from catalogd over HTTP. Both
+paths are parsed by the same `CatalogDiscovery.parseFBC` method into a shared `CatalogInfo` model, and the
+discovery result is cached for the duration of the test run. Each test checks its preconditions against
+that model and logs the reason when skipping:
 
 - **Is the current version in `3.x`?** Check if `3.x` channel entries contain a CSV matching the current
   package version.

--- a/operator/olm-tests/README.md
+++ b/operator/olm-tests/README.md
@@ -163,6 +163,12 @@ asserts that OLM v1 resolves it to the discovered channel head. The resolved ver
 the installed operator deployment, so the test exercises OLM v1's default channel-head resolution rather
 than re-checking a version it pinned itself.
 
+The cross-minor upgrade test only runs when the rolling channel's cross-minor entry is at least
+`3.3.2`, the first release whose bundle carries the cluster-tier CSV RBAC an OLM v1 `ClusterExtension`
+install needs. Earlier bundles rely on an OLM v0 `OperatorGroup` to scope the operator's watch, which
+`ClusterExtension` has no equivalent for, so upgrades starting from them stay covered by
+`UpgradeOLMITTest` (OLM v0) only.
+
 ### How tests determine applicability
 
 Tests query the live catalog after the `CatalogSource`/`ClusterCatalog` is created: OLM v0 reads FBC

--- a/operator/olm-tests/README.md
+++ b/operator/olm-tests/README.md
@@ -157,11 +157,11 @@ upgrade. OLM v1's `ClusterExtension` has no `InstallPlan`/approval concept: reso
 yourself), with no intermediate "pending approval" object to approve. `testManualApprovalUpgrade` therefore
 stays OLM v0-only, gated off entirely for v1 the same way the rest of `UpgradeOLMITTest` already is.
 
-For "fresh install on a minor channel," `UpgradeOLMv1ITTest` pins `spec.source.catalog.version` explicitly
-to the discovered channel head, rather than omitting the field the way OLM v0's `startingCSV`-less
-Subscription does. Whether an unset `version` field reliably resolves to the channel head under OLM v1
-could not be verified against a live cluster in the environment this was developed in, so the test
-validates the pinned-head-install path instead of relying on that unconfirmed default.
+For "fresh install on a minor channel," `UpgradeOLMv1ITTest` deploys a channel-only `ClusterExtension`
+with no `spec.source.catalog.version` — the same shape as OLM v0's `startingCSV`-less Subscription — and
+asserts that OLM v1 resolves it to the discovered channel head. The resolved version is read back from
+the installed operator deployment, so the test exercises OLM v1's default channel-head resolution rather
+than re-checking a version it pinned itself.
 
 ### How tests determine applicability
 

--- a/operator/olm-tests/src/test/deploy/olmv1/cluster-extension-upgrade.yaml
+++ b/operator/olm-tests/src/test/deploy/olmv1/cluster-extension-upgrade.yaml
@@ -1,0 +1,21 @@
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: apicurio-registry-operator-ce
+spec:
+  namespace: ${PLACEHOLDER_NAMESPACE}
+  serviceAccount:
+    name: apicurio-registry-operator-installer
+  source:
+    sourceType: Catalog
+    catalog:
+      selector:
+        matchLabels:
+          app: apicurio-registry-operator-catalog
+          app.kubernetes.io/name: apicurio-registry-operator-catalog
+          app.kubernetes.io/version: ${PLACEHOLDER_VERSION}
+          olm.operatorframework.io/metadata.name: apicurio-registry-operator-catalog # Intentional for development and testing.
+      packageName: ${PLACEHOLDER_PACKAGE_NAME}
+      channels:
+        - ${PLACEHOLDER_UPGRADE_CHANNEL}
+      version: ${PLACEHOLDER_UPGRADE_VERSION}

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogDiscovery.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogDiscovery.java
@@ -19,18 +19,21 @@ import static io.apicurio.registry.operator.it.CatalogInfo.parseVersion;
 import static io.apicurio.registry.operator.it.OLMTestUtils.*;
 
 /**
- * Queries the live OLM catalog by reading the File-Based Catalog (FBC) content directly from the
- * catalog pod. Results are cached so the catalog is queried only once per test run.
+ * Queries the live OLM catalog to discover channels, CSV names, and upgrade paths, by reading the
+ * File-Based Catalog (FBC) content rather than the PackageManifest API (unreliable because it merges
+ * data from all catalog sources on the cluster and strips productized version suffixes). Results are
+ * cached so the catalog is queried only once per test run.
  * <p>
- * This replaces the PackageManifest-based discovery, which was unreliable because it merges data
- * from all catalog sources on the cluster and strips productized version suffixes.
- * <p>
- * The FBC content is read by exec'ing into the catalog pod and cat'ing the catalog file. Two
- * path conventions are supported:
+ * Under OLM v0 the FBC content is read by exec'ing into the catalog pod and cat'ing the catalog file.
+ * Two path conventions are supported:
  * <ul>
  *   <li>IIB (downstream): {@code /configs/<package>/catalog.json}</li>
  *   <li>Upstream: {@code /configs/index.yaml}</li>
  * </ul>
+ * Under OLM v1 there is no catalog pod to exec into directly (catalogd serves the content over HTTP
+ * instead), so the same FBC content is fetched via {@link CatalogdClient} and fed through the same
+ * {@link #parseFBC} parser. Both paths populate the same {@link CatalogInfo} model, so callers do not
+ * need to know which OLM version is in play.
  */
 public class CatalogDiscovery {
 
@@ -49,7 +52,8 @@ public class CatalogDiscovery {
 
     /**
      * Returns the singleton instance, performing discovery on first call. Discovery creates a temporary
-     * namespace, deploys a CatalogSource, reads the FBC content from the catalog pod, and cleans up.
+     * namespace, deploys the OLM-version-appropriate catalog resource, reads the FBC content, and cleans
+     * up.
      */
     public static synchronized CatalogDiscovery getInstance(KubernetesClient client) throws Exception {
         if (instance != null) {
@@ -60,19 +64,12 @@ public class CatalogDiscovery {
         var namespace = "catalog-discovery-" + UUID.randomUUID().toString().substring(0, 8);
         log.info("Starting catalog discovery in temporary namespace {}", namespace);
 
+        var olmVersion = getOlmVersion();
         try {
             ITBase.createNamespace(client, namespace);
 
-            createResource(client, namespace, "olmv0/catalog-source.yaml");
-            waitForCatalogPodReady(client, namespace);
-
-            var podName = findCatalogPodName(client, namespace);
-            log.info("Catalog pod found: {}", podName);
-
-            var fbcContent = readFBCFromPod(client, namespace, podName);
-            log.info("FBC content read from catalog pod ({} bytes)", fbcContent.length());
-
-            var info = parseFBC(fbcContent);
+            var info = olmVersion == 1 ? discoverViaCatalogd(client, namespace)
+                    : discoverViaCatalogPod(client, namespace);
             instance = new CatalogDiscovery(info);
 
             log.info("Catalog discovery complete:");
@@ -87,12 +84,39 @@ public class CatalogDiscovery {
             return instance;
         } finally {
             try {
-                deleteResourceQuietly(client, namespace, "olmv0/catalog-source.yaml");
+                if (olmVersion == 1) {
+                    deleteResourceQuietly(client, namespace, "olmv1/cluster-catalog.yaml");
+                } else {
+                    deleteResourceQuietly(client, namespace, "olmv0/catalog-source.yaml");
+                }
                 client.namespaces().withName(namespace).delete();
             } catch (Exception e) {
                 log.warn("Cleanup of discovery namespace {} failed: {}", namespace, e.getMessage());
             }
         }
+    }
+
+    private static CatalogInfo discoverViaCatalogPod(KubernetesClient client, String namespace)
+            throws Exception {
+        createResource(client, namespace, "olmv0/catalog-source.yaml");
+        waitForCatalogPodReady(client, namespace);
+
+        var podName = findCatalogPodName(client, namespace);
+        log.info("Catalog pod found: {}", podName);
+
+        var fbcContent = readFBCFromPod(client, namespace, podName);
+        log.info("FBC content read from catalog pod ({} bytes)", fbcContent.length());
+        return parseFBC(fbcContent);
+    }
+
+    private static CatalogInfo discoverViaCatalogd(KubernetesClient client, String namespace)
+            throws Exception {
+        createResource(client, namespace, "olmv1/cluster-catalog.yaml");
+        waitForClusterCatalogServing(client, namespace, CATALOG_NAME);
+
+        var fbcContent = CatalogdClient.readCatalogContent(client, namespace, CATALOG_NAME);
+        log.info("FBC content read from catalogd ({} bytes)", fbcContent.length());
+        return parseFBC(fbcContent);
     }
 
     private static String findCatalogPodName(KubernetesClient client, String namespace) {

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogdClient.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogdClient.java
@@ -1,0 +1,95 @@
+package io.apicurio.registry.operator.it;
+
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Reads File-Based Catalog (FBC) content from a catalogd-served {@code ClusterCatalog} (OLM v1).
+ * <p>
+ * catalogd only exposes its HTTP API in-cluster (no route/ingress, self-signed TLS), so there is no
+ * direct network path from the test JVM. This spins up a throwaway pod that curls the catalogd service
+ * and reads the response back from the pod's logs. The base URL is read from the ClusterCatalog's
+ * {@code status.urls.base}, since the catalogd service namespace varies across OCP versions
+ * ({@code olmv1-system} on older, {@code openshift-catalogd} on 4.22+).
+ */
+public final class CatalogdClient {
+
+    private static final Logger log = LoggerFactory.getLogger(CatalogdClient.class);
+
+    private CatalogdClient() {
+    }
+
+    /**
+     * Fetches the full FBC content of {@code catalogName} by running a curl pod in {@code namespace}.
+     */
+    @SuppressWarnings("unchecked")
+    public static String readCatalogContent(KubernetesClient client, String namespace, String catalogName)
+            throws Exception {
+        var cc = client.genericKubernetesResources("olm.operatorframework.io/v1", "ClusterCatalog")
+                .withName(catalogName)
+                .get();
+        if (cc == null) {
+            throw new IllegalStateException("ClusterCatalog '" + catalogName + "' not found");
+        }
+
+        var urls = (Map<String, Object>) cc.get("status", "urls");
+        String baseUrl;
+        if (urls != null && urls.get("base") != null) {
+            baseUrl = (String) urls.get("base");
+            log.info("Discovered catalogd base URL from ClusterCatalog status: {}", baseUrl);
+        } else {
+            // Fallback for older OLM v1 versions that may not populate status.urls
+            baseUrl = "https://catalogd-service.openshift-catalogd.svc/catalogs/" + catalogName;
+            log.warn("ClusterCatalog status.urls.base not available, using fallback: {}", baseUrl);
+        }
+
+        var podName = "catalog-query-" + namespace.substring(namespace.length() - 7);
+
+        try {
+            client.pods().inNamespace(namespace).withName(podName).delete();
+            Thread.sleep(2000);
+        } catch (Exception e) {
+            // ignore: pod may not exist yet
+        }
+
+        // Try the /api/v1/all endpoint first, then /all for older catalogd versions
+        var curlCmd = "curl -sk '" + baseUrl + "/api/v1/all' 2>/dev/null || "
+                + "curl -sk '" + baseUrl + "/all' 2>/dev/null";
+        log.info("Querying catalogd API via curl pod: {}", curlCmd);
+
+        var pod = new PodBuilder()
+                .withNewMetadata().withName(podName).withNamespace(namespace).endMetadata()
+                .withNewSpec()
+                .withRestartPolicy("Never")
+                .addNewContainer()
+                .withName("curl")
+                .withImage("registry.access.redhat.com/ubi9/ubi-minimal:latest")
+                .withCommand("sh", "-c", curlCmd)
+                .endContainer()
+                .endSpec()
+                .build();
+        client.pods().inNamespace(namespace).resource(pod).create();
+
+        await().atMost(Duration.ofMinutes(2)).ignoreExceptions().until(() -> {
+            var p = client.pods().inNamespace(namespace).withName(podName).get();
+            return p != null && ("Succeeded".equals(p.getStatus().getPhase())
+                    || "Failed".equals(p.getStatus().getPhase()));
+        });
+
+        var content = client.pods().inNamespace(namespace).withName(podName).getLog();
+        client.pods().inNamespace(namespace).withName(podName).delete();
+
+        if (content == null || content.isEmpty()) {
+            throw new IllegalStateException("Empty catalog content from catalogd API at " + baseUrl);
+        }
+        log.info("Received {} bytes from catalogd API", content.length());
+        return content;
+    }
+}

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/ChannelValidationOLMITTest.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/ChannelValidationOLMITTest.java
@@ -19,8 +19,9 @@ import static org.awaitility.Awaitility.await;
 /**
  * Validates OLM catalog channel configuration.
  * <p>
- * Under OLM v0, uses the PackageManifest API. Under OLM v1, reads the catalog content from the
- * catalogd HTTP API and parses it via {@link CatalogDiscovery#parseFBC} to build a {@link CatalogInfo}.
+ * Under OLM v0, uses the PackageManifest API. Under OLM v1, reads File-Based Catalog (FBC) content
+ * from catalogd (via {@link CatalogdClient}) and parses it via {@link CatalogDiscovery#parseFBC} into a
+ * {@link CatalogInfo}, since PackageManifest may return data from other catalog sources on the cluster.
  */
 @QuarkusTest
 @Tag(OLM)
@@ -168,79 +169,13 @@ public class ChannelValidationOLMITTest extends OLMITBase {
     // ---- OLM v1 catalogd access ----
 
     /**
-     * Reads the catalog content from the catalogd HTTP API and parses it into a CatalogInfo
-     * using the shared FBC parser.
+     * Reads FBC content from catalogd (via {@link CatalogdClient}) and parses it with
+     * {@link CatalogDiscovery#parseFBC}, the same parser {@code CatalogDiscovery} uses for OLM v0's
+     * exec-from-pod FBC content, so channel/version parsing logic lives in exactly one place. The
+     * base URL is discovered from the ClusterCatalog's {@code status.urls.base} field.
      */
-    @SuppressWarnings("unchecked")
     private CatalogInfo getCatalogInfoV1() throws Exception {
-        var content = readCatalogdContent();
+        var content = CatalogdClient.readCatalogContent(client, namespace, CATALOG_NAME);
         return CatalogDiscovery.parseFBC(content);
-    }
-
-    /**
-     * Reads the raw catalog content from the catalogd HTTP API via a curl pod. The base URL is
-     * discovered from the ClusterCatalog's status.urls.base field.
-     */
-    @SuppressWarnings("unchecked")
-    private String readCatalogdContent() throws Exception {
-        var catalogName = "apicurio-registry-operator-catalog";
-
-        var cc = client.genericKubernetesResources("olm.operatorframework.io/v1", "ClusterCatalog")
-                .withName(catalogName)
-                .get();
-        if (cc == null) {
-            throw new IllegalStateException("ClusterCatalog '" + catalogName + "' not found");
-        }
-
-        var urls = (Map<String, Object>) cc.get("status", "urls");
-        String baseUrl;
-        if (urls != null && urls.get("base") != null) {
-            baseUrl = (String) urls.get("base");
-            log.info("Discovered catalogd base URL from ClusterCatalog status: {}", baseUrl);
-        } else {
-            baseUrl = "https://catalogd-service.openshift-catalogd.svc/catalogs/" + catalogName;
-            log.warn("ClusterCatalog status.urls.base not available, using fallback: {}", baseUrl);
-        }
-
-        var podName = "catalog-query-" + namespace.substring(namespace.length() - 7);
-
-        try {
-            client.pods().inNamespace(namespace).withName(podName).delete();
-            Thread.sleep(2000);
-        } catch (Exception e) {
-            // ignore
-        }
-
-        var curlCmd = "curl -sk '" + baseUrl + "/api/v1/all' 2>/dev/null || "
-                + "curl -sk '" + baseUrl + "/all' 2>/dev/null";
-        log.info("Querying catalogd API via curl pod: {}", curlCmd);
-
-        var pod = new io.fabric8.kubernetes.api.model.PodBuilder()
-                .withNewMetadata().withName(podName).withNamespace(namespace).endMetadata()
-                .withNewSpec()
-                .withRestartPolicy("Never")
-                .addNewContainer()
-                .withName("curl")
-                .withImage("registry.access.redhat.com/ubi9/ubi-minimal:latest")
-                .withCommand("sh", "-c", curlCmd)
-                .endContainer()
-                .endSpec()
-                .build();
-        client.pods().inNamespace(namespace).resource(pod).create();
-
-        await().atMost(java.time.Duration.ofMinutes(2)).ignoreExceptions().until(() -> {
-            var p = client.pods().inNamespace(namespace).withName(podName).get();
-            return p != null && ("Succeeded".equals(p.getStatus().getPhase())
-                    || "Failed".equals(p.getStatus().getPhase()));
-        });
-
-        var content = client.pods().inNamespace(namespace).withName(podName).getLog();
-        client.pods().inNamespace(namespace).withName(podName).delete();
-
-        if (content == null || content.isEmpty()) {
-            throw new IllegalStateException("Empty catalog content from catalogd API at " + baseUrl);
-        }
-        log.info("Received {} bytes from catalogd API", content.length());
-        return content;
     }
 }

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
@@ -19,14 +19,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 import static io.apicurio.registry.operator.it.ITBase.MEDIUM_DURATION;
 import static io.apicurio.registry.operator.it.ITBase.SHORT_DURATION;
 import static io.apicurio.registry.operator.it.ITBase.setDefaultAwaitilityTimings;
 import static io.apicurio.registry.operator.it.OLMTestUtils.waitForCatalogPodReady;
+import static io.apicurio.registry.operator.it.OLMTestUtils.waitForClusterCatalogServing;
 import static io.apicurio.registry.operator.resource.Labels.getOperatorManagedLabels;
 import static io.apicurio.registry.operator.utils.K8sCell.k8sCell;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -211,16 +210,7 @@ public abstract class OLMITBase implements OperatorTestContext {
 
             createResource("olmv1/cluster-catalog.yaml");
 
-            await().ignoreExceptions().until(() -> {
-                var r = client.genericKubernetesResources("olm.operatorframework.io/v1", "ClusterCatalog")
-                        .inNamespace(namespace)
-                        .withName("apicurio-registry-operator-catalog")
-                        .get();
-
-                return ((Collection<Map<String, Object>>) r.get("status", "conditions")).stream().anyMatch(c -> {
-                    return "Serving".equals(c.get("type")) && "True".equals(c.get("status"));
-                });
-            });
+            waitForClusterCatalogServing(client, namespace, "apicurio-registry-operator-catalog");
 
             createResource("olmv1/service-account.yaml");
             createResource("olmv1/cluster-role.yaml");

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMTestUtils.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMTestUtils.java
@@ -11,6 +11,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import static org.awaitility.Awaitility.await;
+
 public final class OLMTestUtils {
 
     public static final String PACKAGE_NAME = "apicurio-registry-3";
@@ -130,7 +132,7 @@ public final class OLMTestUtils {
     }
 
     public static void waitForCatalogPodReady(KubernetesClient client, String namespace) {
-        org.awaitility.Awaitility.await().ignoreExceptions()
+        await().ignoreExceptions()
                 .until(() -> client.pods().inNamespace(namespace).list().getItems().stream()
                         .filter(pod -> pod.getMetadata().getName()
                                 .startsWith("apicurio-registry-operator-catalog"))
@@ -138,7 +140,7 @@ public final class OLMTestUtils {
                                 c -> "Ready".equals(c.getType()) && "True".equals(c.getStatus()))));
         // A Ready pod is not immediately routable: the Service endpoints (and kube-proxy
         // rules) lag by a beat, and OLM's resolver otherwise fails with "no route to host".
-        org.awaitility.Awaitility.await().ignoreExceptions().until(() -> {
+        await().ignoreExceptions().until(() -> {
             var endpoints = client.endpoints().inNamespace(namespace)
                     .withName("apicurio-registry-operator-catalog").get();
             return endpoints != null && endpoints.getSubsets() != null
@@ -154,7 +156,7 @@ public final class OLMTestUtils {
     @SuppressWarnings("unchecked")
     public static void waitForClusterCatalogServing(KubernetesClient client, String namespace,
             String catalogName) {
-        org.awaitility.Awaitility.await().ignoreExceptions().until(() -> {
+        await().ignoreExceptions().until(() -> {
             var cc = client.genericKubernetesResources("olm.operatorframework.io/v1", "ClusterCatalog")
                     .inNamespace(namespace)
                     .withName(catalogName)

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMTestUtils.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMTestUtils.java
@@ -14,6 +14,7 @@ import java.util.Map;
 public final class OLMTestUtils {
 
     public static final String PACKAGE_NAME = "apicurio-registry-3";
+    public static final String CATALOG_NAME = "apicurio-registry-operator-catalog";
     public static final String PROJECT_VERSION_PROP = "registry.version";
     public static final String PROJECT_ROOT_PROP = "test.operator.project-root";
     public static final String CATALOG_IMAGE_PROP = "test.operator.catalog-image";
@@ -24,6 +25,13 @@ public final class OLMTestUtils {
 
     public static String getProjectVersion() {
         return ConfigProvider.getConfig().getValue(PROJECT_VERSION_PROP, String.class);
+    }
+
+    /**
+     * The configured OLM version this test run targets (0 for OLM v0, 1 for OLM v1).
+     */
+    public static int getOlmVersion() {
+        return ConfigProvider.getConfig().getOptionalValue(OLM_VERSION_PROP, Integer.class).orElse(0);
     }
 
     public static String getCatalogImage() {
@@ -136,6 +144,27 @@ public final class OLMTestUtils {
             return endpoints != null && endpoints.getSubsets() != null
                     && endpoints.getSubsets().stream()
                             .anyMatch(s -> s.getAddresses() != null && !s.getAddresses().isEmpty());
+        });
+    }
+
+    /**
+     * Waits until the OLM v1 {@code ClusterCatalog} named {@code catalogName} reports a {@code Serving}
+     * condition of {@code True}, meaning catalogd has finished unpacking it and its content is queryable.
+     */
+    @SuppressWarnings("unchecked")
+    public static void waitForClusterCatalogServing(KubernetesClient client, String namespace,
+            String catalogName) {
+        org.awaitility.Awaitility.await().ignoreExceptions().until(() -> {
+            var cc = client.genericKubernetesResources("olm.operatorframework.io/v1", "ClusterCatalog")
+                    .inNamespace(namespace)
+                    .withName(catalogName)
+                    .get();
+            if (cc == null) {
+                return false;
+            }
+            var conditions = (Collection<Map<String, Object>>) cc.get("status", "conditions");
+            return conditions != null && conditions.stream()
+                    .anyMatch(c -> "Serving".equals(c.get("type")) && "True".equals(c.get("status")));
         });
     }
 }

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMv1ITTest.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMv1ITTest.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.apicurio.registry.operator.Tags.OLM;
 import static io.apicurio.registry.operator.it.ITBase.MEDIUM_DURATION;
@@ -57,6 +58,8 @@ public class UpgradeOLMv1ITTest implements OperatorTestContext {
     private static final Logger log = LoggerFactory.getLogger(UpgradeOLMv1ITTest.class);
 
     private static final String CLUSTER_EXTENSION_NAME = "apicurio-registry-operator-ce";
+
+    private static final String OPERATOR_DEPLOYMENT_PREFIX = "apicurio-registry-operator-v";
 
     private static final Duration UPGRADE_TIMEOUT = Duration.ofSeconds(
             Integer.getInteger("test.operator.timeout.olm-upgrade", 1200));
@@ -407,12 +410,11 @@ public class UpgradeOLMv1ITTest implements OperatorTestContext {
     /**
      * Verifies fresh install on the minor channel lands on the channel head.
      * <p>
-     * Note: unlike the OLM v0 equivalent (which omits {@code startingCSV} and relies on Subscription's
-     * always-resolve-to-newest-in-channel behavior), this pins {@code spec.source.catalog.version}
-     * explicitly to the discovered channel head. Whether an unset {@code version} field reliably resolves
-     * to the channel head under OLM v1 could not be verified against a live cluster in the environment
-     * this was developed in, so this test validates the pinned-head-install path instead of relying on
-     * that unconfirmed default.
+     * Like the OLM v0 equivalent (which omits {@code startingCSV} and relies on the Subscription's
+     * always-resolve-to-newest-in-channel behavior), this deploys a channel-only {@code ClusterExtension}
+     * with no {@code spec.source.catalog.version} and lets OLM v1 resolve the version itself. The test
+     * then reads the version OLM actually installed (from the ready operator deployment) and asserts it
+     * equals the discovered channel head, genuinely exercising OLM v1's default channel-head resolution.
      */
     @RetryTest
     @EnabledIf("minorChannelExists")
@@ -421,14 +423,19 @@ public class UpgradeOLMv1ITTest implements OperatorTestContext {
 
         var minorHeadVersion = catalog.getChannelHeadVersion(minorChannel());
 
-        log.info("Testing fresh install on {} channel, pinned to head {}", minorChannel(),
-                minorHeadVersion);
+        log.info("Testing fresh install on {} channel with a version-less ClusterExtension "
+                + "(expecting OLM to resolve to channel head {})", minorChannel(), minorHeadVersion);
 
-        deployClusterExtension(minorChannel(), minorHeadVersion);
-        verifyUpgradeTo(minorHeadVersion);
+        deployClusterExtensionChannelOnly(minorChannel());
 
-        log.info("Fresh install on {} channel got version {} as expected",
-                minorChannel(), minorHeadVersion);
+        var resolvedVersion = waitForResolvedOperatorVersion();
+        log.info("Version-less ClusterExtension on {} resolved to {} (channel head is {})",
+                minorChannel(), resolvedVersion, minorHeadVersion);
+
+        assertThat(resolvedVersion)
+                .as("A version-less ClusterExtension on channel %s should resolve to the channel head",
+                        minorChannel())
+                .isEqualTo(minorHeadVersion);
     }
 
     /**
@@ -480,9 +487,23 @@ public class UpgradeOLMv1ITTest implements OperatorTestContext {
     // ---- Infrastructure methods ----
 
     private static String deploymentName(Semver version) {
-        return "apicurio-registry-operator-v" + version;
+        return OPERATOR_DEPLOYMENT_PREFIX + version;
     }
 
+    /**
+     * Deploys the catalog, RBAC and a {@code ClusterExtension} on {@code channel} with no
+     * {@code spec.source.catalog.version}, leaving the version for OLM v1 to resolve (expected: the
+     * channel head).
+     */
+    private void deployClusterExtensionChannelOnly(String channel) throws Exception {
+        deployClusterExtension(channel, null);
+    }
+
+    /**
+     * Deploys the catalog, RBAC and a {@code ClusterExtension} on {@code channel}. When {@code version}
+     * is non-null it is pinned as {@code spec.source.catalog.version}; when null, the version constraint
+     * line is dropped so OLM v1 resolves the version itself.
+     */
     private void deployClusterExtension(String channel, Semver version) throws Exception {
         try {
             createResource(client, namespace, "olmv1/cluster-catalog.yaml");
@@ -491,16 +512,45 @@ public class UpgradeOLMv1ITTest implements OperatorTestContext {
             createResource(client, namespace, "olmv1/cluster-role.yaml");
             createResource(client, namespace, "olmv1/cluster-role-binding.yaml");
 
-            var extraVars = Map.of(
-                    "${PLACEHOLDER_UPGRADE_CHANNEL}", channel,
-                    "${PLACEHOLDER_UPGRADE_VERSION}", version.toString());
             var raw = loadRawResource("olmv1/cluster-extension-upgrade.yaml");
+            Map<String, String> extraVars;
+            if (version == null) {
+                // Drop only the version-constraint line so OLM resolves spec.source.catalog.version
+                // itself. The ${PLACEHOLDER_VERSION} label line is left untouched.
+                raw = raw.replaceAll("(?m)^.*\\$\\{PLACEHOLDER_UPGRADE_VERSION}.*\\R?", "");
+                extraVars = Map.of("${PLACEHOLDER_UPGRADE_CHANNEL}", channel);
+            } else {
+                extraVars = Map.of(
+                        "${PLACEHOLDER_UPGRADE_CHANNEL}", channel,
+                        "${PLACEHOLDER_UPGRADE_VERSION}", version.toString());
+            }
             client.resource(replaceVars(raw, namespace, extraVars)).create();
         } catch (Exception e) {
             log.error("OLM v1 catalog/ClusterExtension setup failed, dumping cluster diagnostics", e);
             ClusterDiagnostics.dump(client, namespace, true);
             throw e;
         }
+    }
+
+    /**
+     * Waits until a registry operator deployment ({@code apicurio-registry-operator-v*}) is ready and
+     * returns the version OLM actually resolved, parsed from that deployment's name.
+     */
+    private Semver waitForResolvedOperatorVersion() {
+        var resolved = new AtomicReference<Semver>();
+        await().atMost(UPGRADE_TIMEOUT).ignoreExceptions().untilAsserted(() -> {
+            var ready = client.apps().deployments().inNamespace(namespace).list().getItems().stream()
+                    .filter(d -> d.getMetadata().getName().startsWith(OPERATOR_DEPLOYMENT_PREFIX))
+                    .filter(d -> Integer.valueOf(1).equals(d.getStatus().getReadyReplicas()))
+                    .findFirst();
+            assertThat(ready)
+                    .as("A registry operator deployment (%s*) should become ready",
+                            OPERATOR_DEPLOYMENT_PREFIX)
+                    .isPresent();
+            resolved.set(CatalogInfo.parseVersion(ready.get().getMetadata().getName()
+                    .substring(OPERATOR_DEPLOYMENT_PREFIX.length())));
+        });
+        return resolved.get();
     }
 
     private void waitForOperatorVersion(Semver version) {

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMv1ITTest.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMv1ITTest.java
@@ -1,0 +1,552 @@
+package io.apicurio.registry.operator.it;
+
+import io.apicurio.registry.operator.utils.ClusterDiagnostics;
+import io.apicurio.registry.operator.utils.OperatorTestContext;
+import io.apicurio.registry.operator.utils.OperatorTestExtension;
+import io.apicurio.registry.operator.utils.RetryTest;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.quarkus.test.junit.QuarkusTest;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.semver4j.Semver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static io.apicurio.registry.operator.Tags.OLM;
+import static io.apicurio.registry.operator.it.ITBase.MEDIUM_DURATION;
+import static io.apicurio.registry.operator.it.ITBase.SHORT_DURATION;
+import static io.apicurio.registry.operator.it.ITBase.setDefaultAwaitilityTimings;
+import static io.apicurio.registry.operator.it.OLMTestUtils.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Tests OLM upgrade paths using OLM v1 ({@code ClusterExtension}). This is the OLM v1 counterpart of
+ * {@link UpgradeOLMITTest}, covering every scenario there except manual-approval upgrade: OLM v1's
+ * ClusterExtension has no InstallPlan/approval concept. Resolution is either automatic (whatever version
+ * satisfies {@code spec.source.catalog.version} at reconcile time) or explicit user-driven (edit the
+ * constraint yourself), with no intermediate "pending approval" object to approve. See
+ * {@link UpgradeOLMITTest#testManualApprovalUpgrade} for the OLM v0 equivalent, which remains v0-only.
+ * <p>
+ * Unlike OLM v0's Subscription (which always auto-resolves to the newest CSV in its channel), a
+ * ClusterExtension additionally pins an explicit version constraint. So "upgrade" here means patching
+ * {@code spec.source.catalog.version} (and {@code spec.source.catalog.channels} for channel switches) on
+ * the ClusterExtension and waiting for the operator deployment to follow — there is no separate trigger.
+ * <p>
+ * Catalog discovery (channels, versions, heads) is shared with {@link UpgradeOLMITTest} via
+ * {@link CatalogDiscovery}, which reads catalogd's File-Based Catalog content instead of exec'ing into
+ * a catalog pod when {@code test.operator.olm-version=1}. Both OLM versions resolve to the same
+ * {@link CatalogInfo} model, so the channel/version query logic below is identical to
+ * {@link UpgradeOLMITTest}'s.
+ */
+@QuarkusTest
+@Tag(OLM)
+@EnabledIfSystemProperty(named = OLMTestUtils.OLM_VERSION_PROP, matches = "1")
+@ExtendWith(OperatorTestExtension.class)
+public class UpgradeOLMv1ITTest implements OperatorTestContext {
+
+    private static final Logger log = LoggerFactory.getLogger(UpgradeOLMv1ITTest.class);
+
+    private static final String CLUSTER_EXTENSION_NAME = "apicurio-registry-operator-ce";
+
+    private static final Duration UPGRADE_TIMEOUT = Duration.ofSeconds(
+            Integer.getInteger("test.operator.timeout.olm-upgrade", 900));
+
+    private static CatalogInfo catalog;
+
+    private KubernetesClient client;
+    private String namespace;
+    private boolean cleanup;
+
+    @Override
+    public KubernetesClient getClient() {
+        return client;
+    }
+
+    @Override
+    public String getNamespace() {
+        return namespace;
+    }
+
+    @Override
+    public boolean isOLMTest() {
+        return true;
+    }
+
+    @BeforeAll
+    static void discoverCatalog() throws Exception {
+        setDefaultAwaitilityTimings();
+        var discoveryClient = ITBase.createK8sClient("default");
+        try {
+            catalog = CatalogDiscovery.getInstance(discoveryClient).getCatalogInfo();
+        } finally {
+            discoveryClient.close();
+        }
+    }
+
+    private static String projectVersion() {
+        return OLMTestUtils.getProjectVersion();
+    }
+
+    private static String minorChannel() {
+        return deriveMinorChannel(projectVersion());
+    }
+
+    private static String rollingChannel() {
+        return deriveRollingChannel(projectVersion());
+    }
+
+    private void setUp() throws Exception {
+        setDefaultAwaitilityTimings();
+        namespace = ITBase.calculateNamespace();
+        client = ITBase.createK8sClient(namespace);
+        ITBase.createNamespace(client, namespace);
+        cleanup = ConfigProvider.getConfig().getValue(ITBase.CLEANUP, Boolean.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (cleanup && client != null && namespace != null) {
+            log.info("Cleaning up namespace: {}", namespace);
+            try {
+                deleteResourceQuietly(client, namespace, "olmv1/cluster-extension-upgrade.yaml");
+                waitForClusterScopedDeleted("ClusterExtension", CLUSTER_EXTENSION_NAME);
+                deleteResourceQuietly(client, namespace, "olmv1/cluster-role-binding.yaml");
+                deleteResourceQuietly(client, namespace, "olmv1/cluster-role.yaml");
+                deleteResourceQuietly(client, namespace, "olmv1/service-account.yaml");
+                deleteResourceQuietly(client, namespace, "olmv1/cluster-catalog.yaml");
+                waitForClusterScopedDeleted("ClusterCatalog", CATALOG_NAME);
+                client.namespaces().withName(namespace).delete();
+            } catch (Exception e) {
+                log.warn("Cleanup error: {}", e.getMessage());
+            }
+            client.close();
+        }
+    }
+
+    // ClusterExtension/ClusterCatalog/ClusterRole(Binding) are cluster-scoped with fixed names, so the
+    // next test's setup would collide with a still-terminating resource from this one unless we wait.
+    private void waitForClusterScopedDeleted(String kind, String name) {
+        await().atMost(SHORT_DURATION).ignoreExceptions().until(() -> client
+                .genericKubernetesResources("olm.operatorframework.io/v1", kind)
+                .inNamespace(namespace).withName(name).get() == null);
+    }
+
+    // ---- Condition methods for @EnabledIf (mirrors UpgradeOLMITTest; kept per-class since each class
+    // discovers into its own static `catalog` field) ----
+
+    static boolean minorChannelHasPreviousEntry() {
+        var has = catalog.getPreviousEntry(minorChannel()) != null;
+        if (!has) {
+            log.info("Condition not met: channel {} has fewer than 2 entries (first-in-minor release)",
+                    minorChannel());
+        }
+        return has;
+    }
+
+    static boolean isHeadOfRollingChannel() {
+        var is = catalog.isVersionChannelHead(rollingChannel(), projectVersion());
+        if (!is) {
+            log.info("Condition not met: version {} is not the head of {} (maintenance branch release?)",
+                    projectVersion(), rollingChannel());
+        }
+        return is;
+    }
+
+    static boolean hasCrossMinorEntryInRollingChannel() {
+        if (!isHeadOfRollingChannel()) {
+            return false;
+        }
+        var entry = catalog.getCrossMinorEntry(rollingChannel());
+        if (entry == null) {
+            log.info("Condition not met: no cross-minor entry found in {}", rollingChannel());
+            return false;
+        }
+        return true;
+    }
+
+    static boolean isInRollingAndMinorChannel() {
+        var inRolling = catalog.isVersionChannelHead(rollingChannel(), projectVersion());
+        var hasMinor = catalog.hasChannel(minorChannel());
+        if (!inRolling) {
+            log.info("Condition not met: version {} is not the head of {}",
+                    projectVersion(), rollingChannel());
+        }
+        if (!hasMinor) {
+            log.info("Condition not met: channel {} not found in catalog", minorChannel());
+        }
+        return inRolling && hasMinor;
+    }
+
+    static boolean rollingChannelHasPreviousEntry() {
+        if (!isInRollingAndMinorChannel()) {
+            return false;
+        }
+        var has = catalog.getPreviousEntry(rollingChannel()) != null;
+        if (!has) {
+            log.info("Condition not met: {} has fewer than 2 entries", rollingChannel());
+        }
+        return has;
+    }
+
+    static boolean hasOlderMinorChannel() {
+        if (!isHeadOfRollingChannel()) {
+            return false;
+        }
+        var ch = catalog.getOlderMinorChannel(projectVersion(), rollingChannel());
+        if (ch == null) {
+            log.info("Condition not met: no older minor channel found in catalog");
+            return false;
+        }
+        return true;
+    }
+
+    static boolean minorChannelExists() {
+        var exists = catalog.hasChannel(minorChannel());
+        if (!exists) {
+            log.info("Condition not met: channel {} not found in catalog", minorChannel());
+        }
+        return exists;
+    }
+
+    // ---- Test methods ----
+
+    /**
+     * Verifies patch upgrade within the current minor channel (e.g., 3.3.0 -> 3.3.1 on 3.3.x), driven by
+     * patching {@code spec.source.catalog.version} on the ClusterExtension.
+     */
+    @RetryTest
+    @EnabledIf("minorChannelHasPreviousEntry")
+    void testUpgradeWithinMinorChannel() throws Exception {
+        setUp();
+
+        var prev = catalog.getPreviousEntry(minorChannel());
+        var headVersion = catalog.getChannelHeadVersion(minorChannel());
+
+        log.info("Testing upgrade within {} channel: {} -> {}",
+                minorChannel(), prev.getVersion(), headVersion);
+
+        deployClusterExtension(minorChannel(), prev.getVersion());
+        waitForOperatorVersion(prev.getVersion());
+
+        log.info("Operator {} deployed, patching version constraint to {}", prev.getVersion(),
+                headVersion);
+        patchClusterExtensionSource(minorChannel(), headVersion);
+        verifyUpgradeTo(headVersion);
+
+        log.info("Upgrade within minor channel succeeded: {} -> {}", prev.getVersion(), headVersion);
+    }
+
+    /**
+     * Verifies cross-minor upgrade via the rolling channel (e.g., 3.2.5 -> 3.3.1 on 3.x).
+     */
+    @RetryTest
+    @EnabledIf("hasCrossMinorEntryInRollingChannel")
+    void testUpgradeAcrossMinors() throws Exception {
+        setUp();
+
+        var crossMinorEntry = catalog.getCrossMinorEntry(rollingChannel());
+        var headVersion = catalog.getChannelHeadVersion(rollingChannel());
+
+        log.info("Testing upgrade via {} channel: {} -> {}",
+                rollingChannel(), crossMinorEntry.getVersion(), headVersion);
+
+        deployClusterExtension(rollingChannel(), crossMinorEntry.getVersion());
+        waitForOperatorVersion(crossMinorEntry.getVersion());
+
+        log.info("Operator {} deployed, patching version constraint to {}",
+                crossMinorEntry.getVersion(), headVersion);
+        patchClusterExtensionSource(rollingChannel(), headVersion);
+        verifyUpgradeTo(headVersion);
+
+        log.info("Cross-minor upgrade succeeded: {} -> {}", crossMinorEntry.getVersion(), headVersion);
+    }
+
+    /**
+     * Verifies channel switch from rolling to minor channel. Installs on 3.x, then switches the
+     * ClusterExtension to 3.3.x (patching both channel and version, since a v1 exact version pin does not
+     * auto-follow a channel switch the way a v0 Subscription's channel-only field does) and verifies the
+     * operator reaches the minor channel head.
+     */
+    @RetryTest
+    @EnabledIf("rollingChannelHasPreviousEntry")
+    void testChannelSwitchFromRollingToMinor() throws Exception {
+        setUp();
+
+        var prev = catalog.getPreviousEntry(rollingChannel());
+        var minorHeadVersion = catalog.getChannelHeadVersion(minorChannel());
+
+        log.info("Testing channel switch: install {} on {}, then switch to {}",
+                prev.getVersion(), rollingChannel(), minorChannel());
+
+        deployClusterExtension(rollingChannel(), prev.getVersion());
+        waitForOperatorVersion(prev.getVersion());
+        log.info("Operator {} deployed on {} channel", prev.getVersion(), rollingChannel());
+
+        patchClusterExtensionSource(minorChannel(), minorHeadVersion);
+        log.info("Switched ClusterExtension to {} channel, waiting for upgrade to {}",
+                minorChannel(), minorHeadVersion);
+
+        verifyUpgradeTo(minorHeadVersion);
+        log.info("Channel switch succeeded: operator is now at {} on {} channel",
+                minorHeadVersion, minorChannel());
+    }
+
+    /**
+     * Verifies that switching channels at the channel head is a no-op (operator stays at same version).
+     */
+    @RetryTest
+    @EnabledIf("isInRollingAndMinorChannel")
+    void testChannelSwitchAtChannelHeadIsNoop() throws Exception {
+        setUp();
+
+        var headVersion = catalog.getChannelHeadVersion(rollingChannel());
+
+        log.info("Testing noop channel switch: install {} on {}, then switch to {}",
+                headVersion, rollingChannel(), minorChannel());
+
+        deployClusterExtension(rollingChannel(), headVersion);
+        waitForOperatorVersion(headVersion);
+        log.info("Operator {} deployed on {} channel", headVersion, rollingChannel());
+
+        var podBefore = client.pods().inNamespace(namespace).list().getItems().stream()
+                .filter(p -> p.getMetadata().getName().contains("apicurio-registry-operator"))
+                .filter(p -> "Running".equals(p.getStatus().getPhase()))
+                .map(p -> p.getMetadata().getUid())
+                .findFirst().orElseThrow(() -> new IllegalStateException("No operator pod found"));
+        log.info("Operator pod UID before switch: {}", podBefore);
+
+        patchClusterExtensionSource(minorChannel(), headVersion);
+        log.info("Switched ClusterExtension to {} channel (same version), verifying operator stays "
+                + "at same version...", minorChannel());
+
+        await().atMost(UPGRADE_TIMEOUT).during(Duration.ofSeconds(20)).ignoreExceptions()
+                .untilAsserted(() -> {
+                    var deployment = client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(headVersion)).get();
+                    assertThat(deployment)
+                            .as("Operator deployment at " + headVersion
+                                    + " should still exist after channel switch")
+                            .isNotNull();
+                    assertThat(deployment.getStatus().getReadyReplicas())
+                            .as("Operator should have 1 ready replica after channel switch")
+                            .isEqualTo(1);
+                });
+
+        var podAfter = client.pods().inNamespace(namespace).list().getItems().stream()
+                .filter(p -> p.getMetadata().getName().contains("apicurio-registry-operator"))
+                .filter(p -> "Running".equals(p.getStatus().getPhase()))
+                .map(p -> p.getMetadata().getUid())
+                .findFirst().orElseThrow(
+                        () -> new IllegalStateException("No operator pod found after switch"));
+
+        if (podAfter.equals(podBefore)) {
+            log.info("Channel switch was a true noop: same pod UID {}", podAfter);
+        } else {
+            log.info("OLM restarted the pod on channel switch (old: {}, new: {}), "
+                    + "but version is unchanged", podBefore, podAfter);
+        }
+
+        log.info("Channel switch at channel head verified: operator at {} is healthy", headVersion);
+    }
+
+    /**
+     * Verifies minor channel isolation: upgrading within the minor channel should not cross minor
+     * boundaries.
+     */
+    @RetryTest
+    @EnabledIf("minorChannelHasPreviousEntry")
+    void testMinorChannelIsolation() throws Exception {
+        setUp();
+
+        var prev = catalog.getPreviousEntry(minorChannel());
+        var minorHeadVersion = catalog.getChannelHeadVersion(minorChannel());
+
+        log.info("Testing minor channel isolation: {} -> {} on {}, then verify no further upgrade",
+                prev.getVersion(), minorHeadVersion, minorChannel());
+
+        deployClusterExtension(minorChannel(), prev.getVersion());
+        waitForOperatorVersion(prev.getVersion());
+        patchClusterExtensionSource(minorChannel(), minorHeadVersion);
+        verifyUpgradeTo(minorHeadVersion);
+        log.info("Upgraded to {}. Verifying no further upgrade happens...", minorHeadVersion);
+
+        var rollingHeadVersion = catalog.getChannelHeadVersion(rollingChannel());
+        if (rollingHeadVersion != null && !rollingHeadVersion.equals(minorHeadVersion)) {
+            await().atMost(MEDIUM_DURATION).during(Duration.ofSeconds(30)).ignoreExceptions()
+                    .untilAsserted(() -> {
+                        var deployment = client.apps().deployments().inNamespace(namespace)
+                                .withName(deploymentName(rollingHeadVersion)).get();
+                        assertThat(deployment)
+                                .as("Operator should NOT be upgraded to " + rollingHeadVersion
+                                        + " on the " + minorChannel() + " channel")
+                                .isNull();
+                    });
+        }
+
+        var currentDeployment = client.apps().deployments().inNamespace(namespace)
+                .withName(deploymentName(minorHeadVersion)).get();
+        assertThat(currentDeployment)
+                .as("Operator should still be at " + minorHeadVersion).isNotNull();
+        assertThat(currentDeployment.getStatus().getReadyReplicas())
+                .as("Operator at " + minorHeadVersion + " should still have 1 ready replica")
+                .isEqualTo(1);
+
+        log.info("Minor channel isolation confirmed: operator stayed at {}", minorHeadVersion);
+    }
+
+    /**
+     * Verifies fresh install on the minor channel lands on the channel head.
+     * <p>
+     * Note: unlike the OLM v0 equivalent (which omits {@code startingCSV} and relies on Subscription's
+     * always-resolve-to-newest-in-channel behavior), this pins {@code spec.source.catalog.version}
+     * explicitly to the discovered channel head. Whether an unset {@code version} field reliably resolves
+     * to the channel head under OLM v1 could not be verified against a live cluster in the environment
+     * this was developed in, so this test validates the pinned-head-install path instead of relying on
+     * that unconfirmed default.
+     */
+    @RetryTest
+    @EnabledIf("minorChannelExists")
+    void testFreshInstallOnEachChannel() throws Exception {
+        setUp();
+
+        var minorHeadVersion = catalog.getChannelHeadVersion(minorChannel());
+
+        log.info("Testing fresh install on {} channel, pinned to head {}", minorChannel(),
+                minorHeadVersion);
+
+        deployClusterExtension(minorChannel(), minorHeadVersion);
+        verifyUpgradeTo(minorHeadVersion);
+
+        log.info("Fresh install on {} channel got version {} as expected",
+                minorChannel(), minorHeadVersion);
+    }
+
+    /**
+     * Verifies that switching to an older minor channel does not downgrade the operator: the version
+     * constraint is deliberately left pinned to the current head (which does not exist in the older
+     * channel), so resolution should fail rather than silently downgrading.
+     */
+    @RetryTest
+    @EnabledIf("hasOlderMinorChannel")
+    void testDowngradeChannelSwitchIsRejected() throws Exception {
+        setUp();
+
+        var headVersion = catalog.getChannelHeadVersion(rollingChannel());
+        var olderMinorChannel = catalog.getOlderMinorChannel(projectVersion(), rollingChannel());
+        var olderHeadVersion = catalog.getChannelHeadVersion(olderMinorChannel);
+
+        log.info("Testing downgrade: install current version on {}, then switch to {} "
+                + "without changing the version constraint", rollingChannel(), olderMinorChannel);
+
+        deployClusterExtension(rollingChannel(), headVersion);
+        waitForOperatorVersion(headVersion);
+        log.info("Operator {} deployed on {} channel", headVersion, rollingChannel());
+
+        patchClusterExtensionSource(olderMinorChannel, headVersion);
+        log.info("Switched ClusterExtension to {} channel (version constraint unchanged: {}), "
+                + "verifying no downgrade...", olderMinorChannel, headVersion);
+
+        await().atMost(MEDIUM_DURATION).during(Duration.ofSeconds(30)).ignoreExceptions()
+                .untilAsserted(() -> {
+                    var currentDeployment = client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(headVersion)).get();
+                    assertThat(currentDeployment)
+                            .as("Operator should still be at " + headVersion + " after channel switch")
+                            .isNotNull();
+                    assertThat(currentDeployment.getStatus().getReadyReplicas())
+                            .as("Operator should still have 1 ready replica")
+                            .isEqualTo(1);
+
+                    var olderDeployment = client.apps().deployments().inNamespace(namespace)
+                            .withName(deploymentName(olderHeadVersion)).get();
+                    assertThat(olderDeployment)
+                            .as("Operator should NOT be downgraded to " + olderHeadVersion)
+                            .isNull();
+                });
+
+        log.info("Downgrade rejection confirmed: operator stayed at {}", headVersion);
+    }
+
+    // ---- Infrastructure methods ----
+
+    private static String deploymentName(Semver version) {
+        return "apicurio-registry-operator-v" + version;
+    }
+
+    private void deployClusterExtension(String channel, Semver version) throws Exception {
+        try {
+            createResource(client, namespace, "olmv1/cluster-catalog.yaml");
+            waitForClusterCatalogServing(client, namespace, CATALOG_NAME);
+            createResource(client, namespace, "olmv1/service-account.yaml");
+            createResource(client, namespace, "olmv1/cluster-role.yaml");
+            createResource(client, namespace, "olmv1/cluster-role-binding.yaml");
+
+            var extraVars = Map.of(
+                    "${PLACEHOLDER_UPGRADE_CHANNEL}", channel,
+                    "${PLACEHOLDER_UPGRADE_VERSION}", version.toString());
+            var raw = loadRawResource("olmv1/cluster-extension-upgrade.yaml");
+            client.resource(replaceVars(raw, namespace, extraVars)).create();
+        } catch (Exception e) {
+            log.error("OLM v1 catalog/ClusterExtension setup failed, dumping cluster diagnostics", e);
+            ClusterDiagnostics.dump(client, namespace, true);
+            throw e;
+        }
+    }
+
+    private void waitForOperatorVersion(Semver version) {
+        var name = deploymentName(version);
+        await().atMost(UPGRADE_TIMEOUT).ignoreExceptions().untilAsserted(() -> {
+            var deployment = client.apps().deployments().inNamespace(namespace)
+                    .withName(name).get();
+            assertThat(deployment).as("Deployment " + name + " should exist").isNotNull();
+            assertThat(deployment.getStatus().getReadyReplicas())
+                    .as("Deployment " + name + " should have 1 ready replica")
+                    .isEqualTo(1);
+        });
+        log.info("Operator version {} is ready", version);
+    }
+
+    private void verifyUpgradeTo(Semver targetVersion) {
+        var name = deploymentName(targetVersion);
+        await().atMost(UPGRADE_TIMEOUT).ignoreExceptions().untilAsserted(() -> {
+            var deployment = client.apps().deployments().inNamespace(namespace)
+                    .withName(name).get();
+            assertThat(deployment)
+                    .as("Target deployment " + name + " should exist after upgrade")
+                    .isNotNull();
+            assertThat(deployment.getStatus().getReadyReplicas())
+                    .as("Target deployment " + name + " should have 1 ready replica")
+                    .isEqualTo(1);
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private void patchClusterExtensionSource(String channel, Semver version) {
+        var ce = client.genericKubernetesResources("olm.operatorframework.io/v1", "ClusterExtension")
+                .inNamespace(namespace)
+                .withName(CLUSTER_EXTENSION_NAME)
+                .get();
+        assertThat(ce).as("ClusterExtension should exist").isNotNull();
+
+        var spec = (Map<String, Object>) ce.getAdditionalProperties().get("spec");
+        var source = (Map<String, Object>) spec.get("source");
+        var catalogSource = (Map<String, Object>) source.get("catalog");
+        catalogSource.put("channels", List.of(channel));
+        catalogSource.put("version", version.toString());
+        client.genericKubernetesResources("olm.operatorframework.io/v1", "ClusterExtension")
+                .inNamespace(namespace)
+                .resource(ce)
+                .update();
+        log.info("Patched ClusterExtension catalog source: channel={}, version={}", channel, version);
+    }
+}

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMv1ITTest.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMv1ITTest.java
@@ -61,6 +61,13 @@ public class UpgradeOLMv1ITTest implements OperatorTestContext {
 
     private static final String OPERATOR_DEPLOYMENT_PREFIX = "apicurio-registry-operator-v";
 
+    // The first operator release whose bundle ships the cluster-tier CSV RBAC an OLM v1
+    // ClusterExtension install needs (apicurio-registry#9035). Older bundles rely on an OLM v0
+    // OperatorGroup to scope the operator's watch; ClusterExtension has no equivalent, so they
+    // crash-loop on a forbidden cluster-scoped list when installed via OLM v1. Cross-minor upgrade
+    // coverage from those releases stays OLM v0-only (see UpgradeOLMITTest#testUpgradeAcrossMinors).
+    private static final String MIN_OLM_V1_OPERATOR_VERSION = "3.3.2";
+
     private static final Duration UPGRADE_TIMEOUT = Duration.ofSeconds(
             Integer.getInteger("test.operator.timeout.olm-upgrade", 1200));
 
@@ -172,6 +179,12 @@ public class UpgradeOLMv1ITTest implements OperatorTestContext {
         var entry = catalog.getCrossMinorEntry(rollingChannel());
         if (entry == null) {
             log.info("Condition not met: no cross-minor entry found in {}", rollingChannel());
+            return false;
+        }
+        if (entry.getVersion().isLowerThan(MIN_OLM_V1_OPERATOR_VERSION)) {
+            log.info("Condition not met: cross-minor entry {} in {} predates OLM v1 bundle support "
+                    + "({}); cross-minor upgrade from it is covered by UpgradeOLMITTest (OLM v0)",
+                    entry.getVersion(), rollingChannel(), MIN_OLM_V1_OPERATOR_VERSION);
             return false;
         }
         return true;

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMv1ITTest.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMv1ITTest.java
@@ -59,7 +59,7 @@ public class UpgradeOLMv1ITTest implements OperatorTestContext {
     private static final String CLUSTER_EXTENSION_NAME = "apicurio-registry-operator-ce";
 
     private static final Duration UPGRADE_TIMEOUT = Duration.ofSeconds(
-            Integer.getInteger("test.operator.timeout.olm-upgrade", 900));
+            Integer.getInteger("test.operator.timeout.olm-upgrade", 1200));
 
     private static CatalogInfo catalog;
 


### PR DESCRIPTION
## Summary

This PR adds OLM v1 upgrade test coverage using the `ClusterExtension` and `ClusterCatalog` APIs.

Closes #9677

It builds on the FBC-based catalog discovery work from #9702 (now merged) and adds the OLM v1-specific upgrade flow while keeping the existing OLM v0 tests unchanged.

## What changed

* Added reusable `CatalogdClient` for reading FBC content through the OLM v1 `catalogd` API.
* Updated `CatalogDiscovery` to select the appropriate discovery path based on `test.operator.olm-version`.
* Reused the existing FBC parsing and `CatalogInfo` model for both OLM v0 and OLM v1.
* Removed duplicated catalog-reading logic from `ChannelValidationOLMITTest`.
* Added shared OLM version and `ClusterCatalog` readiness helpers to `OLMTestUtils`.
* Added a parameterized `ClusterExtension` resource for OLM v1 upgrade tests.
* Added `UpgradeOLMv1ITTest` with coverage for the OLM v1 upgrade scenarios.
* Updated the README with the new coverage and known limitation.

## Test coverage

The new OLM v1 tests cover:

* Upgrade within a minor channel
* Upgrade across minor versions
* Channel switching
* No-op channel switch at the head
* Minor channel isolation
* Fresh install on a minor channel
* Rejected downgrade

Manual approval is not covered because OLM v1 has no equivalent `InstallPlan` workflow.

## Validation

* `test-compile` passes.
* `checkstyle:check` passes.
* No new checkstyle errors or warnings were introduced.
* Full OLM v1 integration tests were not run locally because they require a live OLM v1/OpenShift environment.
* The existing CI `olm-v1` matrix should automatically pick up the new `@Tag(OLM)` test.

## Design

`UpgradeOLMITTest` is left unchanged. OLM v1 uses `ClusterExtension` version constraints and channel updates instead of the OLM v0 `Subscription`/`InstallPlan` flow, so the v1 scenarios are implemented in a separate test class.

Catalog discovery is shared between both versions because they ultimately use the same FBC format and `CatalogInfo` model.

## Notes

The FBC-based `CatalogDiscovery` and `CatalogInfo` infrastructure this builds on landed in #9702. This branch has been rebased onto the latest `main` now that #9702 is merged, so it contains only the OLM v1 upgrade-test changes on top.
