### PR TITLE
fix(auth): bound OIDC access-token and auth-failure caches to prevent unbounded memory growth

### DIFF
--- a/app/src/main/java/io/apicurio/registry/auth/AppAuthenticationMechanism.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AppAuthenticationMechanism.java
@@ -87,6 +87,13 @@ public class AppAuthenticationMechanism implements HttpAuthenticationMechanism {
     public static final String MECH_OIDC = "oidc";
     public static final String MECH_KUBERNETES = "kubernetes";
 
+    /**
+     * Maximum number of entries retained in the OIDC access-token and auth-failure caches.
+     * Mirrors the bound used by {@link KubernetesAuthenticationStrategy} to prevent unbounded
+     * memory growth from distinct credential pairs, including failed/attacker-supplied ones.
+     */
+    private static final int MAX_CACHE_SIZE = 10_000;
+
     @Inject
     Logger log;
 
@@ -248,6 +255,21 @@ public class AppAuthenticationMechanism implements HttpAuthenticationMechanism {
     }
 
     /**
+     * Puts a value into an auth cache map, first evicting expired entries and then refusing
+     * to grow past {@link #MAX_CACHE_SIZE}. Mirrors the bounding strategy used by
+     * {@link KubernetesAuthenticationStrategy} to prevent unbounded growth from distinct
+     * credential pairs (including failed/attacker-supplied ones).
+     */
+    private static <V> void boundedCachePut(ConcurrentHashMap<String, WrappedValue<V>> cache,
+            String key, WrappedValue<V> value) {
+        cache.entrySet().removeIf(entry -> entry.getValue().isExpired());
+        if (cache.size() >= MAX_CACHE_SIZE) {
+            return;
+        }
+        cache.put(key, value);
+    }
+
+    /**
      * Obtains an access token using client credentials grant. This method is hosted on this CDI
      * bean (rather than on {@link OidcAuthenticationStrategy}) so that the MicroProfile
      * {@link Retry} interceptor is applied.
@@ -288,7 +310,7 @@ public class AppAuthenticationMechanism implements HttpAuthenticationMechanism {
             if (statusCode == 401) {
                 var ex = new io.quarkus.security.UnauthorizedException(
                         "OIDC token request returned 401");
-                cachedAuthFailures.put(credentialsHash,
+                boundedCachePut(cachedAuthFailures, credentialsHash,
                         new WrappedValue<>(
                                 OidcAuthenticationStrategy.getAccessTokenExpiration(null,
                                         authConfig, jwtParser, log),
@@ -297,7 +319,7 @@ public class AppAuthenticationMechanism implements HttpAuthenticationMechanism {
             } else if (statusCode == 403) {
                 var ex = new io.quarkus.security.ForbiddenException(
                         "OIDC token request returned 403");
-                cachedAuthFailures.put(credentialsHash,
+                boundedCachePut(cachedAuthFailures, credentialsHash,
                         new WrappedValue<>(
                                 OidcAuthenticationStrategy.getAccessTokenExpiration(null,
                                         authConfig, jwtParser, log),
@@ -310,7 +332,7 @@ public class AppAuthenticationMechanism implements HttpAuthenticationMechanism {
 
             JsonObject json = response.bodyAsJsonObject();
             String jwtToken = json.getString("access_token");
-            cachedAccessTokens.put(credentialsHash,
+            boundedCachePut(cachedAccessTokens, credentialsHash,
                     new WrappedValue<>(
                             OidcAuthenticationStrategy.getAccessTokenExpiration(jwtToken,
                                     authConfig, jwtParser, log),


### PR DESCRIPTION
## Problem

Closes #9733

`OidcAuthenticationStrategy`'s `cachedAccessTokens` and `cachedAuthFailures` maps grow without bound  every distinct client-credentials pair adds a permanent entry, including failed (401/403) attempts. This allows unauthenticated clients to grow the cache indefinitely by sending distinct fake credentials.

## Fix

Added a `boundedCachePut()` helper in `AppAuthenticationMechanism` that:
1. Evicts expired entries from the target cache before inserting.
2. Refuses to insert once the cache reaches `MAX_CACHE_SIZE` (10,000).

All three `.put()` call sites (401 failure, 403 failure, successful token cache) now route through this helper instead of calling `.put()` directly.

This mirrors the bounding strategy already used by `KubernetesAuthenticationStrategy` (`MAX_CACHE_SIZE` + `evictExpiredEntries()`), which handles the same class of problem but was never applied to the OIDC strategy.

## Testing

- Reproduced the leak pre-fix: 2000 distinct fake client-credentials requests → 2001 live `WrappedValue` heap instances (via `jmap -histo:live`), confirming unbounded 1:1 growth.
- Verified the fix: 12,000 distinct fake requests post-fix → exactly 10,000 live `WrappedValue` instances, confirming the cap holds and excess entries are rejected rather than accumulating.
- No changes needed to `OidcAuthenticationStrategy.java` itself, since it only reads from these maps; the `.put()` sites all live in `AppAuthenticationMechanism`.