### PR TITLE
fix(auth): add missing @Authorized annotations to REST endpoints

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemasResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemasResourceImpl.java
@@ -91,6 +91,7 @@ public class SchemasResourceImpl extends AbstractResource implements SchemasReso
     }
 
     @Override
+    @Authorized(style = AuthorizedStyle.GlobalId, level = AuthorizedLevel.Read)
     public String getSchemaContentById(BigInteger id, String format, String subject) {
         ContentHandle contentHandle;
         List<ArtifactReferenceDto> references;

--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/GroupsResourceImpl.java
@@ -217,6 +217,7 @@ public class GroupsResourceImpl implements GroupsResource {
      *      java.lang.String, java.lang.String, io.apicurio.registry.types.ReferenceType)
      */
     @Override
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
     public List<ArtifactReference> getArtifactVersionReferences(String groupId, String artifactId,
             String version, ReferenceType refType) {
 

--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/IdsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/IdsResourceImpl.java
@@ -129,6 +129,7 @@ public class IdsResourceImpl implements IdsResource {
      * @see io.apicurio.registry.rest.v2.IdsResource#referencesByContentHash(java.lang.String)
      */
     @Override
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
     public List<ArtifactReference> referencesByContentHash(String contentHash) {
         return common.getReferencesByContentHash(contentHash, V2ApiUtil::referenceDtoToReference);
     }
@@ -137,6 +138,7 @@ public class IdsResourceImpl implements IdsResource {
      * @see io.apicurio.registry.rest.v2.IdsResource#referencesByContentId(long)
      */
     @Override
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
     public List<ArtifactReference> referencesByContentId(long contentId) {
         ContentWrapperDto artifact = storage.getContentById(contentId);
         return artifact.getReferences().stream().map(V2ApiUtil::referenceDtoToReference)
@@ -148,6 +150,7 @@ public class IdsResourceImpl implements IdsResource {
      * io.apicurio.registry.types.ReferenceType)
      */
     @Override
+    @Authorized(style = AuthorizedStyle.GlobalId, level = AuthorizedLevel.Read)
     public List<ArtifactReference> referencesByGlobalId(long globalId, ReferenceType refType) {
         if (refType == ReferenceType.OUTBOUND || refType == null) {
             StoredArtifactVersionDto artifact = storage.getArtifactVersionContent(globalId);


### PR DESCRIPTION
## Summary

- Adds missing `@Authorized` annotations to 5 REST methods across 3 files that were bypassing
  all authentication and authorization
- The `AuthorizedInterceptor` only fires on annotated methods, and with
  `quarkus.http.auth.proactive=false` and no HTTP auth permission policies, unannotated methods
  ran with zero auth regardless of deployment OIDC/RBAC settings
- Each annotation mirrors the pattern used by sibling methods in the same class and the
  equivalent v3 endpoints

## Affected Endpoints

| Endpoint | File | Annotation Added |
|----------|------|-----------------|
| `GET /apis/ccompat/v7/schemas/ids/{id}/schema` (+ v8) | `ccompat/rest/v7/impl/SchemasResourceImpl.java` | `@Authorized(GlobalId, Read)` |
| `GET /apis/registry/v2/ids/contentHashes/{hash}/references` | `rest/v2/impl/IdsResourceImpl.java` | `@Authorized(None, Read)` |
| `GET /apis/registry/v2/ids/contentIds/{id}/references` | `rest/v2/impl/IdsResourceImpl.java` | `@Authorized(None, Read)` |
| `GET /apis/registry/v2/ids/globalIds/{id}/references` | `rest/v2/impl/IdsResourceImpl.java` | `@Authorized(GlobalId, Read)` |
| `GET /apis/registry/v2/groups/{g}/artifacts/{a}/versions/{v}/references` | `rest/v2/impl/GroupsResourceImpl.java` | `@Authorized(GroupAndArtifact, Read)` |

## Test plan

- [ ] `./mvnw test-compile -pl app -am -DskipTests` compiles cleanly
- [ ] `./mvnw checkstyle:check -pl app` passes
- [ ] Existing auth integration tests continue to pass
