### PR TITLE
fix(gitops): prevent symlink traversal during validation cleanup

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GitOpsValidationTaskManager.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GitOpsValidationTaskManager.java
@@ -15,6 +15,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Date;
@@ -478,7 +479,7 @@ public class GitOpsValidationTaskManager {
     }
 
     private void deleteRecursive(Path path) throws IOException {
-        if (Files.isDirectory(path)) {
+        if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
             try (var entries = Files.list(path)) {
                 for (Path entry : entries.toList()) {
                     deleteRecursive(entry);


### PR DESCRIPTION
## Summary

- Fixes a symlink traversal issue in `GitOpsValidationTaskManager.deleteRecursive()` where
  `Files.isDirectory(path)` followed symbolic links by default
- A symlink inside a validation checkout pointing to an external directory would cause cleanup
  to traverse into and delete the target directory's contents
- Adding `LinkOption.NOFOLLOW_LINKS` ensures symlinks are deleted as links without traversing
  their targets

## Test plan

- [ ] `./mvnw test-compile -pl app -am -DskipTests` compiles cleanly
- [ ] `./mvnw checkstyle:check -pl app` passes
