### PR TITLE
fix(operator): fix K8sCell conflict detection and create failure handling

### DIFF
--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/K8sCell.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/K8sCell.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.operator.utils;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
@@ -32,16 +33,15 @@ public class K8sCell<T extends HasMetadata> {
         return new K8sCell<>(client, initialReader);
     }
 
+    /**
+     * Create is deferred until the first {@link #get()}, {@link #getCached()}, or {@link #getOptional()}
+     * call. A {@link KubernetesClientException} from the POST (e.g. 409 on an existing object) propagates
+     * unchanged, so it cannot be mistaken for a later read of a missing resource.
+     */
     public static <T extends HasMetadata> K8sCell<T> k8sCellCreate(KubernetesClient client, Supplier<T> initialCreator) {
         return new K8sCell<>(client, () -> {
-            try {
-                var r = initialCreator.get();
-                r = client.resource(r).create();
-                return r;
-            } catch (Exception ex) {
-                log.debug("Could not create resource", ex);
-                return null;
-            }
+            T r = initialCreator.get();
+            return client.resource(r).create();
         });
     }
 
@@ -87,7 +87,7 @@ public class K8sCell<T extends HasMetadata> {
                 cachedValue = client.resource(cachedValue).update();
                 return true;
             } catch (KubernetesClientException ex) {
-                if (ex.getMessage().contains("the object has been modified") || ex.getMessage().contains("timeout")) {
+                if (isConflict(ex) || isRetryableTimeout(ex)) {
                     log.info("Retrying update of {} because of a Kubernetes client exception: {}",
                             ResourceID.fromResource(cachedValue), ex.getMessage());
                     return false;
@@ -96,5 +96,27 @@ public class K8sCell<T extends HasMetadata> {
                 }
             }
         });
+    }
+
+    /**
+     * HTTP 409 or Status.reason Conflict — the Fabric8-idiomatic conflict check used by
+     * OperatorErrorConditionManager and requested for OLM InstallPlan retries.
+     */
+    static boolean isConflict(KubernetesClientException ex) {
+        if (ex.getCode() == 409) {
+            return true;
+        }
+        Status status = ex.getStatus();
+        return status != null && "Conflict".equals(status.getReason());
+    }
+
+    /**
+     * Client-side / message-signaled timeouts. Fabric8 often surfaces these as
+     * {@link KubernetesClientException} with {@code getCode() == -1} and "timeout" in the message,
+     * not as HTTP 408.
+     */
+    static boolean isRetryableTimeout(KubernetesClientException ex) {
+        String message = ex.getMessage();
+        return message != null && message.contains("timeout");
     }
 }

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/K8sCellTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/K8sCellTest.java
@@ -1,0 +1,168 @@
+package io.apicurio.registry.operator.utils;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.NamespaceableResource;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.apicurio.registry.operator.utils.K8sCell.k8sCell;
+import static io.apicurio.registry.operator.utils.K8sCell.k8sCellCreate;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * There is no Fabric8 mock-server or Mockito usage in the operator test tree.
+ * These tests stub {@link KubernetesClient#resource(HasMetadata)} with a JDK proxy.
+ */
+public class K8sCellTest {
+
+    @Test
+    void createFailurePropagatesOriginalException() {
+        var item = configMap("cm");
+        var original = new KubernetesClientException("already exists", 409,
+                new StatusBuilder().withReason("AlreadyExists").withCode(409).build());
+        KubernetesClient client = stubClient(new StubBehavior() {
+            @Override
+            public HasMetadata create(HasMetadata resource) {
+                throw original;
+            }
+        });
+
+        var cell = k8sCellCreate(client, () -> item);
+
+        assertThatThrownBy(cell::get)
+                .isSameAs(original)
+                .satisfies(ex -> assertThat(((KubernetesClientException) ex).getCode()).isEqualTo(409));
+    }
+
+    @Test
+    void updateRetriesOnHttp409RegardlessOfMessage() {
+        var item = configMap("cm");
+        var conflict = new KubernetesClientException("Operation cannot be fulfilled on configmaps \"cm\"",
+                409, new StatusBuilder().withCode(409).build());
+        assertThat(conflict.getMessage()).doesNotContain("the object has been modified");
+
+        AtomicInteger updates = new AtomicInteger();
+        KubernetesClient client = stubClient(new StubBehavior() {
+            @Override
+            public HasMetadata update(HasMetadata resource) {
+                if (updates.getAndIncrement() == 0) {
+                    throw conflict;
+                }
+                return resource;
+            }
+        });
+
+        k8sCell(client, () -> item).update(cm -> cm.getMetadata().getLabels().put("k", "v"));
+
+        assertThat(updates.get()).isEqualTo(2);
+        assertThat(item.getMetadata().getLabels()).containsEntry("k", "v");
+    }
+
+    @Test
+    void updateRetriesOnLegacyConflictMessageWhenCodeIs409() {
+        var item = configMap("cm");
+        var conflict = new KubernetesClientException(
+                "the object has been modified; please apply your changes to the latest version and try again",
+                409, new StatusBuilder().withReason("Conflict").withCode(409).build());
+
+        AtomicInteger updates = new AtomicInteger();
+        KubernetesClient client = stubClient(new StubBehavior() {
+            @Override
+            public HasMetadata update(HasMetadata resource) {
+                if (updates.getAndIncrement() == 0) {
+                    throw conflict;
+                }
+                return resource;
+            }
+        });
+
+        k8sCell(client, () -> item).update(cm -> cm.getMetadata().getLabels().put("k", "v"));
+
+        assertThat(updates.get()).isEqualTo(2);
+    }
+
+    @Test
+    void isConflictMatchesCodeOrReason() {
+        var byCode = new KubernetesClientException("no useful message", 409, null);
+        var byReason = new KubernetesClientException("also no 409 in the text", 500,
+                new StatusBuilder().withReason("Conflict").build());
+        var other = new KubernetesClientException("forbidden", 403,
+                new StatusBuilder().withReason("Forbidden").withCode(403).build());
+
+        assertThat(K8sCell.isConflict(byCode)).isTrue();
+        assertThat(K8sCell.isConflict(byReason)).isTrue();
+        assertThat(K8sCell.isConflict(other)).isFalse();
+    }
+
+    private static ConfigMap configMap(String name) {
+        return new ConfigMapBuilder()
+                .withNewMetadata()
+                .withName(name)
+                .withNamespace("ns")
+                .withResourceVersion("1")
+                .addToLabels("k", "old")
+                .endMetadata()
+                .build();
+    }
+
+    private interface StubBehavior {
+        default HasMetadata create(HasMetadata resource) {
+            return resource;
+        }
+
+        default HasMetadata get(HasMetadata resource) {
+            return resource;
+        }
+
+        default HasMetadata update(HasMetadata resource) {
+            return resource;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static KubernetesClient stubClient(StubBehavior behavior) {
+        return (KubernetesClient) Proxy.newProxyInstance(
+                KubernetesClient.class.getClassLoader(),
+                new Class<?>[]{KubernetesClient.class},
+                (proxy, method, args) -> {
+                    if ("resource".equals(method.getName()) && args != null && args.length == 1
+                            && args[0] instanceof HasMetadata item) {
+                        return resourceStub(item, behavior);
+                    }
+                    if ("toString".equals(method.getName())) {
+                        return "stub-kubernetes-client";
+                    }
+                    if ("hashCode".equals(method.getName())) {
+                        return System.identityHashCode(proxy);
+                    }
+                    if ("equals".equals(method.getName())) {
+                        return proxy == args[0];
+                    }
+                    throw new UnsupportedOperationException(method.toString());
+                });
+    }
+
+    @SuppressWarnings("unchecked")
+    private static NamespaceableResource<HasMetadata> resourceStub(HasMetadata item, StubBehavior behavior) {
+        return (NamespaceableResource<HasMetadata>) Proxy.newProxyInstance(
+                NamespaceableResource.class.getClassLoader(),
+                new Class<?>[]{NamespaceableResource.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "create" -> behavior.create(item);
+                    case "get" -> behavior.get(item);
+                    case "update" -> behavior.update(item);
+                    case "toString" -> "stub-resource";
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == args[0];
+                    default -> throw new UnsupportedOperationException(method.toString());
+                });
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/K8sCellTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/K8sCellTest.java
@@ -67,26 +67,27 @@ public class K8sCellTest {
     }
 
     @Test
-    void updateRetriesOnLegacyConflictMessageWhenCodeIs409() {
+    void updateDoesNotRetryOnLegacyConflictMessageWithoutHttp409() {
         var item = configMap("cm");
-        var conflict = new KubernetesClientException(
+        var nonConflict = new KubernetesClientException(
                 "the object has been modified; please apply your changes to the latest version and try again",
-                409, new StatusBuilder().withReason("Conflict").withCode(409).build());
+                500, new StatusBuilder().withCode(500).build());
 
         AtomicInteger updates = new AtomicInteger();
         KubernetesClient client = stubClient(new StubBehavior() {
             @Override
             public HasMetadata update(HasMetadata resource) {
-                if (updates.getAndIncrement() == 0) {
-                    throw conflict;
-                }
-                return resource;
+                updates.incrementAndGet();
+                throw nonConflict;
             }
         });
 
-        k8sCell(client, () -> item).update(cm -> cm.getMetadata().getLabels().put("k", "v"));
+        assertThatThrownBy(() ->
+                k8sCell(client, () -> item).update(cm -> cm.getMetadata().getLabels().put("k", "v")))
+                .isInstanceOf(KubernetesClientException.class)
+                .hasMessageContaining("the object has been modified");
 
-        assertThat(updates.get()).isEqualTo(2);
+        assertThat(updates.get()).isEqualTo(1);
     }
 
     @Test
@@ -100,6 +101,16 @@ public class K8sCellTest {
         assertThat(K8sCell.isConflict(byCode)).isTrue();
         assertThat(K8sCell.isConflict(byReason)).isTrue();
         assertThat(K8sCell.isConflict(other)).isFalse();
+    }
+
+    @Test
+    void isRetryableTimeoutMatchesOnlyTimeoutMessage() {
+        var timeout = new KubernetesClientException("Read timeout", -1, null);
+        var other = new KubernetesClientException("forbidden", 403,
+                new StatusBuilder().withReason("Forbidden").withCode(403).build());
+
+        assertThat(K8sCell.isRetryableTimeout(timeout)).isTrue();
+        assertThat(K8sCell.isRetryableTimeout(other)).isFalse();
     }
 
     private static ConfigMap configMap(String name) {

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/K8sCellTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/K8sCellTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * There is no Fabric8 mock-server or Mockito usage in the operator test tree.
  * These tests stub {@link KubernetesClient#resource(HasMetadata)} with a JDK proxy.
  */
-public class K8sCellTest {
+class K8sCellTest {
 
     @Test
     void createFailurePropagatesOriginalException() {
@@ -82,8 +82,9 @@ public class K8sCellTest {
             }
         });
 
-        assertThatThrownBy(() ->
-                k8sCell(client, () -> item).update(cm -> cm.getMetadata().getLabels().put("k", "v")))
+        var cell = k8sCell(client, () -> item);
+
+        assertThatThrownBy(() -> cell.update(cm -> cm.getMetadata().getLabels().put("k", "v")))
                 .isInstanceOf(KubernetesClientException.class)
                 .hasMessageContaining("the object has been modified");
 

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMITTest.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMITTest.java
@@ -26,6 +26,7 @@ import org.awaitility.core.ConditionFactory;
 import static io.apicurio.registry.operator.Tags.OLM;
 import static io.apicurio.registry.operator.it.ITBase.setDefaultAwaitilityTimings;
 import static io.apicurio.registry.operator.it.OLMTestUtils.*;
+import static io.apicurio.registry.operator.utils.K8sCell.k8sCell;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -559,20 +560,18 @@ public class UpgradeOLMITTest implements OperatorTestContext {
 
     @SuppressWarnings("unchecked")
     private void patchSubscriptionChannel(String newChannel) {
-        var subscription = client.genericKubernetesResources(
-                        "operators.coreos.com/v1alpha1", "Subscription")
-                .inNamespace(namespace)
-                .withName("apicurio-registry-operator-subscription")
-                .get();
-        assertThat(subscription).as("Subscription should exist").isNotNull();
-
-        var props = subscription.getAdditionalProperties();
-        var spec = (java.util.Map<String, Object>) props.get("spec");
-        spec.put("channel", newChannel);
-        client.genericKubernetesResources("operators.coreos.com/v1alpha1", "Subscription")
-                .inNamespace(namespace)
-                .resource(subscription)
-                .update();
+        k8sCell(client, () -> {
+            var subscription = client.genericKubernetesResources(
+                            "operators.coreos.com/v1alpha1", "Subscription")
+                    .inNamespace(namespace)
+                    .withName("apicurio-registry-operator-subscription")
+                    .get();
+            assertThat(subscription).as("Subscription should exist").isNotNull();
+            return subscription;
+        }).update(subscription -> {
+            var spec = (java.util.Map<String, Object>) subscription.getAdditionalProperties().get("spec");
+            spec.put("channel", newChannel);
+        });
         log.info("Patched subscription channel to {}", newChannel);
     }
 
@@ -656,15 +655,20 @@ public class UpgradeOLMITTest implements OperatorTestContext {
                 .inNamespace(namespace).list().getItems();
 
         for (var ip : installPlans) {
-            var props = ip.getAdditionalProperties();
-            var spec = (java.util.Map<String, Object>) props.get("spec");
+            var spec = (java.util.Map<String, Object>) ip.getAdditionalProperties().get("spec");
             if (spec != null && Boolean.FALSE.equals(spec.get("approved"))) {
-                spec.put("approved", true);
-                client.genericKubernetesResources("operators.coreos.com/v1alpha1", "InstallPlan")
+                var ipName = ip.getMetadata().getName();
+                k8sCell(client, () -> client.genericKubernetesResources(
+                                "operators.coreos.com/v1alpha1", "InstallPlan")
                         .inNamespace(namespace)
-                        .resource(ip)
-                        .update();
-                log.info("Approved install plan: {}", ip.getMetadata().getName());
+                        .withName(ipName)
+                        .get())
+                        .update(fresh -> {
+                            var freshSpec = (java.util.Map<String, Object>) fresh.getAdditionalProperties()
+                                    .get("spec");
+                            freshSpec.put("approved", true);
+                        });
+                log.info("Approved install plan: {}", ipName);
             }
         }
     }


### PR DESCRIPTION
Fixes #10084

Fixes the two K8sCell bugs discussed in #9701: conflict detection was
matching on message text ("the object has been modified"), which is
fragile and doesn't reliably match OLM's wording. It now checks the
HTTP status code (409) or Status.reason instead, the same pattern
already used in OLMITBase for 404s.

k8sCellCreate also used to catch any exception on create, log it at
debug, and return null, so a 409 or a real failure (403, validation
error) surfaced later as a misleading "Kubernetes resource does not
exist" error. It now lets the original KubernetesClientException
propagate, so the real cause is visible.

Also migrates UpgradeOLMITTest's InstallPlan approval onto the fixed
K8sCell. On main that code mutates the stale InstallPlan returned by
list() and pushes it back, which is what produces the 409s; it now
re-fetches a fresh copy by name inside the cell. (#9339 proposes an
inline retry loop for the same method and is the motivating example
in #9701; it is not merged, so there is no retry loop here to
replace.)

This is the first of several smaller PRs agreed on in #9701. Out of
scope here: delete/finalizer support, broader call-site migration,
and automatic resource tracking, which are follow-up issues.

Refs #9701
