### PR TITLE
feat(rest): cross-registry schema promotion (Phase 1) (#7878)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/promotion/ContentLineDiff.java
+++ b/app/src/main/java/io/apicurio/registry/promotion/ContentLineDiff.java
@@ -1,0 +1,60 @@
+package io.apicurio.registry.promotion;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Minimal line-based diff used for promotion compare reports.
+ */
+public final class ContentLineDiff {
+
+    public record Line(String op, String text) {
+    }
+
+    private ContentLineDiff() {
+    }
+
+    public static List<Line> diff(String previous, String next) {
+        String[] left = split(previous);
+        String[] right = split(next);
+        int[][] lengths = new int[left.length + 1][right.length + 1];
+        for (int i = left.length - 1; i >= 0; i--) {
+            for (int j = right.length - 1; j >= 0; j--) {
+                if (left[i].equals(right[j])) {
+                    lengths[i][j] = lengths[i + 1][j + 1] + 1;
+                } else {
+                    lengths[i][j] = Math.max(lengths[i + 1][j], lengths[i][j + 1]);
+                }
+            }
+        }
+        List<Line> lines = new ArrayList<>();
+        int i = 0;
+        int j = 0;
+        while (i < left.length && j < right.length) {
+            if (left[i].equals(right[j])) {
+                i++;
+                j++;
+            } else if (lengths[i + 1][j] >= lengths[i][j + 1]) {
+                lines.add(new Line("removed", left[i]));
+                i++;
+            } else {
+                lines.add(new Line("added", right[j]));
+                j++;
+            }
+        }
+        while (i < left.length) {
+            lines.add(new Line("removed", left[i++]));
+        }
+        while (j < right.length) {
+            lines.add(new Line("added", right[j++]));
+        }
+        return lines;
+    }
+
+    private static String[] split(String value) {
+        if (value == null || value.isEmpty()) {
+            return new String[0];
+        }
+        return value.split("\n", -1);
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/promotion/CrossRegistryPromotionService.java
+++ b/app/src/main/java/io/apicurio/registry/promotion/CrossRegistryPromotionService.java
@@ -1,0 +1,304 @@
+package io.apicurio.registry.promotion;
+
+import io.apicurio.registry.cdi.Current;
+import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.content.TypedContent;
+import io.apicurio.registry.model.GA;
+import io.apicurio.registry.model.GroupId;
+import io.apicurio.registry.model.VersionExpressionParser;
+import io.apicurio.registry.rest.ParameterValidationUtils;
+import io.apicurio.registry.rest.v3.beans.PromoteArtifact;
+import io.apicurio.registry.rest.v3.beans.PromotionCompareResult;
+import io.apicurio.registry.rest.v3.beans.PromotionCompatibility;
+import io.apicurio.registry.rest.v3.beans.PromotionCompatibilityDifference;
+import io.apicurio.registry.rest.v3.beans.PromotionCoordinate;
+import io.apicurio.registry.rest.v3.beans.PromotionDiffLine;
+import io.apicurio.registry.rest.v3.beans.PromotionResult;
+import io.apicurio.registry.rest.v3.beans.PromotionSource;
+import io.apicurio.registry.rest.v3.impl.V3ApiUtil;
+import io.apicurio.registry.rules.RuleApplicationType;
+import io.apicurio.registry.rules.RulesService;
+import io.apicurio.registry.rules.compatibility.CompatibilityExecutionResult;
+import io.apicurio.registry.rules.compatibility.CompatibilityLevel;
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.RegistryStorage.RetrievalBehavior;
+import io.apicurio.registry.storage.dto.ContentWrapperDto;
+import io.apicurio.registry.storage.dto.EditableArtifactMetaDataDto;
+import io.apicurio.registry.storage.dto.EditableVersionMetaDataDto;
+import io.apicurio.registry.storage.dto.StoredArtifactVersionDto;
+import io.apicurio.registry.storage.error.VersionNotFoundException;
+import io.apicurio.registry.types.provider.ArtifactTypeUtilProvider;
+import io.apicurio.registry.types.provider.ArtifactTypeUtilProviderFactory;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Phase 1 of cross-registry promotion: fetch a version from a configured source, compare it with the local
+ * target, and copy it as an explicit promote.
+ */
+@ApplicationScoped
+public class CrossRegistryPromotionService {
+
+    static final String LABEL_SOURCE = "apicurio.promotion.source";
+    static final String LABEL_SOURCE_GROUP = "apicurio.promotion.sourceGroup";
+    static final String LABEL_SOURCE_ARTIFACT = "apicurio.promotion.sourceArtifact";
+    static final String LABEL_SOURCE_VERSION = "apicurio.promotion.sourceVersion";
+
+    @Inject
+    PromotionConfig config;
+
+    @Inject
+    PromotionSourceClientFactory clients;
+
+    @Inject
+    @Current
+    RegistryStorage storage;
+
+    @Inject
+    ArtifactTypeUtilProviderFactory artifactTypes;
+
+    @Inject
+    RulesService rulesService;
+
+    @Inject
+    SecurityIdentity securityIdentity;
+
+    public List<PromotionSource> listSources() {
+        List<PromotionSource> result = new ArrayList<>();
+        for (PromotionSourceDefinition source : config.listSources()) {
+            PromotionSource bean = new PromotionSource();
+            bean.setName(source.name());
+            bean.setUrl(source.url());
+            bean.setAuth(source.auth());
+            result.add(bean);
+        }
+        return result;
+    }
+
+    public PromotionCompareResult compare(String targetGroupId, String targetArtifactId, PromoteArtifact request) {
+        requireEnabled();
+        ParameterValidationUtils.requireParameter("groupId", targetGroupId);
+        ParameterValidationUtils.requireParameter("artifactId", targetArtifactId);
+        ParameterValidationUtils.requireParameter("body.source", request.getSource());
+
+        RemoteArtifactVersion remote = fetchSource(targetGroupId, targetArtifactId, request);
+        Optional<LocalVersion> local = latestTarget(targetGroupId, targetArtifactId);
+        return buildCompare(remote, local, compatibilityLevel(request));
+    }
+
+    public PromotionResult promote(String targetGroupId, String targetArtifactId, Boolean dryRun,
+            PromoteArtifact request) {
+        requireEnabled();
+        ParameterValidationUtils.requireParameter("groupId", targetGroupId);
+        ParameterValidationUtils.requireParameter("artifactId", targetArtifactId);
+        ParameterValidationUtils.requireParameter("body.source", request.getSource());
+
+        String gid = new GroupId(targetGroupId).getRawGroupIdWithNull();
+        RemoteArtifactVersion remote = fetchSource(targetGroupId, targetArtifactId, request);
+        if (remote.artifactType() == null || remote.content() == null) {
+            throw new PromotionRemoteException("Source version is missing artifactType or content");
+        }
+        Optional<LocalVersion> local = latestTarget(targetGroupId, targetArtifactId);
+        CompatibilityLevel level = compatibilityLevel(request);
+        PromotionCompareResult compare = buildCompare(remote, local, level);
+
+        if (Boolean.TRUE.equals(compare.getIdentical()) && local.isPresent()) {
+            PromotionResult result = new PromotionResult();
+            result.setAlreadyPromoted(true);
+            result.setCompare(compare);
+            result.setVersion(V3ApiUtil.dtoToVersionMetaData(storage.getArtifactVersionMetaData(gid,
+                    targetArtifactId, local.get().version())));
+            return result;
+        }
+
+        boolean isDryRun = dryRun != null && dryRun;
+        String owner = securityIdentity.getPrincipal().getName();
+        ContentHandle content = ContentHandle.create(remote.content());
+        ContentWrapperDto contentDto = ContentWrapperDto.builder().content(content)
+                .contentType(remote.contentType()).references(Collections.emptyList()).build();
+        Map<String, String> labels = promotionLabels(request.getSource(), remote);
+        EditableVersionMetaDataDto versionMeta = EditableVersionMetaDataDto.builder().name(remote.name())
+                .description(remote.description()).labels(labels).build();
+        String version = Boolean.TRUE.equals(request.getPreserveVersion()) ? remote.version() : null;
+        TypedContent typedContent = TypedContent.create(content, remote.contentType());
+
+        boolean exists = storage.isArtifactExists(gid, targetArtifactId);
+        rulesService.applyRules(gid, targetArtifactId, remote.artifactType(), typedContent,
+                exists ? RuleApplicationType.UPDATE : RuleApplicationType.CREATE, Collections.emptyList(),
+                Map.of());
+
+        io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto created;
+        if (!exists) {
+            EditableArtifactMetaDataDto artifactMeta = EditableArtifactMetaDataDto.builder()
+                    .name(remote.name()).description(remote.description()).labels(labels).build();
+            Pair<io.apicurio.registry.storage.dto.ArtifactMetaDataDto, io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto> pair = storage
+                    .createArtifact(gid, targetArtifactId, remote.artifactType(), artifactMeta, version,
+                            contentDto, versionMeta, Collections.emptyList(), false, isDryRun, owner);
+            created = pair.getRight();
+        } else {
+            created = storage.createArtifactVersion(gid, targetArtifactId, version, remote.artifactType(),
+                    contentDto, versionMeta, Collections.emptyList(), false, isDryRun, owner);
+        }
+
+        PromotionResult result = new PromotionResult();
+        result.setAlreadyPromoted(false);
+        result.setCompare(compare);
+        result.setVersion(V3ApiUtil.dtoToVersionMetaData(created));
+        return result;
+    }
+
+    private void requireEnabled() {
+        if (!config.isEnabled()) {
+            throw new BadRequestException("Cross-registry promotion is disabled");
+        }
+    }
+
+    private RemoteArtifactVersion fetchSource(String targetGroupId, String targetArtifactId,
+            PromoteArtifact request) {
+        String sourceGroup = request.getSourceGroupId() != null ? request.getSourceGroupId() : targetGroupId;
+        String sourceArtifact = request.getSourceArtifactId() != null ? request.getSourceArtifactId()
+                : targetArtifactId;
+        String sourceVersion = request.getSourceVersion() != null && !request.getSourceVersion().isBlank()
+                ? request.getSourceVersion()
+                : "branch=latest";
+        return clients.client(request.getSource()).fetch(sourceGroup, sourceArtifact, sourceVersion);
+    }
+
+    private Optional<LocalVersion> latestTarget(String groupId, String artifactId) {
+        String gid = new GroupId(groupId).getRawGroupIdWithNull();
+        if (!storage.isArtifactExists(gid, artifactId)) {
+            return Optional.empty();
+        }
+        try {
+            var gav = VersionExpressionParser.parse(new GA(groupId, artifactId), "branch=latest",
+                    (ga, branchId) -> storage.getBranchTip(ga, branchId, RetrievalBehavior.SKIP_DISABLED_LATEST));
+            StoredArtifactVersionDto content = storage.getArtifactVersionContent(gav.getRawGroupIdWithNull(),
+                    gav.getRawArtifactId(), gav.getRawVersionId());
+            var meta = storage.getArtifactVersionMetaData(gav.getRawGroupIdWithNull(), gav.getRawArtifactId(),
+                    gav.getRawVersionId());
+            return Optional.of(new LocalVersion(gav.getRawGroupIdWithDefaultString(), artifactId,
+                    meta.getVersion(), meta.getArtifactType(), content.getContentType(),
+                    content.getContent().content()));
+        } catch (VersionNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+
+    private PromotionCompareResult buildCompare(RemoteArtifactVersion remote, Optional<LocalVersion> local,
+            CompatibilityLevel level) {
+        String sourceCanonical = canonicalize(remote.artifactType(), remote.contentType(), remote.content());
+        String targetCanonical = local
+                .map(v -> canonicalize(v.artifactType(), v.contentType(), v.content()))
+                .orElse("");
+        boolean identical = local.isPresent() && sourceCanonical.equals(targetCanonical);
+
+        PromotionCompareResult result = new PromotionCompareResult();
+        result.setSource(coordinate(remote.groupId(), remote.artifactId(), remote.version(),
+                remote.artifactType()));
+        result.setTarget(local.map(v -> coordinate(v.groupId(), v.artifactId(), v.version(), v.artifactType()))
+                .orElse(null));
+        result.setIdentical(identical);
+        result.setContentDiff(toDiffLines(ContentLineDiff.diff(targetCanonical, sourceCanonical)));
+        result.setCompatibility(checkCompatibility(remote, local, level));
+        return result;
+    }
+
+    private PromotionCompatibility checkCompatibility(RemoteArtifactVersion remote, Optional<LocalVersion> local,
+            CompatibilityLevel level) {
+        PromotionCompatibility compatibility = new PromotionCompatibility();
+        compatibility.setLevel(level.name());
+        if (level == CompatibilityLevel.NONE || local.isEmpty()) {
+            compatibility.setCompatible(true);
+            compatibility.setDifferences(List.of());
+            return compatibility;
+        }
+        ArtifactTypeUtilProvider provider = artifactTypes.getArtifactTypeProvider(remote.artifactType());
+        TypedContent proposed = TypedContent.create(remote.content(), remote.contentType());
+        TypedContent existing = TypedContent.create(local.get().content(), local.get().contentType());
+        CompatibilityExecutionResult execution = provider.getCompatibilityChecker().testCompatibility(level,
+                List.of(existing), proposed, Map.of());
+        compatibility.setCompatible(execution.isCompatible());
+        List<PromotionCompatibilityDifference> diffs = new ArrayList<>();
+        if (execution.getIncompatibleDifferences() != null) {
+            for (var difference : execution.getIncompatibleDifferences()) {
+                var violation = difference.asRuleViolation();
+                PromotionCompatibilityDifference item = new PromotionCompatibilityDifference();
+                item.setDescription(violation.getDescription());
+                item.setContext(violation.getContext());
+                diffs.add(item);
+            }
+        }
+        compatibility.setDifferences(diffs);
+        return compatibility;
+    }
+
+    private String canonicalize(String artifactType, String contentType, String content) {
+        if (artifactType == null || content == null) {
+            return content == null ? "" : content;
+        }
+        try {
+            ArtifactTypeUtilProvider provider = artifactTypes.getArtifactTypeProvider(artifactType);
+            TypedContent canonical = provider.getContentCanonicalizer()
+                    .canonicalize(TypedContent.create(content, contentType), Map.of());
+            return canonical.getContent().content();
+        } catch (RuntimeException e) {
+            return content;
+        }
+    }
+
+    private CompatibilityLevel compatibilityLevel(PromoteArtifact request) {
+        if (request.getCompatibilityLevel() == null) {
+            return CompatibilityLevel.BACKWARD;
+        }
+        String raw = request.getCompatibilityLevel().name();
+        try {
+            return CompatibilityLevel.valueOf(raw);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("Unknown compatibilityLevel: " + raw);
+        }
+    }
+
+    private static List<PromotionDiffLine> toDiffLines(List<ContentLineDiff.Line> lines) {
+        List<PromotionDiffLine> result = new ArrayList<>();
+        for (ContentLineDiff.Line line : lines) {
+            PromotionDiffLine bean = new PromotionDiffLine();
+            bean.setOp(PromotionDiffLine.Op.fromValue(line.op()));
+            bean.setText(line.text());
+            result.add(bean);
+        }
+        return result;
+    }
+
+    private static PromotionCoordinate coordinate(String groupId, String artifactId, String version,
+            String artifactType) {
+        PromotionCoordinate coordinate = new PromotionCoordinate();
+        coordinate.setGroupId(groupId);
+        coordinate.setArtifactId(artifactId);
+        coordinate.setVersion(version);
+        coordinate.setArtifactType(artifactType);
+        return coordinate;
+    }
+
+    private static Map<String, String> promotionLabels(String sourceName, RemoteArtifactVersion remote) {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put(LABEL_SOURCE, sourceName);
+        labels.put(LABEL_SOURCE_GROUP, remote.groupId());
+        labels.put(LABEL_SOURCE_ARTIFACT, remote.artifactId());
+        labels.put(LABEL_SOURCE_VERSION, remote.version());
+        return labels;
+    }
+
+    private record LocalVersion(String groupId, String artifactId, String version, String artifactType,
+            String contentType, String content) {
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/promotion/HttpPromotionSourceClient.java
+++ b/app/src/main/java/io/apicurio/registry/promotion/HttpPromotionSourceClient.java
@@ -24,6 +24,7 @@ public class HttpPromotionSourceClient implements PromotionSourceClient {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final Duration TIMEOUT = Duration.ofSeconds(30);
+    private static final String AUTHORIZATION = "Authorization";
 
     private final PromotionSourceDefinition source;
     private final HttpClient httpClient;
@@ -79,13 +80,14 @@ public class HttpPromotionSourceClient implements PromotionSourceClient {
         String mode = source.auth() == null ? "none" : source.auth().toLowerCase();
         switch (mode) {
             case "none", "" -> {
+                // Anonymous source registry: do not attach an Authorization header.
             }
             case "bearer" -> {
                 if (source.token() == null) {
                     throw new PromotionRemoteException(
                             "Promotion source '" + source.name() + "' auth=bearer requires a token");
                 }
-                builder.header("Authorization", "Bearer " + source.token());
+                builder.header(AUTHORIZATION, "Bearer " + source.token());
             }
             case "basic" -> {
                 if (source.username() == null) {
@@ -93,10 +95,10 @@ public class HttpPromotionSourceClient implements PromotionSourceClient {
                             "Promotion source '" + source.name() + "' auth=basic requires a username");
                 }
                 String raw = source.username() + ":" + (source.password() == null ? "" : source.password());
-                builder.header("Authorization",
+                builder.header(AUTHORIZATION,
                         "Basic " + Base64.getEncoder().encodeToString(raw.getBytes(StandardCharsets.UTF_8)));
             }
-            case "oauth2" -> builder.header("Authorization", "Bearer " + fetchOAuth2Token());
+            case "oauth2" -> builder.header(AUTHORIZATION, "Bearer " + fetchOAuth2Token());
             default -> throw new PromotionRemoteException(
                     "Unsupported promotion auth mode '" + source.auth() + "' for source '" + source.name() + "'");
         }

--- a/app/src/main/java/io/apicurio/registry/promotion/HttpPromotionSourceClient.java
+++ b/app/src/main/java/io/apicurio/registry/promotion/HttpPromotionSourceClient.java
@@ -1,0 +1,164 @@
+package io.apicurio.registry.promotion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apicurio.registry.model.GroupId;
+import io.apicurio.registry.storage.error.ArtifactNotFoundException;
+import io.apicurio.registry.storage.error.VersionNotFoundException;
+import io.apicurio.registry.types.ContentTypes;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+
+/**
+ * Fetches artifact versions from another Apicurio Registry over the v3 REST API.
+ */
+public class HttpPromotionSourceClient implements PromotionSourceClient {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Duration TIMEOUT = Duration.ofSeconds(30);
+
+    private final PromotionSourceDefinition source;
+    private final HttpClient httpClient;
+
+    public HttpPromotionSourceClient(PromotionSourceDefinition source, HttpClient httpClient) {
+        this.source = source;
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public RemoteArtifactVersion fetch(String groupId, String artifactId, String versionExpression) {
+        String base = normalizeBaseUrl(source.url());
+        String group = new GroupId(groupId).getRawGroupIdWithDefaultString();
+        String versionPath = encode(versionExpression);
+        String metaUrl = base + "/groups/" + encode(group) + "/artifacts/" + encode(artifactId) + "/versions/"
+                + versionPath;
+        HttpResponse<String> metaResponse = send(authorized(HttpRequest.newBuilder(URI.create(metaUrl)).GET()));
+        if (metaResponse.statusCode() == 404) {
+            throw new VersionNotFoundException(group, artifactId, versionExpression);
+        }
+        if (metaResponse.statusCode() >= 400) {
+            throw new PromotionRemoteException("Source registry '" + source.name() + "' returned HTTP "
+                    + metaResponse.statusCode() + " for " + metaUrl);
+        }
+        JsonNode meta;
+        try {
+            meta = MAPPER.readTree(metaResponse.body());
+        } catch (IOException e) {
+            throw new PromotionRemoteException("Source registry returned invalid version metadata", e);
+        }
+        String contentUrl = metaUrl + "/content";
+        HttpResponse<String> contentResponse = send(
+                authorized(HttpRequest.newBuilder(URI.create(contentUrl)).GET()));
+        if (contentResponse.statusCode() == 404) {
+            throw new ArtifactNotFoundException(group, artifactId);
+        }
+        if (contentResponse.statusCode() >= 400) {
+            throw new PromotionRemoteException("Source registry '" + source.name() + "' returned HTTP "
+                    + contentResponse.statusCode() + " for " + contentUrl);
+        }
+        String contentType = contentResponse.headers().firstValue("Content-Type").orElse(ContentTypes.APPLICATION_JSON);
+        int semicolon = contentType.indexOf(';');
+        if (semicolon > 0) {
+            contentType = contentType.substring(0, semicolon).trim();
+        }
+        return new RemoteArtifactVersion(text(meta, "groupId", group), text(meta, "artifactId", artifactId),
+                text(meta, "version", versionExpression), text(meta, "artifactType", null), contentType,
+                contentResponse.body(), text(meta, "name", null), text(meta, "description", null));
+    }
+
+    private HttpRequest authorized(HttpRequest.Builder builder) {
+        builder.timeout(TIMEOUT);
+        String mode = source.auth() == null ? "none" : source.auth().toLowerCase();
+        switch (mode) {
+            case "none", "" -> {
+            }
+            case "bearer" -> {
+                if (source.token() == null) {
+                    throw new PromotionRemoteException(
+                            "Promotion source '" + source.name() + "' auth=bearer requires a token");
+                }
+                builder.header("Authorization", "Bearer " + source.token());
+            }
+            case "basic" -> {
+                if (source.username() == null) {
+                    throw new PromotionRemoteException(
+                            "Promotion source '" + source.name() + "' auth=basic requires a username");
+                }
+                String raw = source.username() + ":" + (source.password() == null ? "" : source.password());
+                builder.header("Authorization",
+                        "Basic " + Base64.getEncoder().encodeToString(raw.getBytes(StandardCharsets.UTF_8)));
+            }
+            case "oauth2" -> builder.header("Authorization", "Bearer " + fetchOAuth2Token());
+            default -> throw new PromotionRemoteException(
+                    "Unsupported promotion auth mode '" + source.auth() + "' for source '" + source.name() + "'");
+        }
+        return builder.build();
+    }
+
+    private String fetchOAuth2Token() {
+        if (source.tokenUrl() == null || source.clientId() == null) {
+            throw new PromotionRemoteException("Promotion source '" + source.name()
+                    + "' auth=oauth2 requires token-url and client-id");
+        }
+        String form = "grant_type=client_credentials&client_id=" + encode(source.clientId()) + "&client_secret="
+                + encode(source.clientSecret() == null ? "" : source.clientSecret());
+        HttpRequest request = HttpRequest.newBuilder(URI.create(source.tokenUrl())).timeout(TIMEOUT)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(form)).build();
+        HttpResponse<String> response = send(request);
+        if (response.statusCode() >= 400) {
+            throw new PromotionRemoteException("OAuth2 token request failed with HTTP " + response.statusCode());
+        }
+        try {
+            JsonNode json = MAPPER.readTree(response.body());
+            if (json.hasNonNull("access_token")) {
+                return json.get("access_token").asText();
+            }
+        } catch (IOException e) {
+            throw new PromotionRemoteException("OAuth2 token response was not JSON", e);
+        }
+        throw new PromotionRemoteException("OAuth2 token response did not include access_token");
+    }
+
+    private HttpResponse<String> send(HttpRequest request) {
+        try {
+            return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException e) {
+            throw new PromotionRemoteException("Failed to reach source registry '" + source.name() + "'", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PromotionRemoteException("Interrupted while calling source registry '" + source.name() + "'",
+                    e);
+        }
+    }
+
+    static String normalizeBaseUrl(String url) {
+        String base = url.trim();
+        while (base.endsWith("/")) {
+            base = base.substring(0, base.length() - 1);
+        }
+        if (!base.contains("/apis/registry")) {
+            base = base + "/apis/registry/v3";
+        }
+        return base;
+    }
+
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+
+    private static String text(JsonNode node, String field, String fallback) {
+        if (node != null && node.hasNonNull(field)) {
+            return node.get(field).asText();
+        }
+        return fallback;
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/promotion/LocalStoragePromotionSourceClient.java
+++ b/app/src/main/java/io/apicurio/registry/promotion/LocalStoragePromotionSourceClient.java
@@ -1,0 +1,36 @@
+package io.apicurio.registry.promotion;
+
+import io.apicurio.registry.model.GA;
+import io.apicurio.registry.model.GroupId;
+import io.apicurio.registry.model.VersionExpressionParser;
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.RegistryStorage.RetrievalBehavior;
+import io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto;
+import io.apicurio.registry.storage.dto.StoredArtifactVersionDto;
+
+/**
+ * Treats this registry instance as the promotion source (same database, typically a different group).
+ */
+public class LocalStoragePromotionSourceClient implements PromotionSourceClient {
+
+    private final RegistryStorage storage;
+
+    public LocalStoragePromotionSourceClient(RegistryStorage storage) {
+        this.storage = storage;
+    }
+
+    @Override
+    public RemoteArtifactVersion fetch(String groupId, String artifactId, String versionExpression) {
+        var gav = VersionExpressionParser.parse(new GA(groupId, artifactId), versionExpression,
+                (ga, branchId) -> storage.getBranchTip(ga, branchId, RetrievalBehavior.SKIP_DISABLED_LATEST));
+        String rawGroup = gav.getRawGroupIdWithNull();
+        ArtifactVersionMetaDataDto meta = storage.getArtifactVersionMetaData(rawGroup, gav.getRawArtifactId(),
+                gav.getRawVersionId());
+        StoredArtifactVersionDto content = storage.getArtifactVersionContent(rawGroup, gav.getRawArtifactId(),
+                gav.getRawVersionId());
+        String publicGroup = new GroupId(rawGroup).getRawGroupIdWithDefaultString();
+        return new RemoteArtifactVersion(publicGroup, meta.getArtifactId(), meta.getVersion(),
+                meta.getArtifactType(), content.getContentType(), content.getContent().content(),
+                meta.getName(), meta.getDescription());
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/promotion/PromotionConfig.java
+++ b/app/src/main/java/io/apicurio/registry/promotion/PromotionConfig.java
@@ -1,0 +1,76 @@
+package io.apicurio.registry.promotion;
+
+import io.apicurio.common.apps.config.Info;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.BadRequestException;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_REST;
+
+/**
+ * Discovers named promotion sources from {@code apicurio.promotion.source.{name}.*} properties.
+ */
+@Singleton
+public class PromotionConfig {
+
+    static final String SOURCE_PREFIX = "apicurio.promotion.source.";
+    static final String URL_SUFFIX = ".url";
+
+    @ConfigProperty(name = "apicurio.promotion.enabled", defaultValue = "true")
+    @Info(category = CATEGORY_REST, description = "Enables the cross-registry promotion REST API", availableSince = "3.3.2")
+    boolean enabled;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public List<PromotionSourceDefinition> listSources() {
+        Config config = ConfigProvider.getConfig();
+        List<PromotionSourceDefinition> sources = new ArrayList<>();
+        for (String propertyName : config.getPropertyNames()) {
+            if (propertyName.startsWith(SOURCE_PREFIX) && propertyName.endsWith(URL_SUFFIX)) {
+                String name = propertyName.substring(SOURCE_PREFIX.length(),
+                        propertyName.length() - URL_SUFFIX.length());
+                if (!name.isBlank() && !name.contains(".")) {
+                    sources.add(readSource(config, name));
+                }
+            }
+        }
+        sources.sort(Comparator.comparing(PromotionSourceDefinition::name));
+        return sources;
+    }
+
+    public PromotionSourceDefinition requireSource(String name) {
+        if (name == null || name.isBlank()) {
+            throw new BadRequestException("Promotion source name is required");
+        }
+        return listSources().stream().filter(source -> source.name().equals(name)).findFirst()
+                .orElseThrow(() -> new BadRequestException(
+                        "Unknown promotion source '" + name + "'. Configure apicurio.promotion.source."
+                                + name + ".url"));
+    }
+
+    private PromotionSourceDefinition readSource(Config config, String name) {
+        String base = SOURCE_PREFIX + name + ".";
+        String url = config.getOptionalValue(base + "url", String.class).orElseThrow();
+        return new PromotionSourceDefinition(name, url.trim(),
+                optional(config, base + "auth").orElse("none"),
+                optional(config, base + "token").orElse(null),
+                optional(config, base + "username").orElse(null),
+                optional(config, base + "password").orElse(null),
+                optional(config, base + "token-url").orElse(null),
+                optional(config, base + "client-id").orElse(null),
+                optional(config, base + "client-secret").orElse(null));
+    }
+
+    private static Optional<String> optional(Config config, String name) {
+        return config.getOptionalValue(name, String.class).map(String::trim).filter(v -> !v.isEmpty());
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/promotion/PromotionRemoteException.java
+++ b/app/src/main/java/io/apicurio/registry/promotion/PromotionRemoteException.java
@@ -1,0 +1,18 @@
+package io.apicurio.registry.promotion;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Raised when a remote source registry cannot be reached or returns an unexpected error.
+ */
+public class PromotionRemoteException extends WebApplicationException {
+
+    public PromotionRemoteException(String message) {
+        super(message, Response.Status.BAD_GATEWAY);
+    }
+
+    public PromotionRemoteException(String message, Throwable cause) {
+        super(message, cause, Response.Status.BAD_GATEWAY);
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/promotion/PromotionSourceClient.java
+++ b/app/src/main/java/io/apicurio/registry/promotion/PromotionSourceClient.java
@@ -1,0 +1,9 @@
+package io.apicurio.registry.promotion;
+
+/**
+ * Fetches an artifact version from a promotion source.
+ */
+public interface PromotionSourceClient {
+
+    RemoteArtifactVersion fetch(String groupId, String artifactId, String versionExpression);
+}

--- a/app/src/main/java/io/apicurio/registry/promotion/PromotionSourceClientFactory.java
+++ b/app/src/main/java/io/apicurio/registry/promotion/PromotionSourceClientFactory.java
@@ -1,0 +1,30 @@
+package io.apicurio.registry.promotion;
+
+import io.apicurio.registry.cdi.Current;
+import io.apicurio.registry.storage.RegistryStorage;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+@ApplicationScoped
+public class PromotionSourceClientFactory {
+
+    private final HttpClient httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+
+    @Inject
+    PromotionConfig config;
+
+    @Inject
+    @Current
+    RegistryStorage storage;
+
+    public PromotionSourceClient client(String sourceName) {
+        PromotionSourceDefinition source = config.requireSource(sourceName);
+        if (source.isLocal()) {
+            return new LocalStoragePromotionSourceClient(storage);
+        }
+        return new HttpPromotionSourceClient(source, httpClient);
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/promotion/PromotionSourceDefinition.java
+++ b/app/src/main/java/io/apicurio/registry/promotion/PromotionSourceDefinition.java
@@ -1,0 +1,14 @@
+package io.apicurio.registry.promotion;
+
+/**
+ * Named source registry used for cross-environment promotion. Secrets are held in memory only and must
+ * never be returned from REST APIs.
+ */
+public record PromotionSourceDefinition(String name, String url, String auth, String token, String username,
+        String password, String tokenUrl, String clientId, String clientSecret) {
+
+    public boolean isLocal() {
+        String value = url == null ? "" : url.trim();
+        return value.startsWith("local:");
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/promotion/RemoteArtifactVersion.java
+++ b/app/src/main/java/io/apicurio/registry/promotion/RemoteArtifactVersion.java
@@ -1,0 +1,8 @@
+package io.apicurio.registry.promotion;
+
+/**
+ * Artifact version fetched from a promotion source (another registry, or this instance).
+ */
+public record RemoteArtifactVersion(String groupId, String artifactId, String version, String artifactType,
+        String contentType, String content, String name, String description) {
+}

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
@@ -191,6 +191,9 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
     @Inject
     io.apicurio.registry.contracts.audit.ContractAuditService contractAuditService;
 
+    @Inject
+    io.apicurio.registry.promotion.CrossRegistryPromotionService crossRegistryPromotionService;
+
     /**
      * @see io.apicurio.registry.rest.v3.GroupsResource#getArtifactVersionReferences(java.lang.String,
      *      java.lang.String, java.lang.String, io.apicurio.registry.types.ReferenceType)
@@ -2604,6 +2607,28 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
         var result = promotionService.promote(rawGroupId, artifactId,
                 contractId, targetStage);
         return Response.ok(Map.of("stage", result.name())).build();
+    }
+
+    /**
+     * @see io.apicurio.registry.rest.v3.GroupsResource#compareArtifactPromotion(java.lang.String, java.lang.String, io.apicurio.registry.rest.v3.beans.PromoteArtifact)
+     */
+    @Override
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Read)
+    public PromotionCompareResult compareArtifactPromotion(String groupId, String artifactId,
+            PromoteArtifact data) {
+        return crossRegistryPromotionService.compare(groupId, artifactId, data);
+    }
+
+    /**
+     * @see io.apicurio.registry.rest.v3.GroupsResource#promoteArtifact(java.lang.String, java.lang.String, java.lang.Boolean, io.apicurio.registry.rest.v3.beans.PromoteArtifact)
+     */
+    @Override
+    @Audited
+    @MethodMetadata(extractParameters = {"0", MPK_GROUP_ID, "1", MPK_ARTIFACT_ID, "2", "dryRun"})
+    @Authorized(style = AuthorizedStyle.GroupAndArtifact, level = AuthorizedLevel.Write, dryRunParam = 2)
+    public PromotionResult promoteArtifact(String groupId, String artifactId, Boolean dryRun,
+            PromoteArtifact data) {
+        return crossRegistryPromotionService.promote(groupId, artifactId, dryRun, data);
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/SystemResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/SystemResourceImpl.java
@@ -12,6 +12,8 @@ import io.apicurio.registry.logging.Logged;
 import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
 import io.apicurio.registry.metrics.health.readiness.ResponseTimeoutReadinessCheck;
 import io.apicurio.registry.rest.RestConfig;
+import io.apicurio.registry.promotion.CrossRegistryPromotionService;
+import io.apicurio.registry.rest.v3.beans.PromotionSource;
 import io.apicurio.registry.rest.v3.beans.SystemInfo;
 import io.apicurio.registry.rest.v3.beans.UserInterfaceConfig;
 import io.apicurio.registry.rest.v3.beans.UserInterfaceConfigAuth;
@@ -24,6 +26,7 @@ import jakarta.inject.Inject;
 import jakarta.interceptor.Interceptors;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @ApplicationScoped
@@ -48,6 +51,9 @@ public class SystemResourceImpl implements SystemResource {
 
     @Inject
     ElasticsearchSearchConfig esSearchConfig;
+
+    @Inject
+    CrossRegistryPromotionService crossRegistryPromotionService;
 
     /**
      * @see io.apicurio.registry.rest.v3.SystemResource#getSystemInfo()
@@ -114,5 +120,14 @@ public class SystemResourceImpl implements SystemResource {
             rval.setOptions(options);
         }
         return rval;
+    }
+
+    /**
+     * @see io.apicurio.registry.rest.v3.SystemResource#listPromotionSources()
+     */
+    @Override
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
+    public List<PromotionSource> listPromotionSources() {
+        return crossRegistryPromotionService.listSources();
     }
 }

--- a/app/src/main/resources/application-test.properties
+++ b/app/src/main/resources/application-test.properties
@@ -26,3 +26,7 @@ apicurio.logconfigjob.every=1s
 
 # Artifact version deletion
 apicurio.rest.artifact.deletion.enabled=true
+
+# Same-instance promotion source for REST tests (issue #7878 phase 1)
+apicurio.promotion.source.local.url=local://
+apicurio.promotion.source.local.auth=none

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -220,6 +220,17 @@ apicurio.log.level.dynamic.allow=${apicurio.config.dynamic.allow-all}
 apicurio.ui.features.agents.enabled.dynamic.allow=${apicurio.config.dynamic.allow-all}
 apicurio.kafkasql.snapshot.scheduled.enabled.dynamic.allow=${apicurio.config.dynamic.allow-all}
 
+# Cross-registry schema promotion (issue #7878, phase 1)
+# Configure one or more sources, then POST /groups/{g}/artifacts/{a}/promotion
+# apicurio.promotion.enabled=true
+# apicurio.promotion.source.staging.url=https://staging-registry:8080
+# apicurio.promotion.source.staging.auth=none
+# apicurio.promotion.source.staging.auth=oauth2
+# apicurio.promotion.source.staging.token-url=https://sso/realms/registry/protocol/openid-connect/token
+# apicurio.promotion.source.staging.client-id=
+# apicurio.promotion.source.staging.client-secret=
+# Use url=local:// to treat this same registry instance as the source (group-to-group).
+
 # Error
 apicurio.api.errors.include-stack-in-response=false
 

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/CrossRegistryPromotionTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/CrossRegistryPromotionTest.java
@@ -1,0 +1,107 @@
+package io.apicurio.registry.noprofile.rest.v3;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.rest.client.models.CreateArtifact;
+import io.apicurio.registry.rest.client.models.CreateVersion;
+import io.apicurio.registry.types.ArtifactType;
+import io.apicurio.registry.types.ContentTypes;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.nullValue;
+
+@QuarkusTest
+public class CrossRegistryPromotionTest extends AbstractResourceTestBase {
+
+    private static final String AVRO_V1 = "{\"type\":\"record\",\"name\":\"User\",\"fields\":["
+            + "{\"name\":\"id\",\"type\":\"int\"}]}";
+    private static final String AVRO_V2 = "{\"type\":\"record\",\"name\":\"User\",\"fields\":["
+            + "{\"name\":\"id\",\"type\":\"int\"},"
+            + "{\"name\":\"email\",\"type\":\"string\",\"default\":\"\"}]}";
+
+    @Test
+    public void testListPromotionSources() {
+        given().when().get("/registry/v3/system/promotion/sources").then().statusCode(200)
+                .body("name", hasItem("local"));
+    }
+
+    @Test
+    public void testUnknownSourceRejected() {
+        String groupId = TestUtils.generateGroupId();
+        String artifactId = TestUtils.generateArtifactId();
+        given().contentType(CT_JSON)
+                .body("{\"source\":\"does-not-exist\"}")
+                .post("/registry/v3/groups/" + groupId + "/artifacts/" + artifactId + "/promotion/compare")
+                .then().statusCode(400);
+    }
+
+    @Test
+    public void testCompareAndPromoteFromLocalSource() throws Exception {
+        String sourceGroup = TestUtils.generateGroupId();
+        String targetGroup = TestUtils.generateGroupId();
+        String artifactId = TestUtils.generateArtifactId();
+
+        createAvro(sourceGroup, artifactId, AVRO_V1);
+        createVersion(sourceGroup, artifactId, AVRO_V2);
+        createAvro(targetGroup, artifactId, AVRO_V1);
+
+        given().contentType(CT_JSON)
+                .body("{\"source\":\"local\",\"sourceGroupId\":\"" + sourceGroup
+                        + "\",\"sourceVersion\":\"2\"}")
+                .post("/registry/v3/groups/" + targetGroup + "/artifacts/" + artifactId + "/promotion/compare")
+                .then().statusCode(200)
+                .body("identical", equalTo(false))
+                .body("source.version", equalTo("2"))
+                .body("target.version", equalTo("1"))
+                .body("compatibility.compatible", equalTo(true));
+
+        given().contentType(CT_JSON)
+                .body("{\"source\":\"local\",\"sourceGroupId\":\"" + sourceGroup
+                        + "\",\"sourceVersion\":\"2\"}")
+                .post("/registry/v3/groups/" + targetGroup + "/artifacts/" + artifactId + "/promotion")
+                .then().statusCode(200)
+                .body("alreadyPromoted", equalTo(false))
+                .body("version.version", equalTo("2"))
+                .body("version.labels['apicurio.promotion.source']", equalTo("local"));
+
+        given().contentType(CT_JSON)
+                .body("{\"source\":\"local\",\"sourceGroupId\":\"" + sourceGroup
+                        + "\",\"sourceVersion\":\"2\"}")
+                .post("/registry/v3/groups/" + targetGroup + "/artifacts/" + artifactId + "/promotion")
+                .then().statusCode(200)
+                .body("alreadyPromoted", equalTo(true))
+                .body("version.version", equalTo("2"));
+    }
+
+    @Test
+    public void testPromoteCreatesArtifactWhenMissing() throws Exception {
+        String sourceGroup = TestUtils.generateGroupId();
+        String targetGroup = TestUtils.generateGroupId();
+        String artifactId = TestUtils.generateArtifactId();
+
+        createAvro(sourceGroup, artifactId, AVRO_V1);
+
+        given().contentType(CT_JSON)
+                .body("{\"source\":\"local\",\"sourceGroupId\":\"" + sourceGroup + "\"}")
+                .post("/registry/v3/groups/" + targetGroup + "/artifacts/" + artifactId + "/promotion")
+                .then().statusCode(200)
+                .body("alreadyPromoted", equalTo(false))
+                .body("version.artifactId", equalTo(artifactId))
+                .body("compare.target", nullValue());
+    }
+
+    private void createAvro(String groupId, String artifactId, String content) throws Exception {
+        CreateArtifact createArtifact = TestUtils.clientCreateArtifact(artifactId, ArtifactType.AVRO, content,
+                ContentTypes.APPLICATION_JSON);
+        clientV3.groups().byGroupId(groupId).artifacts().post(createArtifact);
+    }
+
+    private void createVersion(String groupId, String artifactId, String content) throws Exception {
+        CreateVersion createVersion = TestUtils.clientCreateVersion(content, ContentTypes.APPLICATION_JSON);
+        clientV3.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).versions().post(createVersion);
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/promotion/ContentLineDiffTest.java
+++ b/app/src/test/java/io/apicurio/registry/promotion/ContentLineDiffTest.java
@@ -1,0 +1,34 @@
+package io.apicurio.registry.promotion;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ContentLineDiffTest {
+
+    @Test
+    public void testIdentical() {
+        assertTrue(ContentLineDiff.diff("a\nb", "a\nb").isEmpty());
+    }
+
+    @Test
+    public void testAddAndRemove() {
+        List<ContentLineDiff.Line> diff = ContentLineDiff.diff("keep\nold", "keep\nnew");
+        assertEquals(2, diff.size());
+        assertEquals("removed", diff.get(0).op());
+        assertEquals("old", diff.get(0).text());
+        assertEquals("added", diff.get(1).op());
+        assertEquals("new", diff.get(1).text());
+    }
+
+    @Test
+    public void testFromEmpty() {
+        List<ContentLineDiff.Line> diff = ContentLineDiff.diff("", "only");
+        assertEquals(1, diff.size());
+        assertEquals("added", diff.get(0).op());
+        assertEquals("only", diff.get(0).text());
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/promotion/HttpPromotionSourceClientTest.java
+++ b/app/src/test/java/io/apicurio/registry/promotion/HttpPromotionSourceClientTest.java
@@ -1,0 +1,28 @@
+package io.apicurio.registry.promotion;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HttpPromotionSourceClientTest {
+
+    @Test
+    public void testNormalizeAddsRegistryPath() {
+        assertEquals("https://staging-registry:8080/apis/registry/v3",
+                HttpPromotionSourceClient.normalizeBaseUrl("https://staging-registry:8080"));
+    }
+
+    @Test
+    public void testNormalizeKeepsExistingPath() {
+        assertEquals("https://staging-registry:8080/apis/registry/v3",
+                HttpPromotionSourceClient.normalizeBaseUrl("https://staging-registry:8080/apis/registry/v3/"));
+    }
+
+    @Test
+    public void testLocalSourceDetection() {
+        PromotionSourceDefinition source = new PromotionSourceDefinition("local", "local://", "none", null,
+                null, null, null, null, null);
+        assertTrue(source.isLocal());
+    }
+}

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -2601,6 +2601,42 @@
         "description": "Returns the UI configuration properties for this server.  The registry UI can be\nconnected to a backend using just a URL.  The rest of the UI configuration can then\nbe fetched from the backend using this operation.  This allows UI and backend to\nboth be configured in the same place.\n\nThis operation may fail for one of the following reasons:\n\n* A server error occurred (HTTP error `500`)\n"
       }
     },
+    "/system/promotion/sources": {
+      "summary": "List configured cross-registry promotion sources",
+      "get": {
+        "tags": [
+          "System",
+          "Promotion"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PromotionSource"
+                  }
+                }
+              }
+            },
+            "description": "Configured promotion source registries (secrets are never returned)."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        },
+        "operationId": "listPromotionSources",
+        "summary": "List promotion sources",
+        "description": "Lists named source registries configured for cross-environment schema promotion.\nEach source is defined with `apicurio.promotion.source.{name}.url` (and optional auth properties).\nUse the source `name` when calling compare or promote.  Credentials and tokens are never returned."
+      }
+    },
     "/ids/contentHashes/{contentHash}/references": {
       "get": {
         "tags": [
@@ -5497,6 +5533,163 @@
         }
       ]
     },
+    "/groups/{groupId}/artifacts/{artifactId}/promotion/compare": {
+      "summary": "Compare a remote source version with the local target artifact.",
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromoteArtifact"
+              }
+            }
+          },
+          "required": true
+        },
+        "tags": [
+          "Promotion",
+          "Artifacts"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromotionCompareResult"
+                }
+              }
+            },
+            "description": "Comparison of the source version against the current target version (if any)."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "502": {
+            "description": "The source registry could not be reached or returned an error."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        },
+        "operationId": "compareArtifactPromotion",
+        "summary": "Compare promotion source",
+        "description": "Fetches an artifact version from a configured source registry and compares it with the\ncurrent version of this (target) artifact.  Returns a content diff and a compatibility check.\nThis does not modify any content.\n\nThis operation can fail for the following reasons:\n\n* The promotion source name is unknown or not configured (HTTP error `400`)\n* The source artifact/version was not found (HTTP error `404`)\n* The source registry could not be reached (HTTP error `502`)\n* A server error occurred (HTTP error `500`)\n"
+      },
+      "parameters": [
+        {
+          "name": "groupId",
+          "description": "The target group ID.",
+          "schema": {
+            "type": "string"
+          },
+          "in": "path",
+          "required": true
+        },
+        {
+          "name": "artifactId",
+          "description": "The target artifact ID.",
+          "schema": {
+            "type": "string"
+          },
+          "in": "path",
+          "required": true
+        }
+      ]
+    },
+    "/groups/{groupId}/artifacts/{artifactId}/promotion": {
+      "summary": "Promote an artifact version from a source registry into this registry.",
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromoteArtifact"
+              }
+            }
+          },
+          "required": true
+        },
+        "tags": [
+          "Promotion",
+          "Artifacts"
+        ],
+        "parameters": [
+          {
+            "name": "dryRun",
+            "description": "When set to `true`, the operation will not result in any changes. Instead, it\nwill return a result based on whether the operation **would have succeeded**.",
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromotionResult"
+                }
+              }
+            },
+            "description": "The version was promoted (or already matched the source content)."
+          },
+          "400": {
+            "$ref": "#/components/responses/RuleViolationBadRequest"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "502": {
+            "description": "The source registry could not be reached or returned an error."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        },
+        "operationId": "promoteArtifact",
+        "summary": "Promote artifact from source registry",
+        "description": "Copies a specific artifact version from a configured source registry into this registry.\nUnlike replication, each call is an explicit, audited action.  Existing target compatibility\nrules are applied.  If the latest target content already matches the source, no new version\nis created.\n\nThis operation can fail for the following reasons:\n\n* The promotion source name is unknown or not configured (HTTP error `400`)\n* A configured rule (e.g. compatibility) was violated (HTTP error `400`)\n* The source artifact/version was not found (HTTP error `404`)\n* The source registry could not be reached (HTTP error `502`)\n* A server error occurred (HTTP error `500`)\n"
+      },
+      "parameters": [
+        {
+          "name": "groupId",
+          "description": "The target group ID.",
+          "schema": {
+            "type": "string"
+          },
+          "in": "path",
+          "required": true
+        },
+        {
+          "name": "artifactId",
+          "description": "The target artifact ID.",
+          "schema": {
+            "type": "string"
+          },
+          "in": "path",
+          "required": true
+        }
+      ]
+    },
     "/groups/{groupId}/artifacts/{artifactId}/contract/promote": {
       "summary": "Promote a contract to the next deployment stage.",
       "post": {
@@ -7224,6 +7417,177 @@
           "taskId",
           "state"
         ]
+      },
+      "PromoteArtifact": {
+        "description": "Request to fetch, compare, or promote an artifact version from a configured source registry.",
+        "required": [
+          "source"
+        ],
+        "type": "object",
+        "properties": {
+          "source": {
+            "description": "Name of a configured promotion source (from `apicurio.promotion.source.{name}.url`).",
+            "type": "string",
+            "example": "staging"
+          },
+          "sourceGroupId": {
+            "description": "Group ID in the source registry. Defaults to the target group ID.",
+            "type": "string"
+          },
+          "sourceArtifactId": {
+            "description": "Artifact ID in the source registry. Defaults to the target artifact ID.",
+            "type": "string"
+          },
+          "sourceVersion": {
+            "description": "Source version expression (a version id or `branch=latest`). Defaults to `branch=latest`.",
+            "type": "string",
+            "example": "5"
+          },
+          "compatibilityLevel": {
+            "description": "Compatibility level used for the compare report. Defaults to BACKWARD.",
+            "type": "string",
+            "enum": [
+              "BACKWARD",
+              "BACKWARD_TRANSITIVE",
+              "FORWARD",
+              "FORWARD_TRANSITIVE",
+              "FULL",
+              "FULL_TRANSITIVE",
+              "NONE"
+            ]
+          },
+          "preserveVersion": {
+            "description": "When true, the source version identifier is reused on the target. Defaults to false (auto-assigned).",
+            "type": "boolean"
+          }
+        }
+      },
+      "PromotionSource": {
+        "description": "A configured source registry used for promotion. Secrets are never included.",
+        "required": [
+          "name",
+          "url"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "auth": {
+            "description": "Authentication mode configured for this source: none, bearer, basic, or oauth2.",
+            "type": "string"
+          }
+        }
+      },
+      "PromotionCoordinate": {
+        "description": "Identifies an artifact version involved in a promotion.",
+        "type": "object",
+        "properties": {
+          "groupId": {
+            "type": "string"
+          },
+          "artifactId": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "artifactType": {
+            "type": "string"
+          }
+        }
+      },
+      "PromotionDiffLine": {
+        "description": "A single line in a unified-style content diff.",
+        "required": [
+          "op",
+          "text"
+        ],
+        "type": "object",
+        "properties": {
+          "op": {
+            "type": "string",
+            "enum": [
+              "added",
+              "removed"
+            ]
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "PromotionCompatibility": {
+        "description": "Result of checking whether source content is compatible with the current target version.",
+        "type": "object",
+        "properties": {
+          "level": {
+            "type": "string"
+          },
+          "compatible": {
+            "type": "boolean"
+          },
+          "differences": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PromotionCompatibilityDifference"
+            }
+          }
+        }
+      },
+      "PromotionCompatibilityDifference": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "context": {
+            "type": "string"
+          }
+        }
+      },
+      "PromotionCompareResult": {
+        "description": "Diff and compatibility report between a source version and the current target version.",
+        "type": "object",
+        "properties": {
+          "source": {
+            "$ref": "#/components/schemas/PromotionCoordinate"
+          },
+          "target": {
+            "$ref": "#/components/schemas/PromotionCoordinate"
+          },
+          "identical": {
+            "type": "boolean"
+          },
+          "contentDiff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PromotionDiffLine"
+            }
+          },
+          "compatibility": {
+            "$ref": "#/components/schemas/PromotionCompatibility"
+          }
+        }
+      },
+      "PromotionResult": {
+        "description": "Outcome of promoting a source version into this registry.",
+        "type": "object",
+        "properties": {
+          "alreadyPromoted": {
+            "description": "True when the latest target content already matched the source, so no new version was created.",
+            "type": "boolean"
+          },
+          "version": {
+            "$ref": "#/components/schemas/VersionMetaData"
+          },
+          "compare": {
+            "$ref": "#/components/schemas/PromotionCompareResult"
+          }
+        }
       },
       "SystemInfo": {
         "title": "Root Type for SystemInfo",
@@ -10608,6 +10972,10 @@
     {
       "name": "System",
       "description": "System level functionality, including versioning and status information."
+    },
+    {
+      "name": "Promotion",
+      "description": "Cross-registry schema promotion: fetch a version from a configured source registry, compare it with the local target, and copy it as an explicit promote action."
     },
     {
       "name": "Users",


### PR DESCRIPTION
Closes #10014

Parent epic: #7878
**Implements Phase 1 of #7878**

## Summary

- Adds a governed, **explicit** promotion API (not replication) so a target registry can fetch a version from a named source registry, show a diff + compatibility check, and copy it as a new version.
- This is only: REST fetch + compare + promote. It is **not** the data-contract `POST .../contract/promote` flow (labels on a single registry).
- Sources are configured per name (`apicurio.promotion.source.{name}.url`) with `none` / `bearer` / `basic` / `oauth2`. `local://` uses this instance (group-to-group / tests).

## API

- `GET /apis/registry/v3/system/promotion/sources`
- `POST /apis/registry/v3/groups/{groupId}/artifacts/{artifactId}/promotion/compare`
- `POST /apis/registry/v3/groups/{groupId}/artifacts/{artifactId}/promotion` (`?dryRun=true` supported)

Path `groupId` / `artifactId` are the **target**. Body `source` is the configured source name; `sourceGroupId` / `sourceArtifactId` / `sourceVersion` default to the target GAV and `branch=latest`.

If the latest target content already matches the source, no new version is created (`alreadyPromoted: true`). Promotion labels record source name/GAV. Target compatibility/validity rules still run on write.

## Test plan

- [ ] `mvn -pl common generate-sources -am -DskipTests` then compile `app`
- [ ] `mvn -pl app -am "-Dtest=CrossRegistryPromotionTest,ContentLineDiffTest,HttpPromotionSourceClientTest" "-Dsurefire.failIfNoSpecifiedTests=false" test
- [ ] `GET .../system/promotion/sources` lists configured sources (no secrets)
- [ ] Unknown `source` → 400
- [ ] Compare: `identical`, `contentDiff`, `compatibility`
- [ ] Promote creates a version; second promote of same content → `alreadyPromoted`
- [ ] Promote into a missing target artifact creates it
- [ ] (manual) `?dryRun=true` does not persist
- [ ] (manual) HTTP source against a second registry (`auth=none` or OAuth2)