### PR TITLE
chore(tooling): add OpenCode support via symlinks to .claude config

### DIFF
--- a/.claude/commands/plan-implementation.md
+++ b/.claude/commands/plan-implementation.md
@@ -67,6 +67,6 @@ Create a numbered list of implementation steps in logical order:
 
 ## Output
 
-Present the plan in a structured format and use the ExitPlanMode tool when ready for user approval.
+Present the plan in a structured format and ask the user for approval before implementing (using your tool's plan-approval mechanism if it has one).
 
 After plan approval, the user can run `/implement-changes` to execute the plan.

--- a/.opencode/commands/analyze-gh-issue.md
+++ b/.opencode/commands/analyze-gh-issue.md
@@ -1,0 +1,1 @@
+../../.claude/commands/analyze-gh-issue.md

--- a/.opencode/commands/debug-ci-failure.md
+++ b/.opencode/commands/debug-ci-failure.md
@@ -1,0 +1,1 @@
+../../.claude/commands/debug-ci-failure.md

--- a/.opencode/commands/implement-changes.md
+++ b/.opencode/commands/implement-changes.md
@@ -1,0 +1,1 @@
+../../.claude/commands/implement-changes.md

--- a/.opencode/commands/plan-implementation.md
+++ b/.opencode/commands/plan-implementation.md
@@ -1,0 +1,1 @@
+../../.claude/commands/plan-implementation.md

--- a/.opencode/commands/pr-description.md
+++ b/.opencode/commands/pr-description.md
@@ -1,0 +1,1 @@
+../../.claude/commands/pr-description.md

--- a/.opencode/commands/review-pr.md
+++ b/.opencode/commands/review-pr.md
@@ -1,0 +1,1 @@
+../../.claude/commands/review-pr.md

--- a/.opencode/commands/run-tests.md
+++ b/.opencode/commands/run-tests.md
@@ -1,0 +1,1 @@
+../../.claude/commands/run-tests.md

--- a/.opencode/skills/sdk-update
+++ b/.opencode/skills/sdk-update
@@ -1,0 +1,1 @@
+../../.claude/skills/sdk-update

--- a/.opencode/skills/security-review
+++ b/.opencode/skills/security-review
@@ -1,0 +1,1 @@
+../../.claude/skills/security-review

--- a/.opencode/skills/storage-variant-guide
+++ b/.opencode/skills/storage-variant-guide
@@ -1,0 +1,1 @@
+../../.claude/skills/storage-variant-guide

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,18 @@ Full contribution guidelines are in [CONTRIBUTING.md](CONTRIBUTING.md).
   { "hooks": { "Notification": [{ "matcher": "", "hooks": [{ "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/notify.sh" }] }] } }
   ```
 
+## OpenCode Configuration
+
+OpenCode is supported via symlinks into `.claude/`, so there is a single source of truth:
+
+- **Commands**: `.opencode/commands/*.md` symlink to `.claude/commands/*.md`
+- **Skills**: `.opencode/skills/<name>` symlinks to `.claude/skills/<name>`
+
+Edit the files under `.claude/`; OpenCode follows the symlinks and picks up changes on its
+next startup (OpenCode loads config once at startup — restart it after editing).
+When adding a new command or skill, create the real file in `.claude/` first, then add the
+matching symlink under `.opencode/`.
+
 ## MCP Integration
 
 The `mcp/` module provides an MCP server. Connect Claude Code to a running registry


### PR DESCRIPTION
## Summary

Adds first-class support for [OpenCode](https://opencode.ai) alongside the existing Claude Code configuration, using **symlinks** so there is a single source of truth and zero ongoing maintenance.

The project already commits its Claude Code setup (root `.claude/` is intentionally tracked, maintained by several contributors). This PR lets contributors who use OpenCode get the same slash commands and auto-invoked skills, without duplicating any content.

## How it works

```
.claude/                          <- the ONLY real files (single source of truth)
├── skills/{sdk-update, security-review, storage-variant-guide}/
└── commands/*.md (7 files)

.opencode/                        <- committed symlinks only
├── skills/<name>      -> ../../.claude/skills/<name>
└── commands/<name>.md -> ../../.claude/commands/<name>.md
```

- OpenCode's loader scans `.opencode/skills/**/SKILL.md` and `.opencode/commands/**/*.md`; it follows the symlinks and loads the same markdown both tools already use.
- OpenCode tolerates Claude-specific frontmatter keys (`allowed-tools`, `argument-hint`) — verified with `opencode debug skill` (all 3 skills load with correct name/description/content).
- Editing a file under `.claude/` updates both tools at once. No drift.

## Changes

- **`.opencode/skills/`**: 3 symlinks (`sdk-update`, `security-review`, `storage-variant-guide`)
- **`.opencode/commands/`**: 7 symlinks (`analyze-gh-issue`, `debug-ci-failure`, `implement-changes`, `plan-implementation`, `pr-description`, `review-pr`, `run-tests`)
- **`.claude/commands/plan-implementation.md`**: generalized one Claude-specific line (`ExitPlanMode` tool reference) to tool-neutral wording — "ask the user for approval (using your tool's plan-approval mechanism if it has one)". Works for both tools.
- **`CLAUDE.md`**: new "OpenCode Configuration" section documenting the symlink layout (`AGENTS.md` is a symlink to `CLAUDE.md`, so both stay in sync automatically).

## Test plan

- [x] `opencode debug skill` lists all 3 skills, loading through the symlinks
- [x] All 7 command symlinks resolve to well-formed markdown (`head` through each `.opencode/commands/*.md`)
- [x] Symlinks staged as git mode `120000` (true symlinks, not file copies)
- [x] Claude Code unaffected — same real files, only a wording generalization in one command
- [ ] Windows contributors: symlinks require `git config core.symlinks true` at clone time (same class of consideration as the existing `AGENTS.md -> CLAUDE.md` symlink already in the repo)

## Notes

- No runtime/build impact — documentation and tooling config only.
- OpenCode loads config once at startup, so users restart OpenCode to pick up new/changed commands and skills.