### PR TITLE
docs: add getting-started guide, SUPPORT.md, and issue-template contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,20 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "Usage question or help (CNCF Slack)"
+    url: https://cloud-native.slack.com/archives/C0BDWTC1DTM
+    about: "Ask how-to and usage questions in the #apicurio channel on CNCF Slack. New to CNCF Slack? Join at https://slack.cncf.io first."
+  - name: "Questions and answers (GitHub Discussions)"
+    url: https://github.com/Apicurio/apicurio-registry/discussions/categories/q-a
+    about: "Search existing answers, or ask a question that stays findable for the next person. Best for configuration, deployment, and integration help."
+  - name: "Feature idea or design discussion (GitHub Discussions)"
+    url: https://github.com/Apicurio/apicurio-registry/discussions/categories/ideas
+    about: "Share an idea and shape it with the community before opening a formal feature request."
+  - name: "Documentation"
+    url: https://www.apicur.io/registry/docs/
+    about: "Installation, configuration, and user guides. Many questions are already answered here."
+  - name: "Report a security vulnerability"
+    url: https://github.com/Apicurio/apicurio-registry/blob/main/SECURITY.md
+    about: "Please do not open a public issue for security problems. Follow the private disclosure process in SECURITY.md."
+  - name: "Not sure where to ask?"
+    url: https://github.com/Apicurio/apicurio-registry/blob/main/SUPPORT.md
+    about: "SUPPORT.md maps each kind of question or report to the channel that will get you the fastest answer."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ But first, read this page (including the small print at the end).
 
 * [Legal](#legal)
 * [Reporting an issue](#reporting-an-issue)
+* [Getting started and where to ask](#getting-started-and-where-to-ask)
 * [Before you contribute](#before-you-contribute)
   + [Code reviews](#code-reviews)
   + [Coding Guidelines](#coding-guidelines)
@@ -39,6 +40,18 @@ See [SECURITY.md](SECURITY.md) for details.
 For general questions and development discussions, use the
 [cncf-apicurio-registry-dev@lists.cncf.io](mailto:cncf-apicurio-registry-dev@lists.cncf.io) mailing list
 or the [#apicurio channel](https://cloud-native.slack.com/archives/C0BDWTC1DTM) on CNCF Slack.
+
+## Getting started and where to ask
+
+New here? This section points you to the right place for whatever you need.
+
+**Not sure where a question belongs?** [SUPPORT.md](SUPPORT.md) maps each kind of question or report to the channel that will answer it fastest, from usage questions and bugs to feature ideas and security reports.
+
+**Looking for a first issue?** Browse issues labelled [`good first issue`](https://github.com/Apicurio/apicurio-registry/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) or [`help wanted`](https://github.com/Apicurio/apicurio-registry/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22). When you find one, follow [Claiming an issue](#claiming-an-issue) to self-assign before you start, and ask in the issue if anything is unclear.
+
+**Building and running the project** is covered in [DEVELOPING.md](DEVELOPING.md): prerequisites, build options, running the server, running tests, and IDE setup.
+
+**New to open source, or joining through a mentorship program?** You are very welcome. Apicurio Registry is a CNCF Sandbox project and takes part in programs such as [LFX Mentorship](https://mentorship.lfx.linuxfoundation.org/) and [CNCF Mentoring](https://github.com/cncf/mentoring); general guidance for new CNCF contributors is collected at [contribute.cncf.io](https://contribute.cncf.io/). The guidelines on this page apply equally to mentees and first-time contributors. When in doubt, just ask in the issue or on Slack.
 
 ## Before you contribute
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,88 @@
+# Getting help with Apicurio Registry
+
+Thanks for using Apicurio Registry! This page explains where to get help and where each kind
+of question or report belongs, so you get an answer as quickly as possible and the next person
+can find it too.
+
+A quick search of the [documentation](https://www.apicur.io/registry/docs/) and the existing
+[Q&A discussions](https://github.com/Apicurio/apicurio-registry/discussions/categories/q-a)
+answers many common questions.
+
+## Where should I go?
+
+| What you need | Where to go |
+|---|---|
+| Ask a usage or "how do I..." question | The [#apicurio channel on CNCF Slack](https://cloud-native.slack.com/archives/C0BDWTC1DTM) for a quick chat, or [GitHub Discussions -> Q&A](https://github.com/Apicurio/apicurio-registry/discussions/categories/q-a) so the answer stays searchable |
+| Report a bug | [Open an issue](https://github.com/Apicurio/apicurio-registry/issues/new/choose) using the **Bug report** template |
+| Propose or discuss a feature or idea | Float it in [GitHub Discussions -> Ideas](https://github.com/Apicurio/apicurio-registry/discussions/categories/ideas) first, then open a [Feature request](https://github.com/Apicurio/apicurio-registry/issues/new/choose) once it is concrete |
+| Report a security vulnerability | Do **not** open a public issue. Follow the private disclosure process in [SECURITY.md](SECURITY.md) |
+| Contribute code or documentation | See [CONTRIBUTING.md](CONTRIBUTING.md) and [DEVELOPING.md](DEVELOPING.md) |
+| Read the documentation | The [Apicurio Registry documentation](https://www.apicur.io/registry/docs/) |
+
+New to CNCF Slack? Join at [slack.cncf.io](https://slack.cncf.io) first, then open the
+[#apicurio channel](https://cloud-native.slack.com/archives/C0BDWTC1DTM).
+
+## Before you ask
+
+You will get a faster, better answer if you:
+
+- Search the [documentation](https://www.apicur.io/registry/docs/) and the
+  [existing discussions](https://github.com/Apicurio/apicurio-registry/discussions) first, since
+  most questions have already been answered.
+- Include your **Apicurio Registry version**, your **persistence type** (`in-memory`, `sql`, or
+  `kafkasql`), and how you are deploying, so people can help without a round of back-and-forth.
+
+## Frequently asked questions
+
+These are the questions that come up most often. The answers link to the authoritative
+documentation so they stay current.
+
+**What is Apicurio Registry?**
+
+A registry for storing, managing, and validating API definitions and schemas (Avro, Protobuf,
+JSON Schema, OpenAPI, and more). It is a CNCF Sandbox project. See the
+[documentation](https://www.apicur.io/registry/docs/).
+
+**How do I install, run, or try it?**
+
+The quick start and the deployment options are in the
+[documentation](https://www.apicur.io/registry/docs/). To build from source, see
+[DEVELOPING.md](DEVELOPING.md).
+
+**Which storage or persistence type should I use?**
+
+Registry supports several, selected at runtime: `in-memory` (for trying it out), `sql` (a
+relational database such as PostgreSQL), and `kafkasql` (backed by Kafka). Configuration is
+covered in the [documentation](https://www.apicur.io/registry/docs/).
+
+**How do I use it with my Kafka producers and consumers?**
+
+Through the Apicurio Registry SerDes (serializer and deserializer) libraries. See the
+[documentation](https://www.apicur.io/registry/docs/).
+
+**Is it compatible with Confluent Schema Registry?**
+
+Yes. Registry exposes a compatibility REST API for Confluent Schema Registry clients. See the
+[documentation](https://www.apicur.io/registry/docs/).
+
+**How do I run it on Kubernetes?**
+
+There is an Apicurio Registry Operator and container images; the deployment guides are in the
+[documentation](https://www.apicur.io/registry/docs/).
+
+**Where are the REST API and client SDK references?**
+
+In the [documentation](https://www.apicur.io/registry/docs/).
+
+## Contributing
+
+Want to fix a bug, add a feature, or improve the docs? Start with
+[CONTRIBUTING.md](CONTRIBUTING.md), which covers picking and claiming an issue, the build and
+review process, and where to ask contributor questions. Build and IDE setup live in
+[DEVELOPING.md](DEVELOPING.md).
+
+## Community and Code of Conduct
+
+Apicurio Registry is a [Cloud Native Computing Foundation](https://cncf.io) Sandbox project.
+Everyone interacting in the project's spaces is expected to follow the
+[CNCF Code of Conduct](CODE_OF_CONDUCT.md). Please be kind and respectful; we are glad you are here.


### PR DESCRIPTION
Fixes #9316

## What

Routes recurring onboarding and usage questions to the right channel so they are answered once and stay searchable, instead of reaching maintainers individually.

- **`.github/ISSUE_TEMPLATE/config.yml`** (new): the "New issue" chooser now links the `#apicurio` CNCF Slack channel, GitHub Discussions (Q&A and Ideas), the documentation, and the private security process. Blank issues stay enabled.
- **`SUPPORT.md`** (new): the GitHub-native home for "where do I get help", with a question-to-channel routing table, a short "before you ask" checklist, and the topics that come up most often. GitHub surfaces this automatically in the new-issue flow and the community profile.
- **`CONTRIBUTING.md`**: a new "Getting started and where to ask" section (and ToC entry) pointing first-time contributors at the `good first issue` / `help wanted` labels, the existing claim flow, the build guide (`DEVELOPING.md`), and CNCF/LFX mentorship resources.

Each file has a distinct job, so nothing is duplicated: `config.yml` routes at issue-creation time, `SUPPORT.md` is for users seeking help, and `CONTRIBUTING.md` is for contributors.

## Notes

- Every link was verified against the live repo and web (Slack channel, both Discussions categories, both labels, docs, and the CNCF/LFX resources).
- The new files are YAML and Markdown, which carry no Apache license header in this repo (consistent with the existing issue templates, workflows, and root docs), so the license check is unaffected.