### PR TITLE
fix(config): activate experimental features gate with @Startup annota…

### DIFF
--- a/app/src/main/java/io/apicurio/registry/config/ExperimentalFeaturesConfig.java
+++ b/app/src/main/java/io/apicurio/registry/config/ExperimentalFeaturesConfig.java
@@ -3,6 +3,7 @@ package io.apicurio.registry.config;
 import io.apicurio.common.apps.config.ExperimentalConfigPropertyDef;
 import io.apicurio.common.apps.config.ExperimentalConfigPropertyList;
 import io.apicurio.common.apps.config.Info;
+import io.quarkus.runtime.Startup;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -25,6 +26,7 @@ import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_SYS
  * features (e.g., GitOps storage variant) require special checks below.</p>
  */
 @Singleton
+@Startup
 public class ExperimentalFeaturesConfig {
 
     @Inject


### PR DESCRIPTION
## Summary

The experimental features gate (`ExperimentalFeaturesConfig.validate()`) never runs because CDI never instantiates the bean. Adding `@Startup` ensures the bean is created at application startup and the validation logic executes.

Fixes #9630

## Problem

`ExperimentalFeaturesConfig` is a `@Singleton` bean with `@PostConstruct` validation, but nothing injects it and it has no `@Startup` annotation. CDI never instantiates the bean, so `validate()` never runs. This means:

- `gitops` and `kubernetesops` storage can be enabled without the experimental gate
- `@Info(experimental = true)` properties can be enabled without the gate
- Documentation claims that startup fails without the gate are false

## Solution

Added `@Startup` annotation to `ExperimentalFeaturesConfig` class. This is the same pattern used by `DynamicConfigStartup` in the codebase.

## Changes

- **ExperimentalFeaturesConfig.java**: Added `@Startup` annotation and import

## Testing

- Server should now fail at startup if experimental features are enabled without `apicurio.features.experimental.enabled=true`
- Existing tests should continue to pass