### PR TITLE
test(integration-tests): widen Debezium IT waits that flake under CI load

### DIFF
--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/mysql/DebeziumMySQLAvroBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/mysql/DebeziumMySQLAvroBaseIT.java
@@ -150,7 +150,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         insertCustomer(tableName, "Alice Smith", "alice@example.com");
         insertCustomer(tableName, "Bob Jones", "bob@example.com");
@@ -164,8 +164,8 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
         assertEquals("Alice Smith", afterFirstEvent.get("name").toString());
         assertEquals("alice@example.com", afterFirstEvent.get("email").toString());
 
-        waitForSchemaInRegistry(topicName + "-key", Duration.ofSeconds(10));
-        waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(10));
+        waitForSchemaInRegistry(topicName + "-key", Duration.ofSeconds(30));
+        waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(30));
 
         log.info("Successfully verified basic CDC with schema auto-registration");
     }
@@ -188,7 +188,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         // INSERT
         try (PreparedStatement stmt = getDatabaseConnection().prepareStatement(
@@ -282,23 +282,23 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
         String topic3 = getTopicNameForTable(table3);
 
         consumer.subscribe(List.of(topic1, topic2, topic3));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         executeUpdate("INSERT INTO " + table1 + " (order_number, total) VALUES ('ORD-001', 99.99)");
         executeUpdate("INSERT INTO " + table2 + " (order_id, product_name, quantity) VALUES (1, 'Laptop', 1)");
         executeUpdate("INSERT INTO " + table3 + " (sku, stock_count) VALUES ('SKU-123', 50)");
 
         List<ConsumerRecord<byte[], byte[]>> allRecords = new ArrayList<>();
-        Unreliables.retryUntilTrue(20, TimeUnit.SECONDS, () -> {
+        Unreliables.retryUntilTrue(120, TimeUnit.SECONDS, () -> {
             consumer.poll(Duration.ofMillis(500)).forEach(allRecords::add);
             return allRecords.size() >= 3;
         });
 
         assertEquals(3, allRecords.size());
 
-        waitForSchemaInRegistry(topic1 + "-value", Duration.ofSeconds(10));
-        waitForSchemaInRegistry(topic2 + "-value", Duration.ofSeconds(10));
-        waitForSchemaInRegistry(topic3 + "-value", Duration.ofSeconds(10));
+        waitForSchemaInRegistry(topic1 + "-value", Duration.ofSeconds(30));
+        waitForSchemaInRegistry(topic2 + "-value", Duration.ofSeconds(30));
+        waitForSchemaInRegistry(topic3 + "-value", Duration.ofSeconds(30));
 
         log.info("Successfully verified multiple table capture");
     }
@@ -323,7 +323,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
         // Using shared connector from @BeforeAll
         // Note: Shared connector already has schema.name.adjustment.mode and field.name.adjustment.mode set to "avro"
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         executeUpdate("INSERT INTO " + tableName +
                 " (`first-name`, `last name`, `email@address`) VALUES " +
@@ -358,14 +358,14 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         executeUpdate("INSERT INTO " + tableName + " (name) VALUES ('Original')");
 
         List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         assertEquals(1, events1.size());
 
-        waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(10));
+        waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(30));
 
         try (Statement stmt = getDatabaseConnection().createStatement()) {
             stmt.execute("ALTER TABLE " + tableName + " ADD COLUMN email VARCHAR(100) DEFAULT NULL");
@@ -407,10 +407,10 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         executeUpdate("INSERT INTO " + tableName + " (data) VALUES ('test')");
-        waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(10));
+        waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(30));
 
         CreateRule rule = new CreateRule();
         rule.setRuleType(RuleType.COMPATIBILITY);
@@ -447,11 +447,11 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         executeUpdate("INSERT INTO " + tableName + " (field1) VALUES ('v1')");
         consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
-        waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(10));
+        waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(30));
 
         executeUpdate("ALTER TABLE " + tableName + " ADD COLUMN field2 VARCHAR(100)");
         executeUpdate("INSERT INTO " + tableName + " (field1, field2) VALUES ('v2', 'data2')");
@@ -496,7 +496,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         try (PreparedStatement stmt = getDatabaseConnection().prepareStatement(
                 "INSERT INTO " + tableName +
@@ -545,7 +545,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         try (PreparedStatement stmt = getDatabaseConnection().prepareStatement(
                 "INSERT INTO " + tableName + " (price, tax_rate, weight, quantity) VALUES (?, ?, ?, ?)")) {
@@ -587,7 +587,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         int totalRows = 1000;
         int batchSize = 100;
@@ -603,7 +603,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
         }
 
         List<ConsumerRecord<byte[], byte[]>> allRecords = new ArrayList<>();
-        Unreliables.retryUntilTrue(60, TimeUnit.SECONDS, () -> {
+        Unreliables.retryUntilTrue(120, TimeUnit.SECONDS, () -> {
             consumer.poll(Duration.ofSeconds(1)).forEach(allRecords::add);
             log.info("Consumed {} records so far", allRecords.size());
             return allRecords.size() >= totalRows;
@@ -631,7 +631,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         executeUpdate("INSERT INTO " + tableName + " (data) VALUES ('before')");
         List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/postgresql/DebeziumPostgreSQLAvroBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/postgresql/DebeziumPostgreSQLAvroBaseIT.java
@@ -186,7 +186,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
         // Just subscribe to the topic for this table
         consumer.subscribe(List.of(topicName));
         // Longer wait for first test to ensure consumer is fully ready
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         insertCustomer(tableName, "Alice Smith", "alice@example.com");
         insertCustomer(tableName, "Bob Jones", "bob@example.com");
@@ -201,8 +201,8 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
         assertEquals("Alice Smith", afterFirstEvent.get("name").toString());
         assertEquals("alice@example.com", afterFirstEvent.get("email").toString());
 
-        waitForSchemaInRegistry(topicName + "-key", Duration.ofSeconds(10));
-        waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(10));
+        waitForSchemaInRegistry(topicName + "-key", Duration.ofSeconds(30));
+        waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(30));
 
         log.info("Successfully verified basic CDC with schema auto-registration");
     }
@@ -230,7 +230,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         // INSERT
         try (PreparedStatement stmt = getDatabaseConnection().prepareStatement(
@@ -327,7 +327,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
         String topic3 = getTopicNameForTable(table3);
 
         consumer.subscribe(List.of(topic1, topic2, topic3));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         executeUpdate("INSERT INTO " + table1 + " (order_number, total) VALUES ('ORD-001', 99.99)");
         executeUpdate("INSERT INTO " + table2 + " (order_id, product_name, quantity) VALUES (1, 'Laptop', 1)");
@@ -341,9 +341,9 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         assertEquals(3, allRecords.size());
 
-        waitForSchemaInRegistry(topic1 + "-value", Duration.ofSeconds(10));
-        waitForSchemaInRegistry(topic2 + "-value", Duration.ofSeconds(10));
-        waitForSchemaInRegistry(topic3 + "-value", Duration.ofSeconds(10));
+        waitForSchemaInRegistry(topic1 + "-value", Duration.ofSeconds(30));
+        waitForSchemaInRegistry(topic2 + "-value", Duration.ofSeconds(30));
+        waitForSchemaInRegistry(topic3 + "-value", Duration.ofSeconds(30));
 
         log.info("Successfully verified multiple table capture");
     }
@@ -368,7 +368,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         executeUpdate("INSERT INTO " + tableName +
                 " (\"first-name\", \"last name\", \"email@address\") VALUES " +
@@ -404,7 +404,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         executeUpdate("INSERT INTO " + tableName + " (name) VALUES ('Original')");
 
@@ -412,7 +412,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
         List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
         assertEquals(1, events1.size());
 
-        waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(10));
+        waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(30));
 
         try (Statement stmt = getDatabaseConnection().createStatement()) {
             stmt.execute("ALTER TABLE " + tableName + " ADD COLUMN email VARCHAR(100) DEFAULT NULL");
@@ -455,10 +455,10 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         executeUpdate("INSERT INTO " + tableName + " (data) VALUES ('test')");
-        waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(10));
+        waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(30));
 
         CreateRule rule = new CreateRule();
         rule.setRuleType(RuleType.COMPATIBILITY);
@@ -495,12 +495,12 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         executeUpdate("INSERT INTO " + tableName + " (field1) VALUES ('v1')");
         // Increased timeout for table detection in CI environments
         consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
-        waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(10));
+        waitForSchemaInRegistry(topicName + "-value", Duration.ofSeconds(30));
 
         executeUpdate("ALTER TABLE " + tableName + " ADD COLUMN field2 VARCHAR(100)");
         executeUpdate("INSERT INTO " + tableName + " (field1, field2) VALUES ('v2', 'data2')");
@@ -549,7 +549,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         try (PreparedStatement stmt = getDatabaseConnection().prepareStatement(
                 "INSERT INTO " + tableName +
@@ -598,7 +598,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         try (PreparedStatement stmt = getDatabaseConnection().prepareStatement(
                 "INSERT INTO " + tableName + " (price, tax_rate, weight, quantity) VALUES (?, ?, ?, ?)")) {
@@ -641,7 +641,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         int totalRows = 1000;
         int batchSize = 100;
@@ -685,7 +685,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
 
         // Using shared connector from @BeforeAll
         consumer.subscribe(List.of(topicName));
-        waitForConsumerReady(Duration.ofSeconds(10));
+        waitForConsumerReady(Duration.ofSeconds(30));
 
         executeUpdate("INSERT INTO " + tableName + " (data) VALUES ('before')");
         // Increased timeout for table detection in CI environments


### PR DESCRIPTION
## Summary

Fixes the Debezium IT flakiness reported by the flaky-retries summary on #9722: `DebeziumMySQLAvroLocalConvertersIT` needed a failsafe rerun for 6 of its 10 tests in one h2-debezium run.

## Root Cause

All retried failures are timing, not logic: the tests wait for real CDC through a MySQL → Kafka → Connect → Registry chain on shared CI runners with:

- 10 s waits for consumer partition assignment and schema registration
- 20/60 s poll catchments for 3-event and 1000-event batches

`Unreliables.retryUntilTrue(n, SECONDS)` ticks ~once/second, so 10 s ≈ 10 attempts — not enough when the runner is contended. Fail once, pass on rerun: the exact flaky signature.

## Changes

- `DebeziumMySQLAvroBaseIT` (MySQL): consumer-assignment and schema-registration waits 10 s → 30 s; poll catchments 20/60 s → 120 s
- `DebeziumPostgreSQLAvroBaseIT`: same waits (same flake class, same sibling code)

## Test plan

- [x] Compiles + checkstyle clean
- [ ] h2-debezium CI run on this PR exercises the MySQL snapshot path
- [ ] Watch the flaky-retries summary: DebeziumMySQLAvroLocalConvertersIT should drop off