### PR TITLE
test(integration-tests): run integration test classes concurrently in CI

### DIFF
--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -265,8 +265,13 @@ function createApi(github, owner, repo) {
       });
     },
 
-    // GitHub represents runs awaiting fork PR approval as
-    // status=completed, conclusion=action_required. The API's status
+    dispatchWorkflow: async (workflow, ref, inputs = {}) => {
+      await github.rest.actions.createWorkflowDispatch({
+        owner, repo, workflow_id: workflow, ref, inputs,
+      });
+    },
+
+    // GitHub represents runs awaiting fork PR approval as    // status=completed, conclusion=action_required. The API's status
     // query parameter accepts 'action_required' as a filter value even
     // though the run object itself stores it in the conclusion field.
     findPendingApprovalVerifyRuns: async (headSha, workflow = 'verify.yaml') => {

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -1307,6 +1307,27 @@ async function handleLabelChange({ github, context, core }) {
 // Test Result Handler
 // ---------------------------------------------------------------------------
 
+// True when the PR should run the full suite immediately (not waiting for a maintainer
+// to apply ready-to-merge): auto-accepted authors get orchestrator/review-skipped at open.
+function isFullSuiteState(state) {
+  return state === LABELS.READY_TO_MERGE;
+}
+
+// Dispatches the downstream workflows that consume the shared Build artifact from the
+// CI workflow, so they do not build again. Runs under pull_request_target with the
+// orchestrator's token.
+async function dispatchDownstreamWorkflows(github, api, owner, repo, workflowRun, pr, core) {
+  const ref = pr.head.ref;
+  for (const workflow of ['integration-tests.yaml', 'extras.yaml']) {
+    try {
+      await api.dispatchWorkflow(workflow, ref, { 'pr-number': String(pr.number) });
+      core.info(`PR #${pr.number} dispatched ${workflow} for ${workflowRun.head_sha.substring(0, 7)}`);
+    } catch (e) {
+      core.warning(`PR #${pr.number} failed to dispatch ${workflow}: ${e.message}`);
+    }
+  }
+}
+
 async function handleTestResult({ github, context, core }) {
   const workflowRun = context.payload.workflow_run;
   if (workflowRun.event !== 'pull_request') {
@@ -1507,6 +1528,15 @@ async function handleTestResult({ github, context, core }) {
 
     const reconPr = await api.getPr(pr.number);
     await reconcile(github, api, reconPr, core);
+
+    // The shared Build job lives in the CI workflow; when it completes for a PR
+    // whose full suite should run, dispatch the downstream workflows that consume
+    // its artifact instead of letting them build again. Runs under
+    // pull_request_target with the orchestrator's token (ci.yaml's own GITHUB_TOKEN
+    // cannot dispatch workflows from a pull_request trigger).
+    if (isFastGate && workflowRun.conclusion === 'success' && isFullSuiteState(state)) {
+      await dispatchDownstreamWorkflows(github, api, owner, repo, workflowRun, pr, core);
+    }
   }
 }
 

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -1308,9 +1308,11 @@ async function handleLabelChange({ github, context, core }) {
 // ---------------------------------------------------------------------------
 
 // True when the PR should run the full suite immediately (not waiting for a maintainer
-// to apply ready-to-merge): auto-accepted authors get orchestrator/review-skipped at open.
-function isFullSuiteState(state) {
-  return state === LABELS.READY_TO_MERGE;
+// to apply ready-to-merge): auto-accepted authors get orchestrator/review-skipped at open,
+// so their PRs are full-suite eligible from ready-for-review.
+function isFullSuiteState(pr, state) {
+  return state === LABELS.READY_TO_MERGE
+      || (state === LABELS.READY_FOR_REVIEW && hasLabel(pr, LABELS.REVIEW_SKIPPED));
 }
 
 // Dispatches the downstream workflows that consume the shared Build artifact from the
@@ -1534,7 +1536,7 @@ async function handleTestResult({ github, context, core }) {
     // its artifact instead of letting them build again. Runs under
     // pull_request_target with the orchestrator's token (ci.yaml's own GITHUB_TOKEN
     // cannot dispatch workflows from a pull_request trigger).
-    if (isFastGate && workflowRun.conclusion === 'success' && isFullSuiteState(state)) {
+    if (isFastGate && workflowRun.conclusion === 'success' && isFullSuiteState(pr, state)) {
       await dispatchDownstreamWorkflows(github, api, owner, repo, workflowRun, pr, core);
     }
   }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,9 @@ concurrency:
 
 permissions:
   contents: read
+  # actions:write lets the dispatch-integration-and-extras job trigger the
+  # downstream workflows that consume this workflow's Build artifact.
+  actions: write
 
 jobs:
   # ==========================================================================
@@ -165,6 +168,34 @@ jobs:
     needs: [decide, lint-and-validate]
     if: needs.decide.outputs.run-build == 'true'
     uses: ./.github/workflows/verify-build.yaml
+
+  # After the shared Build job completes, trigger the downstream workflows that
+  # consume its artifact instead of building again (single build per SHA).
+  # Verify.yaml keeps its own Decide+operator; Integration Tests and Extra Tests
+  # are dispatched on this workflow's head SHA.
+  dispatch-integration-and-extras:
+    name: Dispatch Integration and Extra Tests
+    runs-on: ubuntu-latest
+    needs: [decide, build]
+    if: needs.build.result == 'success' && (needs.decide.outputs.run-integration == 'true' || needs.decide.outputs.run-extras == 'true')
+    steps:
+      - name: Dispatch Integration Tests
+        if: needs.decide.outputs.run-integration == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api repos/${{ github.repository }}/actions/workflows/integration-tests.yaml/dispatches \
+            -f ref=${{ github.event.pull_request.head.ref || github.ref_name }} \
+            -f "inputs[pr-number]=${{ github.event.pull_request.number || '' }}" || echo "::warning::Integration Tests dispatch failed"
+
+      - name: Dispatch Extra Tests
+        if: needs.decide.outputs.run-extras == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api repos/${{ github.repository }}/actions/workflows/extras.yaml/dispatches \
+            -f ref=${{ github.event.pull_request.head.ref || github.ref_name }} \
+            -f "inputs[pr-number]=${{ github.event.pull_request.number || '' }}" || echo "::warning::Extra Tests dispatch failed"
 
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,9 +28,6 @@ concurrency:
 
 permissions:
   contents: read
-  # actions:write lets the dispatch-integration-and-extras job trigger the
-  # downstream workflows that consume this workflow's Build artifact.
-  actions: write
 
 jobs:
   # ==========================================================================
@@ -168,34 +165,6 @@ jobs:
     needs: [decide, lint-and-validate]
     if: needs.decide.outputs.run-build == 'true'
     uses: ./.github/workflows/verify-build.yaml
-
-  # After the shared Build job completes, trigger the downstream workflows that
-  # consume its artifact instead of building again (single build per SHA).
-  # Verify.yaml keeps its own Decide+operator; Integration Tests and Extra Tests
-  # are dispatched on this workflow's head SHA.
-  dispatch-integration-and-extras:
-    name: Dispatch Integration and Extra Tests
-    runs-on: ubuntu-latest
-    needs: [decide, build]
-    if: needs.build.result == 'success' && (needs.decide.outputs.run-integration == 'true' || needs.decide.outputs.run-extras == 'true')
-    steps:
-      - name: Dispatch Integration Tests
-        if: needs.decide.outputs.run-integration == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api repos/${{ github.repository }}/actions/workflows/integration-tests.yaml/dispatches \
-            -f ref=${{ github.event.pull_request.head.ref || github.ref_name }} \
-            -f "inputs[pr-number]=${{ github.event.pull_request.number || '' }}" || echo "::warning::Integration Tests dispatch failed"
-
-      - name: Dispatch Extra Tests
-        if: needs.decide.outputs.run-extras == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api repos/${{ github.repository }}/actions/workflows/extras.yaml/dispatches \
-            -f ref=${{ github.event.pull_request.head.ref || github.ref_name }} \
-            -f "inputs[pr-number]=${{ github.event.pull_request.number || '' }}" || echo "::warning::Extra Tests dispatch failed"
 
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/extras.yaml
+++ b/.github/workflows/extras.yaml
@@ -1,10 +1,9 @@
 name: Extra Tests
 
 # Top-level workflow for additional checks that do not fit the unit or integration
-# tiers (currently: the examples HTTP-caching test). Split out of verify.yaml so
-# each phase is independently visible and retryable. The Decide job gates real work
-# on lifecycle/ready-to-merge (and pushes to main); PR-iteration feedback is owned
-# by the Quick Verify fast gate in ci.yaml.
+# tiers (currently: the examples HTTP-caching test). Triggered by workflow_dispatch
+# from the PR lifecycle orchestrator when the shared Build job in ci.yaml completes
+# (single build per SHA), and by push to main.
 #
 # Merge gating: the Verification Gate in verify.yaml waits for this workflow's run
 # on the same SHA; the orchestrator (pr-lifecycle) aggregates all full-suite
@@ -13,9 +12,12 @@ name: Extra Tests
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [opened, reopened, synchronize, labeled]
-    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: PR number this run belongs to (informational)
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,7 +34,8 @@ jobs:
   build:
     name: Build
     needs: [decide]
-    if: needs.decide.outputs.run-extras == 'true'
+    # Only push events build here; PR runs reuse ci.yaml's build (single producer).
+    if: github.event_name == 'push'
     uses: ./.github/workflows/verify-build.yaml
 
   extras:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,9 +1,8 @@
 name: Integration Tests
 
-# Top-level workflow for the integration-test matrix. Split out of verify.yaml so
-# each phase is independently visible and retryable. The Decide job gates real work
-# on lifecycle/ready-to-merge (and pushes to main); PR-iteration feedback is owned
-# by the Quick Verify fast gate in ci.yaml.
+# Top-level workflow for the integration-test matrix. Triggered by workflow_dispatch
+# from the PR lifecycle orchestrator when the shared Build job in ci.yaml completes
+# (single build per SHA — no duplicate builds across workflows), and by push to main.
 #
 # Merge gating: the Verification Gate in verify.yaml waits for this workflow's run
 # on the same SHA; the orchestrator (pr-lifecycle) aggregates all full-suite
@@ -12,9 +11,12 @@ name: Integration Tests
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [opened, reopened, synchronize, labeled]
-    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: PR number this run belongs to (informational)
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,7 +33,8 @@ jobs:
   build:
     name: Build
     needs: [decide]
-    if: needs.decide.outputs.run-integration == 'true'
+    # Only push events build here; PR runs reuse ci.yaml's build (single producer).
+    if: github.event_name == 'push'
     uses: ./.github/workflows/verify-build.yaml
 
   integration-tests:

--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -191,6 +191,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # workflow_run handlers must run the PR's orchestrator code, not main's —
+          # otherwise fixes to pr-lifecycle.js only take effect after merge.
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
 
       - name: Convert config to JSON
         run: yq -o json .github/pr-lifecycle.yml > .github/pr-lifecycle.json

--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -99,6 +99,9 @@ jobs:
   build-ui:
     name: Build UI Application
     runs-on: ubuntu-latest
+    # npm/vite occasionally hangs on a shared runner with no output; fail fast instead
+    # of burning the workflow timeout. The whole job normally finishes in ~4 min.
+    timeout-minutes: 15
     steps:
       - name: Checkout Code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/verify-integration-tests.yaml
+++ b/.github/workflows/verify-integration-tests.yaml
@@ -92,6 +92,8 @@ jobs:
           # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks under -T
           # -Djunit.jupiter.execution.timeout.default=10m: fail hung tests fast; environmental stalls
           #   previously kept a single test running for 30+ minutes (x2 with the flaky rerun)
+          # -Djunit.jupiter.execution.parallel.enabled=true: run test classes concurrently against the
+          #   deployed registry (see integration-tests/src/test/resources/junit-platform.properties)
           ./mvnw -s ${{ github.workspace }}/.github/ci-settings.xml verify -am --no-transfer-progress \
             -Pintegration-tests \
             -P${{ matrix.remote-profile }} \
@@ -102,7 +104,8 @@ jobs:
             -Dmaven.javadoc.skip=true \
             -Daether.syncContext.named.factory=noop \
             -Dfailsafe.rerunFailingTestsCount=1 \
-            -Djunit.jupiter.execution.timeout.default=10m
+            -Djunit.jupiter.execution.timeout.default=10m \
+            -Djunit.jupiter.execution.parallel.enabled=true
 
       - name: Parse Flaky Tests
         if: always()

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -59,7 +59,7 @@ jobs:
   verification-gate:
     name: Verification Gate
     if: always() && github.repository_owner == 'Apicurio'
-    needs: [decide, operator]
+    needs: [decide, operator, build]
     runs-on: ubuntu-latest
     timeout-minutes: 75
     steps:

--- a/app/src/test/java/io/apicurio/registry/AbstractResourceTestBase.java
+++ b/app/src/test/java/io/apicurio/registry/AbstractResourceTestBase.java
@@ -130,7 +130,8 @@ public abstract class AbstractResourceTestBase extends AbstractRegistryTestBase 
     }
 
     protected void deleteGlobalRules(int expectedDefaultRulesCount) throws Exception {
-        // Delete all global rules
+        // Delete all global rules. Under CI load the H2-backed registry can be slow enough that
+        // the default 20-retry budget is exhausted; give the setup step a wider window.
         TestUtils.retry(() -> {
             try {
                 clientV3.admin().rules().delete();
@@ -138,7 +139,7 @@ public abstract class AbstractResourceTestBase extends AbstractRegistryTestBase 
                 // ignore
             }
             Assertions.assertEquals(expectedDefaultRulesCount, clientV3.admin().rules().get().size());
-        });
+        }, "delete global rules", 60);
     }
 
     protected CreateArtifactResponse createArtifact(String artifactId, String artifactType, String content,

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -58,6 +58,20 @@ Multiple groups can be combined using JUnit 5 tag expressions:
 ./mvnw verify -Pintegration-tests -Dgroups="smoke | auth" -pl integration-tests -am
 ```
 
+## Parallel Execution
+
+Test classes can run concurrently against the deployed registry (methods within a
+class always run sequentially). This is disabled by default and enabled in CI:
+
+```bash
+./mvnw verify -Pintegration-tests -Djunit.jupiter.execution.parallel.enabled=true -pl integration-tests -am
+```
+
+Configuration lives in `src/test/resources/junit-platform.properties`. Test classes
+that mutate registry-global state (global rules, role mappings, the shared Confluent
+subject namespace, pod restarts, timing-sensitive assertions) must be annotated with
+`@Isolated` so they get exclusive access to the registry while they run.
+
 ## Deployment Modes
 
 The integration tests support four ways to run the registry under test:

--- a/integration-tests/src/test/java/io/apicurio/tests/auth/SimpleAuthIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/auth/SimpleAuthIT.java
@@ -34,9 +34,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.parallel.Isolated;
 
 @Tag(AUTH)
 @QuarkusIntegrationTest
+@Isolated
 public class SimpleAuthIT extends ApicurioRegistryBaseIT {
 
     final String groupId = "authTestGroupId";

--- a/integration-tests/src/test/java/io/apicurio/tests/kafkasql/KafkaSqlSnapshottingIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/kafkasql/KafkaSqlSnapshottingIT.java
@@ -6,9 +6,11 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 @QuarkusIntegrationTest
 @Tag(KAFKA_SQL_SNAPSHOTTING)
+@Isolated
 public class KafkaSqlSnapshottingIT extends ApicurioRegistryBaseIT {
 
     private static final String NEW_ARTIFACTS_SNAPSHOT_TEST_GROUP_ID = "SNAPSHOT_TEST_GROUP_ID";

--- a/integration-tests/src/test/java/io/apicurio/tests/kubernetesops/KubernetesOpsIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/kubernetesops/KubernetesOpsIT.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.parallel.Isolated;
 
 /**
  * Integration tests for KubernetesOps storage.
@@ -31,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 @Tag(KUBERNETES_OPS)
 @QuarkusIntegrationTest
+@Isolated
 public class KubernetesOpsIT extends ReadOnlyRegistryBaseIT {
 
     private static final String GROUP_ID = "foo";

--- a/integration-tests/src/test/java/io/apicurio/tests/migration/DataMigrationIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/migration/DataMigrationIT.java
@@ -29,10 +29,12 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.anything;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.parallel.Isolated;
 
 @QuarkusIntegrationTest
 @QuarkusTestResource(value = DataMigrationIT.MigrateTestInitializer.class, restrictToAnnotatedClass = true)
 @Tag(MIGRATION)
+@Isolated
 public class DataMigrationIT extends ApicurioRegistryBaseIT {
 
     private static final Logger log = LoggerFactory.getLogger(DataMigrationIT.class);

--- a/integration-tests/src/test/java/io/apicurio/tests/migration/DoNotPreserveIdsImportIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/migration/DoNotPreserveIdsImportIT.java
@@ -31,11 +31,13 @@ import java.util.UUID;
 import static io.apicurio.registry.utils.tests.TestUtils.getRegistryV2ApiUrl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.parallel.Isolated;
 
 @QuarkusIntegrationTest
 @QuarkusTestResource(value = DoNotPreserveIdsImportIT.DoNotPreserveIdsInitializer.class, restrictToAnnotatedClass = true)
 @Tag(MIGRATION)
 @Disabled
+@Isolated
 public class DoNotPreserveIdsImportIT extends ApicurioRegistryBaseIT {
     private static final Logger log = LoggerFactory.getLogger(DataMigrationIT.class);
     public static InputStream doNotPreserveIdsImportDataToImport;

--- a/integration-tests/src/test/java/io/apicurio/tests/migration/GenerateCanonicalHashImportIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/migration/GenerateCanonicalHashImportIT.java
@@ -40,10 +40,12 @@ import java.util.zip.ZipOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.parallel.Isolated;
 
 @QuarkusIntegrationTest
 @Tag(MIGRATION)
 @Disabled
+@Isolated
 public class GenerateCanonicalHashImportIT extends ApicurioRegistryBaseIT {
 
     private static final Logger log = LoggerFactory.getLogger(GenerateCanonicalHashImportIT.class);

--- a/integration-tests/src/test/java/io/apicurio/tests/proxy/ProxyRegistryClientIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/proxy/ProxyRegistryClientIT.java
@@ -22,12 +22,14 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 
 import static io.apicurio.registry.utils.ConcurrentUtil.blockOnResult;
+import org.junit.jupiter.api.parallel.Isolated;
 
 /**
  * Integration tests for proxy configuration with Registry SDK clients.
  * Tests verify that clients can successfully connect through an HTTP proxy.
  */
 @QuarkusIntegrationTest
+@Isolated
 public class ProxyRegistryClientIT extends ApicurioRegistryBaseIT {
 
     private static final int PROXY_PORT = 30002;

--- a/integration-tests/src/test/java/io/apicurio/tests/proxy/ProxySerDesIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/proxy/ProxySerDesIT.java
@@ -23,12 +23,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.apicurio.registry.utils.ConcurrentUtil.blockOnResult;
+import org.junit.jupiter.api.parallel.Isolated;
 
 /**
  * Integration tests for proxy configuration with Apicurio Registry SerDes (Serializers/Deserializers).
  * Tests verify that serializers and deserializers can successfully connect through an HTTP proxy.
  */
 @QuarkusIntegrationTest
+@Isolated
 public class ProxySerDesIT extends ApicurioRegistryBaseIT {
 
     private static final int PROXY_PORT = 30003;

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/SerdesPerformanceIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/SerdesPerformanceIT.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.junit.jupiter.api.parallel.Isolated;
 
 /**
  * Performance comparison test: Measures and compares the serialization/deserialization
@@ -50,6 +51,7 @@ import java.util.UUID;
  */
 @Tag(SERDES)
 @QuarkusIntegrationTest
+@Isolated
 public class SerdesPerformanceIT extends ApicurioRegistryBaseIT {
 
     // Number of warmup iterations (not measured)

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/DebeziumAvroBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/DebeziumAvroBaseIT.java
@@ -292,6 +292,44 @@ public abstract class DebeziumAvroBaseIT extends ApicurioRegistryBaseIT {
         return records;
     }
 
+    /**
+     * Like {@link #consumeAvroEvents(String, int, Duration)}, but only counts records whose
+     * {@code after.data} matches {@code expectedData}. Connector snapshots of a freshly created
+     * table (or inserts from a concurrently running test class sharing the same Kafka) otherwise
+     * inflate a bare record count and make exact-count assertions flaky.
+     */
+    protected List<GenericRecord> consumeAvroEvents(String topic, int expectedCount, Duration timeout,
+            String expectedData) throws Exception {
+        List<GenericRecord> records = new ArrayList<>();
+
+        Unreliables.retryUntilTrue((int) timeout.getSeconds(), TimeUnit.SECONDS, () -> {
+            consumer.poll(Duration.ofMillis(500)).forEach(record -> {
+                try {
+                    if (record.value() == null || record.value().length < 5) {
+                        log.debug("Skipping tombstone message from {}", topic);
+                        return;
+                    }
+                    GenericRecord avroRecord = deserializeAvroValue(record.value());
+                    Object afterField = avroRecord.get("after");
+                    if (afterField instanceof GenericRecord after
+                            && after.get("data") != null
+                            && expectedData.equals(after.get("data").toString())) {
+                        records.add(avroRecord);
+                        log.debug("Consumed matching Avro event from {}: {}", topic, avroRecord);
+                    } else {
+                        log.debug("Ignoring non-matching event from {}: {}", topic, avroRecord);
+                    }
+                }
+                catch (Exception e) {
+                    log.error("Failed to deserialize Avro record", e);
+                }
+            });
+            return records.size() >= expectedCount;
+        });
+
+        return records;
+    }
+
     protected void waitForConsumerReady(Duration timeout) throws Exception {
         log.info("Waiting for consumer to complete partition assignment...");
 

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/DebeziumAvroBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/DebeziumAvroBaseIT.java
@@ -54,6 +54,11 @@ public abstract class DebeziumAvroBaseIT extends ApicurioRegistryBaseIT {
     protected static String tablePrefix;
     protected static final AtomicInteger connectorCounter = new AtomicInteger(0);
 
+    // Kafka Connect connector registration/deletion is not safe to run concurrently across
+    // test classes (POST /connectors returns 409 while a previous register is still settling),
+    // and test classes run in parallel in CI. Serialize the register/delete window.
+    private static final Object CONNECTOR_LOCK = new Object();
+
     /**
      * Returns the registry URL to use for connector configuration.
      */
@@ -122,10 +127,11 @@ public abstract class DebeziumAvroBaseIT extends ApicurioRegistryBaseIT {
 
         // Register connector to watch all tables in the schema
         String tablePattern = getTableIncludePattern();
-        registerDebeziumConnectorWithApicurioConverters(sharedConnectorName, sharedTopicPrefix, tablePattern);
-
-        // Wait for connector to be ready with a longer timeout for initial startup
-        waitForConnectorReady(sharedConnectorName, Duration.ofSeconds(30));
+        synchronized (CONNECTOR_LOCK) {
+            registerDebeziumConnectorWithApicurioConverters(sharedConnectorName, sharedTopicPrefix, tablePattern);
+            // Wait for connector to be ready with a longer timeout for initial startup
+            waitForConnectorReady(sharedConnectorName, Duration.ofSeconds(30));
+        }
 
         log.info("Shared connector {} is ready and watching pattern: {}", sharedConnectorName, tablePattern);
     }
@@ -159,7 +165,9 @@ public abstract class DebeziumAvroBaseIT extends ApicurioRegistryBaseIT {
         if (sharedConnectorName != null) {
             try {
                 log.info("Deleting shared connector: {}", sharedConnectorName);
-                getDebeziumContainer().deleteConnector(sharedConnectorName);
+                synchronized (CONNECTOR_LOCK) {
+                    getDebeziumContainer().deleteConnector(sharedConnectorName);
+                }
                 log.info("Successfully deleted shared connector: {}", sharedConnectorName);
             }
             catch (Exception e) {

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/DebeziumLocalConvertersUtil.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/DebeziumLocalConvertersUtil.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.utility.MountableFile;
 
 import java.io.File;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Utility class for mounting locally built Apicurio converters into Debezium containers.
@@ -25,7 +26,12 @@ public class DebeziumLocalConvertersUtil {
      * @param container the Debezium container to mount converters into
      * @throws IllegalStateException if converters directory doesn't exist, is empty, or has validation errors
      */
+    private static final AtomicBoolean MOUNTED = new AtomicBoolean(false);
+
     public static void mountLocalConverters(DebeziumContainer container) {
+        if (!MOUNTED.compareAndSet(false, true)) {
+            return; // already mounted by a concurrently-running test class
+        }
         String projectDir = System.getProperty("user.dir");
         String convertersPath = projectDir + CONVERTERS_PATH_SUFFIX;
         File convertersDir = new File(convertersPath);

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/mysql/DebeziumMySQLAvroBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/mysql/DebeziumMySQLAvroBaseIT.java
@@ -634,11 +634,14 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
         waitForConsumerReady(Duration.ofSeconds(30));
 
         executeUpdate("INSERT INTO " + tableName + " (data) VALUES ('before')");
-        List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
+        // Under parallel execution the shared connector's snapshot of this table (or a prior
+        // insert from another test) can still be in flight; count by the inserted value, not by
+        // bare record count.
+        List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30), "before");
         assertEquals(1, events1.size());
 
         executeUpdate("INSERT INTO " + tableName + " (data) VALUES ('after')");
-        List<GenericRecord> events2 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
+        List<GenericRecord> events2 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30), "after");
         assertEquals(1, events2.size());
 
         GenericRecord afterEvent = events2.get(0);

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/postgresql/DebeziumPostgreSQLAvroBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/postgresql/DebeziumPostgreSQLAvroBaseIT.java
@@ -688,12 +688,14 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
         waitForConsumerReady(Duration.ofSeconds(30));
 
         executeUpdate("INSERT INTO " + tableName + " (data) VALUES ('before')");
-        // Increased timeout for table detection in CI environments
-        List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
+        // Under parallel execution the shared connector's snapshot of this table (or a prior
+        // insert from another test) can still be in flight; count by the inserted value, not by
+        // bare record count.
+        List<GenericRecord> events1 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30), "before");
         assertEquals(1, events1.size());
 
         executeUpdate("INSERT INTO " + tableName + " (data) VALUES ('after')");
-        List<GenericRecord> events2 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30));
+        List<GenericRecord> events2 = consumeAvroEvents(topicName, 1, Duration.ofSeconds(30), "after");
         assertEquals(1, events2.size());
 
         GenericRecord afterEvent = events2.get(0);

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/confluent/BasicConfluentSerDesIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/confluent/BasicConfluentSerDesIT.java
@@ -36,9 +36,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.apicurio.deployment.Constants.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.parallel.Isolated;
 
 @Tag(SERDES)
 @QuarkusIntegrationTest
+@Isolated
 public class BasicConfluentSerDesIT extends ConfluentBaseIT {
 
     private KafkaFacade kafkaCluster = KafkaFacade.getInstance();

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/AgentCardIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/AgentCardIT.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.parallel.Isolated;
 
 /**
  * Integration tests for A2A Agent Card artifact type. Tests CRUD operations, validation, and compatibility
@@ -28,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 @Tag(SMOKE)
 @QuarkusIntegrationTest
+@Isolated
 class AgentCardIT extends ApicurioRegistryBaseIT {
 
     private static final String AGENT_CARD_CONTENT = """

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/AllArtifactTypesIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/AllArtifactTypesIT.java
@@ -27,9 +27,11 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.parallel.Isolated;
 
 @Tag(SMOKE)
 @QuarkusIntegrationTest
+@Isolated
 class AllArtifactTypesIT extends ApicurioRegistryBaseIT {
 
     void doTest(String v1Resource, String v2Resource, String atype, String contentType) throws Exception {

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/ArtifactsIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/ArtifactsIT.java
@@ -43,9 +43,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.parallel.Isolated;
 
 @Tag(SMOKE)
 @QuarkusIntegrationTest
+@Isolated
 class ArtifactsIT extends ApicurioRegistryBaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactsIT.class);

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/LoadIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/LoadIT.java
@@ -3,6 +3,7 @@ package io.apicurio.tests.smokeTests.apicurio;
 import io.apicurio.tests.ApicurioRegistryBaseIT;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.parallel.Isolated;
 
 /**
  * Disabled because this is too flaky and it needs to be redesigned to align better with common usage of the
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Disabled;
 // @Tag(SMOKE)
 @Disabled
 @QuarkusIntegrationTest
+@Isolated
 public class LoadIT extends ApicurioRegistryBaseIT {
 
     // private static final Logger LOGGER = LoggerFactory.getLogger(LoadIT.class);

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/ReferenceGraphIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/ReferenceGraphIT.java
@@ -30,12 +30,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.parallel.Isolated;
 
 /**
  * Integration tests for the Reference Graph API endpoint.
  */
 @Tag(SMOKE)
 @QuarkusIntegrationTest
+@Isolated
 class ReferenceGraphIT extends ApicurioRegistryBaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ReferenceGraphIT.class);

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/RulesResourceIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/apicurio/RulesResourceIT.java
@@ -25,9 +25,11 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.parallel.Isolated;
 
 @Tag(SMOKE)
 @QuarkusIntegrationTest
+@Isolated
 class RulesResourceIT extends ApicurioRegistryBaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RulesResourceIT.class);

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/confluent/MetadataConfluentIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/confluent/MetadataConfluentIT.java
@@ -19,9 +19,11 @@ import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import org.junit.jupiter.api.parallel.Isolated;
 
 @Tag(SMOKE)
 @QuarkusIntegrationTest
+@Isolated
 public class MetadataConfluentIT extends ConfluentBaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MetadataConfluentIT.class);

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/confluent/RulesResourceConfluentIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/confluent/RulesResourceConfluentIT.java
@@ -17,9 +17,11 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.parallel.Isolated;
 
 @Tag(SMOKE)
 @QuarkusIntegrationTest
+@Isolated
 class RulesResourceConfluentIT extends ConfluentBaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MetadataConfluentIT.class);

--- a/integration-tests/src/test/java/io/apicurio/tests/smokeTests/confluent/SchemasConfluentIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/smokeTests/confluent/SchemasConfluentIT.java
@@ -36,9 +36,11 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.parallel.Isolated;
 
 @Tag(SMOKE)
 @QuarkusIntegrationTest
+@Isolated
 public class SchemasConfluentIT extends ConfluentBaseIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SchemasConfluentIT.class);

--- a/integration-tests/src/test/java/io/apicurio/tests/utils/KafkaFacade.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/utils/KafkaFacade.java
@@ -22,7 +22,12 @@ public class KafkaFacade implements AutoCloseable {
     private static KafkaFacade instance;
     private StrimziKafkaCluster kafkaContainer;
 
-    public static KafkaFacade getInstance() {
+    // Number of test classes currently using the shared cluster. The cluster is only
+    // stopped when the last user releases it, so concurrently running test classes
+    // cannot stop Kafka from under each other.
+    private int users = 0;
+
+    public static synchronized KafkaFacade getInstance() {
         if (instance == null) {
             instance = new KafkaFacade();
         }
@@ -53,7 +58,8 @@ public class KafkaFacade implements AutoCloseable {
         return kafkaContainer != null;
     }
 
-    public void startIfNeeded() {
+    public synchronized void startIfNeeded() {
+        users++;
         if (isRunning()) {
             LOGGER.info("Skipping deployment of kafka, because it's already deployed");
         } else {
@@ -63,7 +69,7 @@ public class KafkaFacade implements AutoCloseable {
 
     private static final int MAX_START_ATTEMPTS = 2;
 
-    public void start() {
+    public synchronized void start() {
         if (isRunning()) {
             throw new IllegalStateException("Kafka cluster is already running");
         }
@@ -99,13 +105,16 @@ public class KafkaFacade implements AutoCloseable {
         }
     }
 
-    public void stopIfPossible() throws Exception {
-        if (isRunning()) {
+    public synchronized void stopIfPossible() throws Exception {
+        if (users > 0) {
+            users--;
+        }
+        if (users == 0 && isRunning()) {
             close();
         }
     }
 
-    public AdminClient adminClient() {
+    public synchronized AdminClient adminClient() {
         if (client == null) {
             client = AdminClient.create(connectionProperties());
         }
@@ -113,7 +122,7 @@ public class KafkaFacade implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public synchronized void close() throws Exception {
         LOGGER.info("Stopping kafka container");
         if (client != null) {
             client.close();

--- a/integration-tests/src/test/resources/junit-platform.properties
+++ b/integration-tests/src/test/resources/junit-platform.properties
@@ -1,0 +1,13 @@
+# Concurrent class-level test execution. Disabled by default so local runs behave
+# exactly as before; CI opts in with -Djunit.jupiter.execution.parallel.enabled=true.
+#
+# Test methods within a class always run in the same thread (mode.default=same_thread);
+# only distinct test classes run concurrently. Classes that mutate registry-global state
+# (global rules, role mappings, pod restarts, snapshots, timing-sensitive assertions)
+# are annotated with @Isolated and keep exclusive access to the registry while they run.
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=4
+junit.jupiter.execution.parallel.config.fixed.max-pool-size=4

--- a/pom.xml
+++ b/pom.xml
@@ -485,6 +485,13 @@
       </dependency>
       <dependency>
         <groupId>io.apicurio</groupId>
+        <artifactId>apicurio-registry-schema-util-common</artifactId>
+        <version>${project.version}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.apicurio</groupId>
         <artifactId>apicurio-registry-schema-util-json</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
## Summary

Enable JUnit 5 class-level parallel execution for the integration-tests module: test classes run concurrently (fixed pool of 4) against the single deployed registry; methods within a class stay sequential.

Measured locally: serdes group 4m48s → 2m53s; combined default groups (smoke|serdes|acceptance) 142/142 green in 4m40s vs ~7 min serial.

## Design

- `integration-tests/src/test/resources/junit-platform.properties`: parallel config, **disabled by default** (local runs behave exactly as before); CI opts in via `-Djunit.jupiter.execution.parallel.enabled=true` in verify-integration-tests.yaml
- **@Isolated on 19 classes** that mutate registry-global state: global rules (AgentCardIT, AllArtifactTypesIT, ArtifactsIT, ReferenceGraphIT, RulesResourceIT, RulesResourceConfluentIT), role mappings/auth (SimpleAuthIT), the shared Confluent subject namespace (SchemasConfluentIT, MetadataConfluentIT, BasicConfluentSerDesIT), pod restarts (KubernetesOpsIT, KafkaSqlSnapshottingIT), migrations (3 classes), fixed-port proxies (2 classes), and timing-sensitive tests (LoadIT, SerdesPerformanceIT)
- **KafkaFacade is now synchronized + reference-counted**: a finishing test class can no longer stop the shared Kafka cluster while other classes still use it. This was a real race, caught during local validation (26 errors → 0 after the fix)

## Parallelism issues found during validation and fixed here

- **Debezium connector 409s**: all Debezium classes share a static connector-name counter and one Kafka Connect instance, so parallel registration collided (409 Conflict). Register+wait and delete windows are serialized via a static lock (79fb7d4)
- **Local-converter double-mount**: `mountLocalConverters` ran once per class with no guard; now idempotent via AtomicBoolean (80702f7)
- **Recovery-test miscounts**: exact-count assertions were inflated by snapshot/parallel inserts; `consumeAvroEvents` gained a value-filtered overload and the recovery tests count by the inserted value (2ed70c1)

## Also fixed (not parallelism-related, but blocking the build)

- **Build race on main** (d079d22): schema-util/json's tests import CompatibilityTestExecutor from schema-util/common's test-jar, which was not in dependencyManagement — under the Build job's -T 0.5C the reactor didn't order json's testCompile after common's package. Verified locally with the exact Build command (fails without, succeeds with).
- **Test-setup flake on main** (0af1dcb): AbstractResourceTestBase.deleteGlobalRules (shared @BeforeEach) exhausts the default 20-retry budget against a loaded H2 registry; widened to 60 retries so tests stop failing in setup.

## Single build per SHA (e204518)

integration-tests.yaml and extras.yaml no longer build on pull_request — they are workflow_dispatch-triggered by ci.yaml's new dispatch-integration-and-extras job right after Build, and reuse CI's Build artifact. One Java+UI build per SHA instead of three.

## Test plan

- [x] Local full parallel runs against a registry container configured like CI (deletion enabled): smoke 72/72, serdes 70/70, combined default groups 142/142
- [x] The cross-class interference found locally (Confluent global subject counting) is covered by the @Isolated set
- [x] Build race reproduced and fixed with the exact CI command
- [x] CI: watch the IT matrix on this PR — first validation of parallel execution against minikube-deployed registries, with the Debezium fixes in place

