### PR TITLE
fix(rules): validate references in AgentCardContentValidator (#9728)

### DIFF
--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/AbstractContentValidator.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/AbstractContentValidator.java
@@ -1,5 +1,8 @@
 package io.apicurio.registry.rules.validity;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import io.apicurio.registry.content.TypedContent;
+import io.apicurio.registry.content.util.ContentTypeUtil;
 import io.apicurio.registry.rest.v3.beans.ArtifactReference;
 import io.apicurio.registry.rules.integrity.IntegrityLevel;
 import io.apicurio.registry.rules.violation.RuleViolation;
@@ -7,7 +10,10 @@ import io.apicurio.registry.rules.violation.RuleViolationException;
 import io.apicurio.registry.types.RuleType;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -57,5 +63,50 @@ public abstract class AbstractContentValidator implements ContentValidator {
      */
     protected String extractReferenceName(ArtifactReference ref) {
         return ref.getName();
+    }
+
+    /**
+     * Extracts external $ref values from JSON/YAML content, ignoring internal JSON Pointer references starting with "#/".
+     *
+     * @param content the typed content to extract references from
+     * @return set of external reference strings
+     */
+    protected Set<String> extractExternalJsonRefs(TypedContent content) {
+        try {
+            JsonNode tree = ContentTypeUtil.parseJsonOrYaml(content);
+            Set<String> refs = new HashSet<>();
+            findExternalRefs(tree, refs);
+            return refs;
+        } catch (Exception e) {
+            return Collections.emptySet();
+        }
+    }
+
+    /**
+     * Recursively traverses a JSON node to collect external $ref values.
+     *
+     * @param node the current JSON node
+     * @param refs the set collecting external references
+     */
+    protected void findExternalRefs(JsonNode node, Set<String> refs) {
+        if (node == null) {
+            return;
+        }
+        if (node.isObject()) {
+            if (node.has("$ref")) {
+                String ref = node.get("$ref").asText(null);
+                if (ref != null && !ref.startsWith("#/")) {
+                    refs.add(ref);
+                }
+            }
+            Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+            while (fields.hasNext()) {
+                findExternalRefs(fields.next().getValue(), refs);
+            }
+        } else if (node.isArray()) {
+            for (JsonNode element : node) {
+                findExternalRefs(element, refs);
+            }
+        }
     }
 }

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/AgentCardContentValidator.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/AgentCardContentValidator.java
@@ -18,7 +18,7 @@ import java.util.Set;
 /**
  * Content validator for A2A Agent Card artifacts, aligned with A2A Protocol v1.0.
  */
-public class AgentCardContentValidator implements ContentValidator {
+public class AgentCardContentValidator extends AbstractContentValidator {
 
     @Override
     public void validate(ValidityLevel level, TypedContent content,
@@ -428,11 +428,37 @@ public class AgentCardContentValidator implements ContentValidator {
     @Override
     public void validateReferences(TypedContent content, List<ArtifactReference> references)
             throws RuleViolationException {
-        if (references != null && !references.isEmpty()) {
-            throw new RuleViolationException("Agent Cards do not support references",
-                    RuleType.INTEGRITY, "NONE",
-                    Collections.singleton(
-                            new RuleViolation("References are not supported for Agent Cards", "")));
+        Set<String> allRefs = getAllRefs(content);
+        if (!allRefs.isEmpty()) {
+            validateMappedReferences(references, allRefs, "Unmapped reference detected.");
+        }
+    }
+
+    private Set<String> getAllRefs(TypedContent content) {
+        try {
+            JsonNode tree = ContentTypeUtil.parseJsonOrYaml(content);
+            Set<String> refs = new HashSet<>();
+            findRefs(tree, refs);
+            return refs;
+        } catch (Exception e) {
+            return Collections.emptySet();
+        }
+    }
+
+    private void findRefs(JsonNode node, Set<String> refs) {
+        if (node == null) {
+            return;
+        }
+        if (node.isObject()) {
+            if (node.has("$ref") && node.get("$ref").isTextual()) {
+                String ref = node.get("$ref").asText();
+                if (ref != null && !ref.startsWith("#/")) {
+                    refs.add(ref);
+                }
+            }
+            node.elements().forEachRemaining(child -> findRefs(child, refs));
+        } else if (node.isArray()) {
+            node.elements().forEachRemaining(child -> findRefs(child, refs));
         }
     }
 }

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/AgentCardContentValidator.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/AgentCardContentValidator.java
@@ -428,37 +428,9 @@ public class AgentCardContentValidator extends AbstractContentValidator {
     @Override
     public void validateReferences(TypedContent content, List<ArtifactReference> references)
             throws RuleViolationException {
-        Set<String> allRefs = getAllRefs(content);
+        Set<String> allRefs = extractExternalJsonRefs(content);
         if (!allRefs.isEmpty()) {
             validateMappedReferences(references, allRefs, "Unmapped reference detected.");
-        }
-    }
-
-    private Set<String> getAllRefs(TypedContent content) {
-        try {
-            JsonNode tree = ContentTypeUtil.parseJsonOrYaml(content);
-            Set<String> refs = new HashSet<>();
-            findRefs(tree, refs);
-            return refs;
-        } catch (Exception e) {
-            return Collections.emptySet();
-        }
-    }
-
-    private void findRefs(JsonNode node, Set<String> refs) {
-        if (node == null) {
-            return;
-        }
-        if (node.isObject()) {
-            if (node.has("$ref") && node.get("$ref").isTextual()) {
-                String ref = node.get("$ref").asText();
-                if (ref != null && !ref.startsWith("#/")) {
-                    refs.add(ref);
-                }
-            }
-            node.elements().forEachRemaining(child -> findRefs(child, refs));
-        } else if (node.isArray()) {
-            node.elements().forEachRemaining(child -> findRefs(child, refs));
         }
     }
 }

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/ModelSchemaContentValidator.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/ModelSchemaContentValidator.java
@@ -10,7 +10,6 @@ import io.apicurio.registry.types.RuleType;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -96,40 +95,9 @@ public class ModelSchemaContentValidator extends AbstractContentValidator {
     @Override
     public void validateReferences(TypedContent content, List<ArtifactReference> references)
             throws RuleViolationException {
-        Set<String> allRefs = getAllRefs(content);
+        Set<String> allRefs = extractExternalJsonRefs(content);
         if (!allRefs.isEmpty()) {
             validateMappedReferences(references, allRefs, "Unmapped reference detected.");
-        }
-    }
-
-    private Set<String> getAllRefs(TypedContent content) {
-        try {
-            JsonNode tree = ContentTypeUtil.parseJsonOrYaml(content);
-            Set<String> refs = new HashSet<>();
-            findRefs(tree, refs);
-            return refs;
-        } catch (Exception e) {
-            return Collections.emptySet();
-        }
-    }
-
-    private void findRefs(JsonNode node, Set<String> refs) {
-        if (node.isObject()) {
-            if (node.has("$ref")) {
-                String ref = node.get("$ref").asText(null);
-                if (ref != null && !ref.startsWith("#/")) {
-                    refs.add(ref);
-                }
-            }
-            Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
-            while (fields.hasNext()) {
-                Map.Entry<String, JsonNode> field = fields.next();
-                findRefs(field.getValue(), refs);
-            }
-        } else if (node.isArray()) {
-            for (JsonNode element : node) {
-                findRefs(element, refs);
-            }
         }
     }
 }

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/PromptTemplateContentValidator.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/PromptTemplateContentValidator.java
@@ -202,33 +202,14 @@ public class PromptTemplateContentValidator extends AbstractContentValidator {
             JsonNode tree = ContentTypeUtil.parseJsonOrYaml(content);
             Set<String> refs = new HashSet<>();
             if (tree.has("variables")) {
-                findRefs(tree.get("variables"), refs);
+                findExternalRefs(tree.get("variables"), refs);
             }
             if (tree.has("outputSchema")) {
-                findRefs(tree.get("outputSchema"), refs);
+                findExternalRefs(tree.get("outputSchema"), refs);
             }
             return refs;
         } catch (Exception e) {
             return Collections.emptySet();
-        }
-    }
-
-    private void findRefs(JsonNode node, Set<String> refs) {
-        if (node.isObject()) {
-            if (node.has("$ref")) {
-                String ref = node.get("$ref").asText(null);
-                if (ref != null && !ref.startsWith("#/")) {
-                    refs.add(ref);
-                }
-            }
-            Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
-            while (fields.hasNext()) {
-                findRefs(fields.next().getValue(), refs);
-            }
-        } else if (node.isArray()) {
-            for (JsonNode element : node) {
-                findRefs(element, refs);
-            }
         }
     }
 }

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/AgentCardContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/AgentCardContentValidatorTest.java
@@ -257,4 +257,65 @@ public class AgentCardContentValidatorTest extends ArtifactUtilProviderTestBase 
         AgentCardContentValidator validator = new AgentCardContentValidator();
         validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
     }
+
+    @Test
+    public void testAgentCardValidateReferencesNoRefs() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("agentcard-valid.json");
+        AgentCardContentValidator validator = new AgentCardContentValidator();
+        validator.validateReferences(content, Collections.emptyList());
+    }
+
+    private String createRefAgentCardJson(String refSchemaName) {
+        return "{\n" +
+                "  \"name\": \"RefAgent\",\n" +
+                "  \"version\": \"1.0.0\",\n" +
+                "  \"description\": \"Agent with references\",\n" +
+                "  \"url\": \"https://example.com/agent\",\n" +
+                "  \"capabilities\": {\"streaming\": false},\n" +
+                "  \"skills\": [{\n" +
+                "    \"id\": \"skill-1\",\n" +
+                "    \"name\": \"Skill One\",\n" +
+                "    \"description\": \"First skill\",\n" +
+                "    \"tags\": [\"test\"],\n" +
+                "    \"inputSchema\": {\"$ref\": \"" + refSchemaName + "\"}\n" +
+                "  }],\n" +
+                "  \"defaultInputModes\": [\"text\"],\n" +
+                "  \"defaultOutputModes\": [\"text\"]\n" +
+                "}";
+    }
+
+    @Test
+    public void testAgentCardValidateReferencesMapped() throws Exception {
+        TypedContent content = TypedContent.create(io.apicurio.registry.content.ContentHandle.create(createRefAgentCardJson("common-schema.json")), "application/json");
+        AgentCardContentValidator validator = new AgentCardContentValidator();
+
+        io.apicurio.registry.rest.v3.beans.ArtifactReference ref = io.apicurio.registry.rest.v3.beans.ArtifactReference.builder()
+                .groupId("default")
+                .artifactId("common-schema")
+                .version("1.0")
+                .name("common-schema.json")
+                .build();
+
+        validator.validateReferences(content, Collections.singletonList(ref));
+    }
+
+    @Test
+    public void testAgentCardValidateReferencesUnmapped() throws Exception {
+        TypedContent content = TypedContent.create(io.apicurio.registry.content.ContentHandle.create(createRefAgentCardJson("missing-schema.json")), "application/json");
+        AgentCardContentValidator validator = new AgentCardContentValidator();
+
+        RuleViolationException error = Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validateReferences(content, Collections.emptyList());
+        });
+        Assertions.assertEquals(io.apicurio.registry.types.RuleType.INTEGRITY, error.getRuleType());
+        Assertions.assertEquals(io.apicurio.registry.rules.integrity.IntegrityLevel.ALL_REFS_MAPPED.name(), error.getRuleConfiguration().orElse(null));
+        Assertions.assertFalse(error.getCauses().isEmpty());
+    }
+
+    @Test
+    public void testAgentCardValidateReferencesInternalRefIgnored() throws Exception {
+        TypedContent content = TypedContent.create(io.apicurio.registry.content.ContentHandle.create(createRefAgentCardJson("#/definitions/InternalSkillSchema")), "application/json");
+        AgentCardContentValidator validator = new AgentCardContentValidator();
+        validator.validateReferences(content, Collections.emptyList());
+    }
 }


### PR DESCRIPTION
Fixes #9728

### Summary of Changes
1. Extended `AbstractContentValidator` in `AgentCardContentValidator` to enable reference validation logic instead of throwing a hardcoded MVP rejection stub.
2. Implemented recursive `$ref` extraction (`getAllRefs` and `findRefs`) for Agent Cards to validate mapped references using `validateMappedReferences`.
3. Added unit tests in `AgentCardContentValidatorTest` verifying empty reference validation, valid mapped reference validation, and unmapped reference failures asserting `IntegrityLevel.ALL_REFS_MAPPED`.

Signed-off-by: Karan Thengane <karanthengane23@gmail.com>