### PR TITLE
ci(orchestrator): revert workflow_run head-SHA checkout — breaks fork PRs

### DIFF
--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -191,10 +191,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          # workflow_run handlers must run the PR's orchestrator code, not main's —
-          # otherwise fixes to pr-lifecycle.js only take effect after merge.
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
+        # workflow_run handlers must NOT check out the run's head SHA: GitHub refuses
+        # fork pull_request code in a workflow_run context, and the checkout fails the
+        # whole orchestrator. The orchestrator's dispatch logic lives on main once
+        # merged; for the rollout PR itself, the dispatch is bootstrapped manually.
 
       - name: Convert config to JSON
         run: yq -o json .github/pr-lifecycle.yml > .github/pr-lifecycle.json


### PR DESCRIPTION
## Summary

Reverts the head-SHA checkout in the workflow_run test-result handler (#9757's 09a8c97f). GitHub refuses to check out fork pull_request code in a workflow_run context, so the orchestrator errors on every CI completion for a fork PR and never processes the result — no lifecycle/tested, no promotion, no dispatch.

## Root Cause

actions/checkout refuses fork code in a workflow_run workflow (which runs with the base repo's token). The intent (orchestrator changes in a PR run for that PR) is not achievable this way.

## Changes

- pr-lifecycle.yml: workflow_run handler checks out the default branch (main) again.

## Test plan

- [x] YAML parses
- [ ] After merge: the next fork PR's CI completion should be processed by the orchestrator without the checkout error