### PR TITLE
fix(deps): bump jackson-core/jackson-databind to 2.18.9 in kafkasql-topic-import

### DIFF
--- a/examples/tools/kafkasql-topic-import/pom.xml
+++ b/examples/tools/kafkasql-topic-import/pom.xml
@@ -28,13 +28,13 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.18.2</version>
+      <version>2.18.9</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.18.2</version>
+      <version>2.18.9</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## What
Bumps `jackson-core` and `jackson-databind` from 2.18.2 to 2.18.9 in `examples/tools/kafkasql-topic-import/pom.xml`.

## Why
2.18.2 is affected by several CVEs fixed across the 2.18.x patch line (quadratic CPU consumption in async parsing, number-length constraint bypass leading to potential DoS, and others). 2.18.9 is the latest 2.18.x release and resolves all of them. Pure patch-version bump, no API changes.

Fixes Dependabot alerts: #753, #617, #618, #619, #620, #667, #668, #669, #670 (all against the same dependency pair in the same file).

## Testing
- `./mvnw compile -Pexamples -pl examples/tools/kafkasql-topic-import -am -DskipTests` — compiles cleanly.
- No existing tests in this module (utility/example tool); this is a dependency-only change with no code/behavior modification.