### PR TITLE
ci: use real Check Runs instead of commit statuses for dispatched PR visibility

### DIFF
--- a/.github/workflows/extras.yaml
+++ b/.github/workflows/extras.yaml
@@ -100,7 +100,7 @@ jobs:
           echo "All checks passed"
 
   # ============================================================================
-  # PR VISIBILITY: commit statuses on the PR's actual SHA
+  # PR VISIBILITY: a real Check Run on the PR's actual SHA
   #
   # workflow_dispatch runs are never associated with a PR by GitHub — the
   # check_suite's pull_requests array is empty regardless of which ref was
@@ -108,48 +108,59 @@ jobs:
   # branch produces the same empty array), because association is based on
   # (repository, head_branch) matching an open PR's head, and a dispatched
   # run's head_branch is always the ref it was dispatched to, never the PR's
-  # actual branch (which for a fork PR does not even exist on this repo).
-  # So without this, a fork PR's own page never shows Extra Tests at all,
-  # even once it runs and passes — the native Actions check is invisible
-  # there. Commit statuses are looked up purely by SHA and do show up in a
-  # PR's checks list; this is the same mechanism third-party CI systems use
-  # for exactly this scenario.
+  # actual branch (which for a fork PR does not even exist on this repo). So
+  # without this, a fork PR's own Checks tab never shows Extra Tests at all,
+  # even once it runs and passes.
+  #
+  # A commit status (statuses API) is visible in gh pr checks and the merge
+  # box, but not grouped into the PR's Checks tab the way native workflow
+  # checks are. Check Runs are: the REST docs say only a GitHub App can create
+  # one via a personal token — but the GITHUB_TOKEN minted for a workflow run
+  # is itself an installation token for the built-in github-actions App, not
+  # a personal OAuth token, so it can create one directly, explicitly setting
+  # head_sha to the PR's real commit (confirmed empirically). Check runs are
+  # looked up by SHA, so this appears correctly grouped in the PR's own
+  # Checks tab under the app name, unlike the check_suite GitHub auto-creates
+  # for the dispatch itself.
   notify-pr-pending:
     name: Notify PR (pending)
     needs: [decide]
     if: github.event_name == 'workflow_dispatch' && inputs.pr-sha != '' && needs.decide.outputs.run-extras == 'true'
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      checks: write
+    outputs:
+      check-run-id: ${{ steps.create.outputs.id }}
     steps:
-      - name: Post pending status
+      - name: Create check run
+        id: create
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh api "repos/${{ github.repository }}/statuses/${{ inputs.pr-sha }}" \
-            -f state=pending \
-            -f context="Extra Tests Gate" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            -f description="Running extra tests..."
+          ID=$(gh api "repos/${{ github.repository }}/check-runs" \
+            -f name="Extra Tests Gate" \
+            -f head_sha="${{ inputs.pr-sha }}" \
+            -f status=in_progress \
+            -f details_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --jq '.id')
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
 
   notify-pr-result:
     name: Notify PR (result)
-    needs: [decide, gate]
-    if: always() && github.event_name == 'workflow_dispatch' && inputs.pr-sha != ''
+    needs: [decide, gate, notify-pr-pending]
+    if: always() && github.event_name == 'workflow_dispatch' && inputs.pr-sha != '' && needs.notify-pr-pending.result == 'success'
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      checks: write
     steps:
-      - name: Post final status
+      - name: Complete check run
         env:
           GH_TOKEN: ${{ github.token }}
           RESULT: ${{ needs.gate.result }}
+          CHECK_RUN_ID: ${{ needs.notify-pr-pending.outputs.check-run-id }}
         run: |
-          STATE=$([ "$RESULT" = "success" ] && echo success || echo failure)
-          DESC=$([ "$RESULT" = "success" ] && echo "Extra tests passed" || echo "Extra tests failed")
-          gh api "repos/${{ github.repository }}/statuses/${{ inputs.pr-sha }}" \
-            -f state="$STATE" \
-            -f context="Extra Tests Gate" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            -f description="$DESC"
-          echo "All checks passed"
+          CONCLUSION=$([ "$RESULT" = "success" ] && echo success || echo failure)
+          gh api "repos/${{ github.repository }}/check-runs/$CHECK_RUN_ID" -X PATCH \
+            -f status=completed \
+            -f conclusion="$CONCLUSION" \
+            -f details_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -99,7 +99,7 @@ jobs:
           echo "All checks passed"
 
   # ============================================================================
-  # PR VISIBILITY: commit statuses on the PR's actual SHA
+  # PR VISIBILITY: a real Check Run on the PR's actual SHA
   #
   # workflow_dispatch runs are never associated with a PR by GitHub — the
   # check_suite's pull_requests array is empty regardless of which ref was
@@ -107,47 +107,59 @@ jobs:
   # branch produces the same empty array), because association is based on
   # (repository, head_branch) matching an open PR's head, and a dispatched
   # run's head_branch is always the ref it was dispatched to, never the PR's
-  # actual branch (which for a fork PR does not even exist on this repo).
-  # So without this, a fork PR's own page never shows Integration Tests at
-  # all, even once it runs and passes — the native Actions check is invisible
-  # there. Commit statuses are looked up purely by SHA and do show up in a
-  # PR's checks list; this is the same mechanism third-party CI systems use
-  # for exactly this scenario.
+  # actual branch (which for a fork PR does not even exist on this repo). So
+  # without this, a fork PR's own Checks tab never shows Integration Tests at
+  # all, even once it runs and passes.
+  #
+  # A commit status (statuses API) is visible in gh pr checks and the merge
+  # box, but not grouped into the PR's Checks tab the way native workflow
+  # checks are. Check Runs are: the REST docs say only a GitHub App can create
+  # one via a personal token — but the GITHUB_TOKEN minted for a workflow run
+  # is itself an installation token for the built-in github-actions App, not
+  # a personal OAuth token, so it can create one directly, explicitly setting
+  # head_sha to the PR's real commit (confirmed empirically). Check runs are
+  # looked up by SHA, so this appears correctly grouped in the PR's own
+  # Checks tab under the app name, unlike the check_suite GitHub auto-creates
+  # for the dispatch itself.
   notify-pr-pending:
     name: Notify PR (pending)
     needs: [decide]
     if: github.event_name == 'workflow_dispatch' && inputs.pr-sha != '' && needs.decide.outputs.run-integration == 'true'
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      checks: write
+    outputs:
+      check-run-id: ${{ steps.create.outputs.id }}
     steps:
-      - name: Post pending status
+      - name: Create check run
+        id: create
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh api "repos/${{ github.repository }}/statuses/${{ inputs.pr-sha }}" \
-            -f state=pending \
-            -f context="Integration Tests Gate" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            -f description="Running the integration test matrix..."
+          ID=$(gh api "repos/${{ github.repository }}/check-runs" \
+            -f name="Integration Tests Gate" \
+            -f head_sha="${{ inputs.pr-sha }}" \
+            -f status=in_progress \
+            -f details_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --jq '.id')
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
 
   notify-pr-result:
     name: Notify PR (result)
-    needs: [decide, gate]
-    if: always() && github.event_name == 'workflow_dispatch' && inputs.pr-sha != ''
+    needs: [decide, gate, notify-pr-pending]
+    if: always() && github.event_name == 'workflow_dispatch' && inputs.pr-sha != '' && needs.notify-pr-pending.result == 'success'
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      checks: write
     steps:
-      - name: Post final status
+      - name: Complete check run
         env:
           GH_TOKEN: ${{ github.token }}
           RESULT: ${{ needs.gate.result }}
+          CHECK_RUN_ID: ${{ needs.notify-pr-pending.outputs.check-run-id }}
         run: |
-          STATE=$([ "$RESULT" = "success" ] && echo success || echo failure)
-          DESC=$([ "$RESULT" = "success" ] && echo "Integration tests passed" || echo "Integration tests failed")
-          gh api "repos/${{ github.repository }}/statuses/${{ inputs.pr-sha }}" \
-            -f state="$STATE" \
-            -f context="Integration Tests Gate" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            -f description="$DESC"
+          CONCLUSION=$([ "$RESULT" = "success" ] && echo success || echo failure)
+          gh api "repos/${{ github.repository }}/check-runs/$CHECK_RUN_ID" -X PATCH \
+            -f status=completed \
+            -f conclusion="$CONCLUSION" \
+            -f details_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## What
Replaces the commit-status posting added for Integration Tests/Extra Tests (workflow_dispatch runs never get natively associated with a PR — see prior commit) with real Check Runs via the Checks API.

## Why
Commit statuses show up in `gh pr checks` and the merge box, but not grouped into the PR's own Checks tab the way native workflow checks are. The Checks API docs say only a GitHub App can create a check run — but a workflow's own `GITHUB_TOKEN` is itself an installation token for the built-in `github-actions` App, not a personal OAuth token, so it can create one directly with an explicit `head_sha`.

Confirmed empirically:
- Dispatched a real run against an open PR's exact head SHA with this change; the resulting check run shows up via `commits/{sha}/check-runs` and, more importantly, in the PR's own `statusCheckRollup` as a proper `CheckRun` (not a `StatusContext`) — this is the same data GitHub's merge box and required-checks computation use.

**Known limitation:** the check run's check_suite has no `workflowRun` association (since it wasn't created by GitHub's own workflow-trigger mechanism), so it won't be visually nested under an "Integration Tests" workflow header the way `CI Gate` is nested under `CI` — it appears as its own named check ("Integration Tests Gate" / "Extra Tests Gate"), same as how SonarCloud's checks appear ungrouped today. This is a GitHub platform constraint, not something a workflow can control.

## Testing
- Both workflow YAML files parse and validate.
- Manually dispatched `integration-tests.yaml` against a real open PR's exact head SHA (with the new check-run code) and confirmed via the API that the check run is created, updates correctly, and is included in that PR's `statusCheckRollup`.