### PR TITLE
fix(ci): distinguish genuine full-suite failures from the Gate's own not-ready check

### DIFF
--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -297,7 +297,7 @@ const FULL_SUITE_WORKFLOW_FILES = ['verify.yaml'];
 // Returns:
 //   { status: 'pending' }  — some workflow has no run yet or is still running
 //   { status: 'success' }  — every workflow's latest run succeeded
-//   { status: 'failure' }  — at least one failed/was cancelled (fail fast)
+//   { status: 'failure' }  — at least one genuinely failed/was cancelled (fail fast)
 async function getFullSuiteResult(github, owner, repo, headSha, core) {
   const { data } = await github.rest.actions.listWorkflowRunsForRepo({
     owner, repo, head_sha: headSha, per_page: 100,
@@ -319,6 +319,24 @@ async function getFullSuiteResult(github, owner, repo, headSha, core) {
   }
   for (const run of latest.values()) {
     if (run.conclusion !== 'success') {
+      // verify.yaml's Gate job intentionally fails (not skips) while the PR
+      // is not yet lifecycle/ready-to-merge, as the only way to make the
+      // required branch-protection check honestly reflect "not satisfied
+      // yet" instead of the false-pass a skipped required job would produce
+      // (see verify.yaml's Gate for the full reasoning). That failure is
+      // expected and must NOT be treated as a genuine full-suite failure
+      // here — every job in the run other than Gate itself is either
+      // success or skipped in that case, since Decide gated all of them on
+      // the same not-yet-ready state. Only trust 'failure' when some other
+      // job actually failed.
+      const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
+        owner, repo, run_id: run.id, per_page: 100,
+      });
+      const realFailure = jobs.some(j => j.name !== 'Verification Gate' && j.conclusion === 'failure');
+      if (!realFailure) {
+        core.info(`Full suite for ${headSha}: ${run.name}'s only failure is its own not-ready-to-merge-yet check, treating as pending`);
+        return { status: 'pending' };
+      }
       return { status: 'failure', failedRun: run };
     }
   }

--- a/.github/scripts/pr-lifecycle.test.js
+++ b/.github/scripts/pr-lifecycle.test.js
@@ -43,7 +43,7 @@ async function withConfig(cfg, fn) {
 
 const SHA = 'abcdef1234567890';
 
-function makeWorld(prLabels, { approved = false, suiteRuns = [] } = {}) {
+function makeWorld(prLabels, { approved = false, suiteRuns = [], suiteJobs = {} } = {}) {
   const labels = new Set(prLabels);
   const calls = { added: [], removed: [], comments: [], merges: [], branchUpdates: [] };
 
@@ -79,6 +79,14 @@ function makeWorld(prLabels, { approved = false, suiteRuns = [] } = {}) {
         listWorkflowRuns: async () => ({ data: { workflow_runs: [] } }),
         listWorkflowRunsForRepo: async () => ({ data: { workflow_runs: suiteRuns } }),
         listWorkflowRunArtifacts: async () => ({}),
+        // Used by getFullSuiteResult to tell a genuine full-suite failure
+        // apart from the Gate's own not-ready-to-merge-yet check failing
+        // (see suiteJobs option below). Defaults to "some other job
+        // genuinely failed" so existing greenSuite({ Verify: 'failure' })
+        // callers keep meaning a real failure without having to specify it.
+        listJobsForWorkflowRun: async ({ run_id }) => ({
+          data: { jobs: suiteJobs[run_id] ?? [{ name: 'Some Job', conclusion: 'failure' }] },
+        }),
       },
     },
     // paginate: reviews list when asked for reviews, empty otherwise
@@ -118,6 +126,7 @@ function greenSuite(overrides = {}) {
     const inProgress = o.endsWith('/');
     const conclusion = inProgress ? null : o;
     return {
+      id: name, // looked up by suiteJobs/listJobsForWorkflowRun in the mock
       name,
       status: inProgress ? o.slice(0, -1) : 'completed',
       conclusion,
@@ -288,6 +297,23 @@ test('late Quick Check success does not promote the PR after a full-suite failur
   await lifecycle.handleTestResult({ github: w.github, context: runPayload('Quick Check', 'success'), core: w.core });
   assert.ok(!w.calls.added.includes(LABELS.TESTED));
   assert.ok(!w.calls.added.includes(LABELS.FULL_VERIFIED));
+});
+
+test('Quick Check success DOES promote a first-time PR even though an earlier not-yet-ready Verify run shows failure', async () => {
+  // Every Verify run before a PR is promoted legitimately fails its own
+  // "is this actually ready to merge" check (see verify.yaml's Gate) --
+  // that is not a real test failure and must not be confused with one.
+  // Here only "Verification Gate" failed; every other job in the run was
+  // skipped (Decide gated them on the same not-yet-ready state), so
+  // getFullSuiteResult must treat this as pending, not a genuine failure,
+  // and let the fast gate promote the PR normally.
+  const w = makeWorld([LABELS.READY_FOR_REVIEW, LABELS.REVIEW_SKIPPED, LABELS.WAITING_ON_MAINTAINER], {
+    suiteRuns: greenSuite({ Verify: 'failure' }),
+    suiteJobs: { Verify: [{ name: 'Verification Gate', conclusion: 'failure' }] },
+  });
+  await lifecycle.handleTestResult({ github: w.github, context: runPayload('Quick Check', 'success'), core: w.core });
+  assert.ok(w.calls.added.includes(LABELS.TESTED));
+  assert.ok(w.calls.added.includes(LABELS.READY_TO_MERGE));
 });
 
 test('Verify failure at ready-to-merge reverts to ready-for-review', async () => {


### PR DESCRIPTION
## What

Fixes a critical regression from #9772 discovered via live validation on PR #9765 immediately after #9772 merged: **no PR can promote past `lifecycle/ready-for-review` anymore.**

## Why

#9772's Verification Gate live check makes `verify.yaml`'s Gate job fail (not pass) while a PR is not yet `lifecycle/ready-to-merge`, so the required branch-protection check honestly reflects "not satisfied yet" instead of a false pass. That's correct and intentional.

But `pr-lifecycle.js`'s `getFullSuiteResult` (used by `handleTestResult`'s safeguard against late fast-gate completions racing a real failure revert) treats **any** non-success conclusion on `verify.yaml`'s latest run as a genuine full-suite failure. Since every `Verify` run before a PR is promoted now legitimately "fails" the not-ready-yet check, `getFullSuiteResult` permanently reports `failure` for every PR's first review cycle — which the fast-gate handler interprets as "the full suite already failed, do not promote," blocking promotion forever.

Confirmed live: Quick Verify passed on PR #9765, but the orchestrator logged `PR #9765 full-suite failure recorded for this SHA, skipping fast-gate result` and never added `lifecycle/tested`.

## Fix

`getFullSuiteResult` now checks the failing run's own jobs before trusting its conclusion. If `Verification Gate` is the only job that failed (everything else is success or skipped, since Decide gated them all on the same not-yet-ready state), that's the expected not-ready check, not a real failure — treated as pending instead. A genuine failure (e.g. Unit Tests actually failing once the suite runs for real) still has at least one other job with `conclusion=failure` and is reported as a real failure exactly as before.

## Validation

- `node --test .github/scripts/pr-lifecycle.test.js` — 16/16 pass, including a new test proving a first-time PR promotes normally despite an earlier not-yet-ready `Verify` run recorded as failed.
- No workflow YAML touched — only `.github/scripts/pr-lifecycle.js`/`pr-lifecycle.test.js`.