### PR TITLE
fix(deps): bump jackson-core/jackson-databind to 2.18.9 in kafkasql-topic-import

### DIFF
--- a/examples/tools/kafkasql-topic-import/pom.xml
+++ b/examples/tools/kafkasql-topic-import/pom.xml
@@ -28,13 +28,13 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.18.2</version>
+      <version>2.18.9</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.18.2</version>
+      <version>2.18.9</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Bumps `jackson-core`/`jackson-databind` from 2.18.2 to 2.18.9 in `examples/tools/kafkasql-topic-import/pom.xml`, fixing Dependabot alerts.

Re-opened (again) fully rebased on latest main (#9768, #9772, #9783) for a clean validation cycle. Previously #9765, #9784.