### PR TITLE
fix(auth): replace check-then-act with atomic compute() to prevent OIDC token cache stampede (#9776)

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -365,6 +365,12 @@
       <groupId>io.apicurio</groupId>
       <artifactId>apicurio-registry-utils-tests</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.squareup.okhttp3</groupId>
+          <artifactId>okhttp</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.strimzi</groupId>
@@ -420,6 +426,12 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>no.nav.security</groupId>
+      <artifactId>mock-oauth2-server</artifactId>
+      <version>6.0.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/src/main/java/io/apicurio/registry/auth/AppAuthenticationMechanism.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AppAuthenticationMechanism.java
@@ -53,7 +53,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -252,17 +251,16 @@ public class AppAuthenticationMechanism implements HttpAuthenticationMechanism {
      * bean (rather than on {@link OidcAuthenticationStrategy}) so that the MicroProfile
      * {@link Retry} interceptor is applied.
      *
+     * <p>This method performs only the HTTP token request. Cache insertion is handled
+     * atomically by the caller via {@code ConcurrentHashMap.compute()}.
+     *
      * @param clientCredentials the client ID and secret
-     * @param credentialsHash hash key for the token cache
-     * @param cachedAccessTokens token cache (owned by the OIDC strategy)
-     * @param cachedAuthFailures failure cache (owned by the OIDC strategy)
      * @param oidcTokenUrl the token endpoint URL (computed by the OIDC strategy at init)
+     * @return the fetched token wrapped with its computed expiration
      */
     @Retry(retryOn = OidcAuthException.class, maxRetries = 4, delay = 1,
             delayUnit = ChronoUnit.SECONDS)
-    public String getAccessToken(Pair<String, String> clientCredentials, String credentialsHash,
-            ConcurrentHashMap<String, WrappedValue<String>> cachedAccessTokens,
-            ConcurrentHashMap<String, WrappedValue<RuntimeException>> cachedAuthFailures,
+    public WrappedValue<String> getAccessToken(Pair<String, String> clientCredentials,
             String oidcTokenUrl) {
         String clientId = clientCredentials.getLeft();
         String clientSecret = clientCredentials.getRight();
@@ -286,23 +284,11 @@ public class AppAuthenticationMechanism implements HttpAuthenticationMechanism {
 
             int statusCode = response.statusCode();
             if (statusCode == 401) {
-                var ex = new io.quarkus.security.UnauthorizedException(
+                throw new io.quarkus.security.UnauthorizedException(
                         "OIDC token request returned 401");
-                cachedAuthFailures.put(credentialsHash,
-                        new WrappedValue<>(
-                                OidcAuthenticationStrategy.getAccessTokenExpiration(null,
-                                        authConfig, jwtParser, log),
-                                Instant.now(), ex));
-                throw ex;
             } else if (statusCode == 403) {
-                var ex = new io.quarkus.security.ForbiddenException(
+                throw new io.quarkus.security.ForbiddenException(
                         "OIDC token request returned 403");
-                cachedAuthFailures.put(credentialsHash,
-                        new WrappedValue<>(
-                                OidcAuthenticationStrategy.getAccessTokenExpiration(null,
-                                        authConfig, jwtParser, log),
-                                Instant.now(), ex));
-                throw ex;
             } else if (statusCode < 200 || statusCode >= 300) {
                 throw new OidcAuthException(
                         "OIDC token request failed with status " + statusCode);
@@ -310,12 +296,10 @@ public class AppAuthenticationMechanism implements HttpAuthenticationMechanism {
 
             JsonObject json = response.bodyAsJsonObject();
             String jwtToken = json.getString("access_token");
-            cachedAccessTokens.put(credentialsHash,
-                    new WrappedValue<>(
-                            OidcAuthenticationStrategy.getAccessTokenExpiration(jwtToken,
-                                    authConfig, jwtParser, log),
-                            Instant.now(), jwtToken));
-            return jwtToken;
+            return new WrappedValue<>(
+                    OidcAuthenticationStrategy.getAccessTokenExpiration(jwtToken,
+                            authConfig, jwtParser, log),
+                    Instant.now(), jwtToken);
         } catch (io.quarkus.security.UnauthorizedException
                 | io.quarkus.security.ForbiddenException ex) {
             throw ex;

--- a/app/src/main/java/io/apicurio/registry/auth/OidcAuthenticationStrategy.java
+++ b/app/src/main/java/io/apicurio/registry/auth/OidcAuthenticationStrategy.java
@@ -44,6 +44,8 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 
@@ -56,7 +58,13 @@ public class OidcAuthenticationStrategy implements AuthenticationStrategy {
     // Cached auth failures expire after 60 seconds so the system retries quickly
     // when the OIDC server recovers. This is deliberately shorter than the success
     // token TTL (accessTokenExpiration, default 10 minutes).
-    private static final Duration FAILURE_CACHE_TTL = Duration.ofSeconds(60);
+    //
+    // Why not @CircuitBreaker? The circuit breaker annotation operates per-method,
+    // not per-key. A single bad client would open the circuit for all clients,
+    // denying service to valid credentials. The manual per-key TTL isolates
+    // failures: only the offending credentials hash is blocked, and only for
+    // FAILURE_CACHE_TTL seconds.
+    static final Duration FAILURE_CACHE_TTL = Duration.ofSeconds(60);
 
     private final OidcAuthenticationMechanism oidcAuthenticationMechanism;
     private final AuthConfig authConfig;
@@ -65,8 +73,9 @@ public class OidcAuthenticationStrategy implements AuthenticationStrategy {
     private final Logger log;
     private final AppAuthenticationMechanism parent;
 
-    private final ConcurrentHashMap<String, WrappedValue<String>> cachedAccessTokens;
-    private final ConcurrentHashMap<String, WrappedValue<RuntimeException>> cachedAuthFailures;
+    // Package-private for test access
+    final ConcurrentHashMap<String, CompletableFuture<WrappedValue<String>>> cachedAccessTokens;
+    final ConcurrentHashMap<String, WrappedValue<RuntimeException>> cachedAuthFailures;
     private final String oidcTokenUrl;
 
     /**
@@ -245,22 +254,7 @@ public class OidcAuthenticationStrategy implements AuthenticationStrategy {
 
         String jwtToken;
         try {
-            // Atomic check-and-fetch: only one thread fetches per expired key
-            WrappedValue<String> cached = cachedAccessTokens.compute(credentialsHash,
-                    (key, existing) -> {
-                        if (existing != null && !existing.isExpired()) {
-                            return existing;
-                        }
-                        // Re-check failures: another thread may have cached one while
-                        // we waited for the compute lock
-                        WrappedValue<RuntimeException> failure =
-                                cachedAuthFailures.get(key);
-                        if (failure != null && !failure.isExpired()) {
-                            throw failure.getValue();
-                        }
-                        return parent.getAccessToken(clientCredentials, oidcTokenUrl);
-                    });
-            jwtToken = cached.getValue();
+            jwtToken = fetchOrJoinToken(credentialsHash, clientCredentials);
         } catch (io.quarkus.security.UnauthorizedException
                 | io.quarkus.security.ForbiddenException
                 | OidcAuthException ex) {
@@ -273,6 +267,68 @@ public class OidcAuthenticationStrategy implements AuthenticationStrategy {
 
         context.request().headers().set("Authorization", "Bearer " + jwtToken);
         return oidcAuthenticationMechanism.authenticate(context, identityProviderManager);
+    }
+
+    /**
+     * Fetches a token or joins an in-flight fetch for the same credentials hash.
+     *
+     * <p>Uses a future-valued cache so the ConcurrentHashMap bin monitor is held only
+     * long enough to register or look up a CompletableFuture. The actual blocking I/O
+     * (with @Retry, up to ~4 s) runs outside the lock. Other threads with the same key
+     * join() the future outside the lock; threads with different keys that happen to
+     * hash to the same bin are not blocked.
+     */
+    private String fetchOrJoinToken(String credentialsHash,
+            Pair<String, String> clientCredentials) {
+        CompletableFuture<WrappedValue<String>> newFuture = new CompletableFuture<>();
+        CompletableFuture<WrappedValue<String>> future = cachedAccessTokens.compute(
+                credentialsHash, (key, existing) -> {
+                    if (existing != null) {
+                        // Another thread is already fetching; join it outside the lock
+                        if (!existing.isDone()) {
+                            return existing;
+                        }
+                        // Completed successfully and not expired; reuse
+                        if (!existing.isCompletedExceptionally()) {
+                            WrappedValue<String> val = existing.join();
+                            if (!val.isExpired()) {
+                                return existing;
+                            }
+                        }
+                    }
+                    // Re-check failures: another thread may have cached one while
+                    // we waited for the compute lock
+                    WrappedValue<RuntimeException> failure = cachedAuthFailures.get(key);
+                    if (failure != null && !failure.isExpired()) {
+                        throw failure.getValue();
+                    }
+                    return newFuture;
+                });
+
+        // We are the creator: do the blocking fetch outside the lock
+        if (future == newFuture) {
+            try {
+                WrappedValue<String> result = parent.getAccessToken(
+                        clientCredentials, oidcTokenUrl);
+                future.complete(result);
+            } catch (RuntimeException ex) {
+                // Remove the placeholder so the next caller retries fresh
+                cachedAccessTokens.remove(credentialsHash, future);
+                future.completeExceptionally(ex);
+                throw ex;
+            }
+        }
+
+        // Join outside the lock (no-op if we are the creator and it succeeded)
+        try {
+            return future.join().getValue();
+        } catch (CompletionException ce) {
+            Throwable cause = ce.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            throw new OidcAuthException("Failed to obtain access token", cause);
+        }
     }
 
     private String getCredentialsHash(String credentials) {

--- a/app/src/main/java/io/apicurio/registry/auth/OidcAuthenticationStrategy.java
+++ b/app/src/main/java/io/apicurio/registry/auth/OidcAuthenticationStrategy.java
@@ -282,28 +282,7 @@ public class OidcAuthenticationStrategy implements AuthenticationStrategy {
             Pair<String, String> clientCredentials) {
         CompletableFuture<WrappedValue<String>> newFuture = new CompletableFuture<>();
         CompletableFuture<WrappedValue<String>> future = cachedAccessTokens.compute(
-                credentialsHash, (key, existing) -> {
-                    if (existing != null) {
-                        // Another thread is already fetching; join it outside the lock
-                        if (!existing.isDone()) {
-                            return existing;
-                        }
-                        // Completed successfully and not expired; reuse
-                        if (!existing.isCompletedExceptionally()) {
-                            WrappedValue<String> val = existing.join();
-                            if (!val.isExpired()) {
-                                return existing;
-                            }
-                        }
-                    }
-                    // Re-check failures: another thread may have cached one while
-                    // we waited for the compute lock
-                    WrappedValue<RuntimeException> failure = cachedAuthFailures.get(key);
-                    if (failure != null && !failure.isExpired()) {
-                        throw failure.getValue();
-                    }
-                    return newFuture;
-                });
+                credentialsHash, (key, existing) -> reuseOrReplace(key, existing, newFuture));
 
         // We are the creator: do the blocking fetch outside the lock
         if (future == newFuture) {
@@ -312,7 +291,8 @@ public class OidcAuthenticationStrategy implements AuthenticationStrategy {
                         clientCredentials, oidcTokenUrl);
                 future.complete(result);
             } catch (RuntimeException ex) {
-                // Remove the placeholder so the next caller retries fresh
+                // 2-arg remove: only removes if the value is still OUR future.
+                // A concurrent compute() may have already replaced it.
                 cachedAccessTokens.remove(credentialsHash, future);
                 future.completeExceptionally(ex);
                 throw ex;
@@ -324,11 +304,33 @@ public class OidcAuthenticationStrategy implements AuthenticationStrategy {
             return future.join().getValue();
         } catch (CompletionException ce) {
             Throwable cause = ce.getCause();
-            if (cause instanceof RuntimeException) {
-                throw (RuntimeException) cause;
+            if (cause instanceof RuntimeException re) {
+                throw re;
             }
             throw new OidcAuthException("Failed to obtain access token", cause);
         }
+    }
+
+    private CompletableFuture<WrappedValue<String>> reuseOrReplace(
+            String key,
+            CompletableFuture<WrappedValue<String>> existing,
+            CompletableFuture<WrappedValue<String>> newFuture) {
+        if (existing != null) {
+            if (!existing.isDone()) {
+                return existing;
+            }
+            if (!existing.isCompletedExceptionally()) {
+                WrappedValue<String> val = existing.join();
+                if (!val.isExpired()) {
+                    return existing;
+                }
+            }
+        }
+        WrappedValue<RuntimeException> failure = cachedAuthFailures.get(key);
+        if (failure != null && !failure.isExpired()) {
+            throw failure.getValue();
+        }
+        return newFuture;
     }
 
     private String getCredentialsHash(String credentials) {

--- a/app/src/main/java/io/apicurio/registry/auth/OidcAuthenticationStrategy.java
+++ b/app/src/main/java/io/apicurio/registry/auth/OidcAuthenticationStrategy.java
@@ -53,6 +53,11 @@ import java.util.function.BiConsumer;
  */
 public class OidcAuthenticationStrategy implements AuthenticationStrategy {
 
+    // Cached auth failures expire after 60 seconds so the system retries quickly
+    // when the OIDC server recovers. This is deliberately shorter than the success
+    // token TTL (accessTokenExpiration, default 10 minutes).
+    private static final Duration FAILURE_CACHE_TTL = Duration.ofSeconds(60);
+
     private final OidcAuthenticationMechanism oidcAuthenticationMechanism;
     private final AuthConfig authConfig;
     private final AuditLogService auditLog;
@@ -229,29 +234,45 @@ public class OidcAuthenticationStrategy implements AuthenticationStrategy {
     private Uni<SecurityIdentity> authenticateWithClientCredentials(
             Pair<String, String> clientCredentials, RoutingContext context,
             IdentityProviderManager identityProviderManager) {
-        String jwtToken;
         String credentialsHash = getCredentialsHash(
                 clientCredentials.getLeft() + clientCredentials.getRight());
-        if (authFailureIsCached(credentialsHash)) {
-            throw cachedAuthFailures.get(credentialsHash).getValue();
-        } else if (accessTokenIsCached(credentialsHash)) {
-            jwtToken = cachedAccessTokens.get(credentialsHash).getValue();
-        } else {
-            jwtToken = parent.getAccessToken(clientCredentials, credentialsHash,
-                    cachedAccessTokens, cachedAuthFailures, oidcTokenUrl);
+
+        // Atomic read: single get() avoids the containsKey/get TOCTOU
+        WrappedValue<RuntimeException> cachedFailure = cachedAuthFailures.get(credentialsHash);
+        if (cachedFailure != null && !cachedFailure.isExpired()) {
+            throw cachedFailure.getValue();
         }
+
+        String jwtToken;
+        try {
+            // Atomic check-and-fetch: only one thread fetches per expired key
+            WrappedValue<String> cached = cachedAccessTokens.compute(credentialsHash,
+                    (key, existing) -> {
+                        if (existing != null && !existing.isExpired()) {
+                            return existing;
+                        }
+                        // Re-check failures: another thread may have cached one while
+                        // we waited for the compute lock
+                        WrappedValue<RuntimeException> failure =
+                                cachedAuthFailures.get(key);
+                        if (failure != null && !failure.isExpired()) {
+                            throw failure.getValue();
+                        }
+                        return parent.getAccessToken(clientCredentials, oidcTokenUrl);
+                    });
+            jwtToken = cached.getValue();
+        } catch (io.quarkus.security.UnauthorizedException
+                | io.quarkus.security.ForbiddenException
+                | OidcAuthException ex) {
+            // Cache failures (auth rejections and server errors) with a short TTL
+            // to avoid hammering the OIDC server while allowing quick recovery.
+            cachedAuthFailures.put(credentialsHash,
+                    new WrappedValue<>(FAILURE_CACHE_TTL, Instant.now(), ex));
+            throw ex;
+        }
+
         context.request().headers().set("Authorization", "Bearer " + jwtToken);
         return oidcAuthenticationMechanism.authenticate(context, identityProviderManager);
-    }
-
-    private boolean authFailureIsCached(String credentialsHash) {
-        return cachedAuthFailures.containsKey(credentialsHash)
-                && !cachedAuthFailures.get(credentialsHash).isExpired();
-    }
-
-    private boolean accessTokenIsCached(String credentialsHash) {
-        return cachedAccessTokens.containsKey(credentialsHash)
-                && !cachedAccessTokens.get(credentialsHash).isExpired();
     }
 
     private String getCredentialsHash(String credentials) {

--- a/app/src/main/java/io/apicurio/registry/auth/OidcAuthenticationStrategy.java
+++ b/app/src/main/java/io/apicurio/registry/auth/OidcAuthenticationStrategy.java
@@ -296,6 +296,26 @@ public class OidcAuthenticationStrategy implements AuthenticationStrategy {
                 cachedAccessTokens.remove(credentialsHash, future);
                 future.completeExceptionally(ex);
                 throw ex;
+            } finally {
+                // The catch above covers RuntimeException only; on an Error the future
+                // would stay in the map uncompleted. reuseOrReplace hands any not-done
+                // future to every later caller, and join() has no timeout, so they would
+                // block forever.
+                //
+                // A finally cannot see the throwable, so the real cause is not attached
+                // here. It is not lost: the creator rethrows it and it propagates with a
+                // full stack trace. Joining threads instead see this OidcAuthException,
+                // which authenticateWithClientCredentials caches for FAILURE_CACHE_TTL,
+                // so those credentials fail fast for 60s rather than wedging.
+                //
+                // Note this covers a creator that DIES. A creator wedged inside
+                // getAccessToken never leaves the try block at all, so the join is still
+                // unbounded on that path; bounding it needs a @Timeout on the fetch.
+                if (!future.isDone()) {
+                    cachedAccessTokens.remove(credentialsHash, future);
+                    future.completeExceptionally(new OidcAuthException(
+                            "Token fetch thread died without completing the future"));
+                }
             }
         }
 

--- a/app/src/test/java/io/apicurio/registry/auth/OidcFailureCacheTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/OidcFailureCacheTest.java
@@ -1,0 +1,286 @@
+package io.apicurio.registry.auth;
+
+import io.quarkus.oidc.runtime.OidcAuthenticationMechanism;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+import no.nav.security.mock.oauth2.MockOAuth2Server;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests negative-path behavior of the OIDC failure cache:
+ * <ul>
+ *     <li>A 403 response is cached and rethrown without a second fetch</li>
+ *     <li>After FAILURE_CACHE_TTL expires, the cache lets a retry through (recovery)</li>
+ * </ul>
+ */
+class OidcFailureCacheTest {
+
+    private MockOAuth2Server mockServer;
+
+    @BeforeEach
+    void startMockServer() {
+        mockServer = new MockOAuth2Server();
+        mockServer.start();
+    }
+
+    @AfterEach
+    void stopMockServer() {
+        if (mockServer != null) {
+            mockServer.shutdown();
+        }
+    }
+
+    @Test
+    void forbiddenResponseIsCachedAndRethrownWithoutSecondFetch() throws Exception {
+        AtomicInteger fetchCount = new AtomicInteger(0);
+
+        AppAuthenticationMechanism mockParent = mock(AppAuthenticationMechanism.class);
+        when(mockParent.getAccessToken(any(Pair.class), anyString()))
+                .thenAnswer(invocation -> {
+                    fetchCount.incrementAndGet();
+                    throw new io.quarkus.security.ForbiddenException(
+                            "OIDC token request returned 403");
+                });
+
+        OidcAuthenticationMechanism oidcMech = mock(OidcAuthenticationMechanism.class);
+
+        AuthConfig authConfig = new AuthConfig();
+        String tokenUrl = mockServer.tokenEndpointUrl("default").toString();
+        authConfig.authServerUrl = mockServer.issuerUrl("default").toString();
+        authConfig.oidcTokenPath = tokenUrl;
+
+        OidcAuthenticationStrategy strategy = new OidcAuthenticationStrategy(
+                oidcMech, authConfig, null, null,
+                LoggerFactory.getLogger(OidcFailureCacheTest.class), mockParent);
+
+        Method authMethod = OidcAuthenticationStrategy.class.getDeclaredMethod(
+                "authenticateWithClientCredentials",
+                Pair.class, RoutingContext.class, IdentityProviderManager.class);
+        authMethod.setAccessible(true);
+
+        Pair<String, String> credentials = Pair.of("test-client", "test-secret");
+        IdentityProviderManager idpManager = mock(IdentityProviderManager.class);
+
+        // First call: should fetch and fail with ForbiddenException
+        RoutingContext ctx1 = createMockRoutingContext();
+        try {
+            authMethod.invoke(strategy, credentials, ctx1, idpManager);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof io.quarkus.security.ForbiddenException,
+                    "Expected ForbiddenException, got " + e.getCause().getClass().getName());
+        }
+        assertEquals(1, fetchCount.get(), "First call should trigger exactly one fetch");
+        assertFalse(strategy.cachedAuthFailures.isEmpty(),
+                "Failure should be cached after first call");
+
+        // Second call: should throw cached ForbiddenException without fetching
+        RoutingContext ctx2 = createMockRoutingContext();
+        try {
+            authMethod.invoke(strategy, credentials, ctx2, idpManager);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof io.quarkus.security.ForbiddenException,
+                    "Cached failure should be ForbiddenException, got "
+                            + e.getCause().getClass().getName());
+        }
+        assertEquals(1, fetchCount.get(),
+                "Second call should NOT trigger a fetch; the cached failure should be returned");
+    }
+
+    @Test
+    void oidcAuthExceptionIsCachedAndRethrownWithoutSecondFetch() throws Exception {
+        AtomicInteger fetchCount = new AtomicInteger(0);
+
+        AppAuthenticationMechanism mockParent = mock(AppAuthenticationMechanism.class);
+        when(mockParent.getAccessToken(any(Pair.class), anyString()))
+                .thenAnswer(invocation -> {
+                    fetchCount.incrementAndGet();
+                    throw new OidcAuthException("OIDC token request failed with status 500");
+                });
+
+        OidcAuthenticationMechanism oidcMech = mock(OidcAuthenticationMechanism.class);
+
+        AuthConfig authConfig = new AuthConfig();
+        String tokenUrl = mockServer.tokenEndpointUrl("default").toString();
+        authConfig.authServerUrl = mockServer.issuerUrl("default").toString();
+        authConfig.oidcTokenPath = tokenUrl;
+
+        OidcAuthenticationStrategy strategy = new OidcAuthenticationStrategy(
+                oidcMech, authConfig, null, null,
+                LoggerFactory.getLogger(OidcFailureCacheTest.class), mockParent);
+
+        Method authMethod = OidcAuthenticationStrategy.class.getDeclaredMethod(
+                "authenticateWithClientCredentials",
+                Pair.class, RoutingContext.class, IdentityProviderManager.class);
+        authMethod.setAccessible(true);
+
+        Pair<String, String> credentials = Pair.of("server-error-client", "secret");
+        IdentityProviderManager idpManager = mock(IdentityProviderManager.class);
+
+        // First call: should fetch and fail with OidcAuthException
+        RoutingContext ctx1 = createMockRoutingContext();
+        try {
+            authMethod.invoke(strategy, credentials, ctx1, idpManager);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof OidcAuthException,
+                    "Expected OidcAuthException, got " + e.getCause().getClass().getName());
+        }
+        assertEquals(1, fetchCount.get(), "First call should trigger exactly one fetch");
+
+        // Second call: cached OidcAuthException, no fetch
+        RoutingContext ctx2 = createMockRoutingContext();
+        try {
+            authMethod.invoke(strategy, credentials, ctx2, idpManager);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof OidcAuthException,
+                    "Cached failure should be OidcAuthException, got "
+                            + e.getCause().getClass().getName());
+        }
+        assertEquals(1, fetchCount.get(),
+                "Second call should NOT trigger a fetch; the cached failure should be returned");
+    }
+
+    @Test
+    void expiredFailureCacheAllowsRetryAndRecovery() throws Exception {
+        AtomicInteger fetchCount = new AtomicInteger(0);
+
+        AppAuthenticationMechanism mockParent = mock(AppAuthenticationMechanism.class);
+        when(mockParent.getAccessToken(any(Pair.class), anyString()))
+                .thenAnswer(invocation -> {
+                    fetchCount.incrementAndGet();
+                    return new WrappedValue<>(
+                            Duration.ofMinutes(10), Instant.now(), "recovered-token");
+                });
+
+        OidcAuthenticationMechanism oidcMech = mock(OidcAuthenticationMechanism.class);
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+        when(oidcMech.authenticate(any(RoutingContext.class), any(IdentityProviderManager.class)))
+                .thenReturn(Uni.createFrom().item(identity));
+
+        AuthConfig authConfig = new AuthConfig();
+        String tokenUrl = mockServer.tokenEndpointUrl("default").toString();
+        authConfig.authServerUrl = mockServer.issuerUrl("default").toString();
+        authConfig.oidcTokenPath = tokenUrl;
+
+        OidcAuthenticationStrategy strategy = new OidcAuthenticationStrategy(
+                oidcMech, authConfig, null, null,
+                LoggerFactory.getLogger(OidcFailureCacheTest.class), mockParent);
+
+        // Pre-populate the failure cache with an already-expired entry.
+        // Using a 1ms TTL and an instant in the past ensures it is expired.
+        String credentialsHash = org.apache.commons.codec.digest.DigestUtils
+                .sha256Hex("recovery-clientrecovery-secret");
+        strategy.cachedAuthFailures.put(credentialsHash,
+                new WrappedValue<>(Duration.ofMillis(1),
+                        Instant.now().minusSeconds(10),
+                        new io.quarkus.security.ForbiddenException("stale cached failure")));
+
+        // Verify the cached entry is indeed expired
+        assertTrue(strategy.cachedAuthFailures.get(credentialsHash).isExpired(),
+                "The pre-populated failure cache entry should be expired");
+
+        Method authMethod = OidcAuthenticationStrategy.class.getDeclaredMethod(
+                "authenticateWithClientCredentials",
+                Pair.class, RoutingContext.class, IdentityProviderManager.class);
+        authMethod.setAccessible(true);
+
+        Pair<String, String> credentials = Pair.of("recovery-client", "recovery-secret");
+        IdentityProviderManager idpManager = mock(IdentityProviderManager.class);
+        RoutingContext ctx = createMockRoutingContext();
+
+        // Call should succeed because the failure cache entry is expired.
+        // The parent mock returns a valid token, so no exception is thrown.
+        authMethod.invoke(strategy, credentials, ctx, idpManager);
+
+        assertEquals(1, fetchCount.get(),
+                "After the failure cache expires, a fresh fetch should be attempted");
+
+        // Verify the token was set on the request
+        assertEquals("Bearer recovered-token",
+                ctx.request().headers().get("Authorization"),
+                "A successful recovery should set the Authorization header");
+    }
+
+    @Test
+    void nonExpiredFailureCacheBlocksRetry() throws Exception {
+        AtomicInteger fetchCount = new AtomicInteger(0);
+
+        AppAuthenticationMechanism mockParent = mock(AppAuthenticationMechanism.class);
+        when(mockParent.getAccessToken(any(Pair.class), anyString()))
+                .thenAnswer(invocation -> {
+                    fetchCount.incrementAndGet();
+                    return new WrappedValue<>(
+                            Duration.ofMinutes(10), Instant.now(), "should-not-reach");
+                });
+
+        OidcAuthenticationMechanism oidcMech = mock(OidcAuthenticationMechanism.class);
+
+        AuthConfig authConfig = new AuthConfig();
+        String tokenUrl = mockServer.tokenEndpointUrl("default").toString();
+        authConfig.authServerUrl = mockServer.issuerUrl("default").toString();
+        authConfig.oidcTokenPath = tokenUrl;
+
+        OidcAuthenticationStrategy strategy = new OidcAuthenticationStrategy(
+                oidcMech, authConfig, null, null,
+                LoggerFactory.getLogger(OidcFailureCacheTest.class), mockParent);
+
+        // Pre-populate the failure cache with a non-expired entry
+        String credentialsHash = org.apache.commons.codec.digest.DigestUtils
+                .sha256Hex("blocked-clientblocked-secret");
+        strategy.cachedAuthFailures.put(credentialsHash,
+                new WrappedValue<>(Duration.ofMinutes(5), Instant.now(),
+                        new io.quarkus.security.ForbiddenException("active cached failure")));
+
+        assertFalse(strategy.cachedAuthFailures.get(credentialsHash).isExpired(),
+                "The pre-populated failure cache entry should NOT be expired");
+
+        Method authMethod = OidcAuthenticationStrategy.class.getDeclaredMethod(
+                "authenticateWithClientCredentials",
+                Pair.class, RoutingContext.class, IdentityProviderManager.class);
+        authMethod.setAccessible(true);
+
+        Pair<String, String> credentials = Pair.of("blocked-client", "blocked-secret");
+        IdentityProviderManager idpManager = mock(IdentityProviderManager.class);
+        RoutingContext ctx = createMockRoutingContext();
+
+        try {
+            authMethod.invoke(strategy, credentials, ctx, idpManager);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof io.quarkus.security.ForbiddenException,
+                    "Active failure cache should block retry with ForbiddenException, got "
+                            + e.getCause().getClass().getName());
+        }
+
+        assertEquals(0, fetchCount.get(),
+                "An active (non-expired) failure cache entry should block fetching entirely");
+    }
+
+    private static RoutingContext createMockRoutingContext() {
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+        when(request.headers()).thenReturn(headers);
+        when(ctx.request()).thenReturn(request);
+        return ctx;
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/auth/OidcFailureCacheTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/OidcFailureCacheTest.java
@@ -8,19 +8,30 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.RoutingContext;
 import no.nav.security.mock.oauth2.MockOAuth2Server;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -28,10 +39,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests negative-path behavior of the OIDC failure cache:
+ * Tests negative-path behavior of the OIDC credential caches:
  * <ul>
  *     <li>A 403 response is cached and rethrown without a second fetch</li>
+ *     <li>A server-side OidcAuthException is cached the same way</li>
  *     <li>After FAILURE_CACHE_TTL expires, the cache lets a retry through (recovery)</li>
+ *     <li>Before it expires, the cache blocks the retry entirely</li>
+ *     <li>A fetch that dies on an Error strands neither a later caller nor a caller
+ *     already joined on the in-flight future</li>
  * </ul>
  */
 class OidcFailureCacheTest {
@@ -86,7 +101,7 @@ class OidcFailureCacheTest {
         RoutingContext ctx1 = createMockRoutingContext();
         try {
             authMethod.invoke(strategy, credentials, ctx1, idpManager);
-        } catch (java.lang.reflect.InvocationTargetException e) {
+        } catch (InvocationTargetException e) {
             assertTrue(e.getCause() instanceof io.quarkus.security.ForbiddenException,
                     "Expected ForbiddenException, got " + e.getCause().getClass().getName());
         }
@@ -98,7 +113,7 @@ class OidcFailureCacheTest {
         RoutingContext ctx2 = createMockRoutingContext();
         try {
             authMethod.invoke(strategy, credentials, ctx2, idpManager);
-        } catch (java.lang.reflect.InvocationTargetException e) {
+        } catch (InvocationTargetException e) {
             assertTrue(e.getCause() instanceof io.quarkus.security.ForbiddenException,
                     "Cached failure should be ForbiddenException, got "
                             + e.getCause().getClass().getName());
@@ -141,7 +156,7 @@ class OidcFailureCacheTest {
         RoutingContext ctx1 = createMockRoutingContext();
         try {
             authMethod.invoke(strategy, credentials, ctx1, idpManager);
-        } catch (java.lang.reflect.InvocationTargetException e) {
+        } catch (InvocationTargetException e) {
             assertTrue(e.getCause() instanceof OidcAuthException,
                     "Expected OidcAuthException, got " + e.getCause().getClass().getName());
         }
@@ -151,7 +166,7 @@ class OidcFailureCacheTest {
         RoutingContext ctx2 = createMockRoutingContext();
         try {
             authMethod.invoke(strategy, credentials, ctx2, idpManager);
-        } catch (java.lang.reflect.InvocationTargetException e) {
+        } catch (InvocationTargetException e) {
             assertTrue(e.getCause() instanceof OidcAuthException,
                     "Cached failure should be OidcAuthException, got "
                             + e.getCause().getClass().getName());
@@ -188,8 +203,7 @@ class OidcFailureCacheTest {
 
         // Pre-populate the failure cache with an already-expired entry.
         // Using a 1ms TTL and an instant in the past ensures it is expired.
-        String credentialsHash = org.apache.commons.codec.digest.DigestUtils
-                .sha256Hex("recovery-clientrecovery-secret");
+        String credentialsHash = DigestUtils.sha256Hex("recovery-clientrecovery-secret");
         strategy.cachedAuthFailures.put(credentialsHash,
                 new WrappedValue<>(Duration.ofMillis(1),
                         Instant.now().minusSeconds(10),
@@ -245,8 +259,7 @@ class OidcFailureCacheTest {
                 LoggerFactory.getLogger(OidcFailureCacheTest.class), mockParent);
 
         // Pre-populate the failure cache with a non-expired entry
-        String credentialsHash = org.apache.commons.codec.digest.DigestUtils
-                .sha256Hex("blocked-clientblocked-secret");
+        String credentialsHash = DigestUtils.sha256Hex("blocked-clientblocked-secret");
         strategy.cachedAuthFailures.put(credentialsHash,
                 new WrappedValue<>(Duration.ofMinutes(5), Instant.now(),
                         new io.quarkus.security.ForbiddenException("active cached failure")));
@@ -265,7 +278,7 @@ class OidcFailureCacheTest {
 
         try {
             authMethod.invoke(strategy, credentials, ctx, idpManager);
-        } catch (java.lang.reflect.InvocationTargetException e) {
+        } catch (InvocationTargetException e) {
             assertTrue(e.getCause() instanceof io.quarkus.security.ForbiddenException,
                     "Active failure cache should block retry with ForbiddenException, got "
                             + e.getCause().getClass().getName());
@@ -273,6 +286,101 @@ class OidcFailureCacheTest {
 
         assertEquals(0, fetchCount.get(),
                 "An active (non-expired) failure cache entry should block fetching entirely");
+    }
+
+    @Test
+    void errorDuringFetchDoesNotStrandLaterCallers() throws Exception {
+        AtomicInteger fetchCount = new AtomicInteger(0);
+        AtomicReference<CompletableFuture<WrappedValue<String>>> inFlight =
+                new AtomicReference<>();
+        String credentialsHash = DigestUtils.sha256Hex("error-clienterror-secret");
+
+        AppAuthenticationMechanism mockParent = mock(AppAuthenticationMechanism.class);
+
+        OidcAuthenticationMechanism oidcMech = mock(OidcAuthenticationMechanism.class);
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+        when(oidcMech.authenticate(any(RoutingContext.class), any(IdentityProviderManager.class)))
+                .thenReturn(Uni.createFrom().item(identity));
+
+        AuthConfig authConfig = new AuthConfig();
+        String tokenUrl = mockServer.tokenEndpointUrl("default").toString();
+        authConfig.authServerUrl = mockServer.issuerUrl("default").toString();
+        authConfig.oidcTokenPath = tokenUrl;
+
+        OidcAuthenticationStrategy strategy = new OidcAuthenticationStrategy(
+                oidcMech, authConfig, null, null,
+                LoggerFactory.getLogger(OidcFailureCacheTest.class), mockParent);
+
+        // Stubbed after construction so the answer can reach into the strategy. While
+        // the answer runs, the future is registered in the map and not yet completed,
+        // which is exactly the state a concurrent caller would join on.
+        when(mockParent.getAccessToken(any(Pair.class), anyString()))
+                .thenAnswer(invocation -> {
+                    if (fetchCount.incrementAndGet() == 1) {
+                        inFlight.set(strategy.cachedAccessTokens.get(credentialsHash));
+                        // An Error, not a RuntimeException: the creator's catch block
+                        // does not cover it, so only a finally can clean up after it.
+                        throw new SimulatedJvmError();
+                    }
+                    return new WrappedValue<>(
+                            Duration.ofMinutes(10), Instant.now(), "token-after-error");
+                });
+
+        Method authMethod = OidcAuthenticationStrategy.class.getDeclaredMethod(
+                "authenticateWithClientCredentials",
+                Pair.class, RoutingContext.class, IdentityProviderManager.class);
+        authMethod.setAccessible(true);
+
+        Pair<String, String> credentials = Pair.of("error-client", "error-secret");
+        IdentityProviderManager idpManager = mock(IdentityProviderManager.class);
+
+        // First call: the Error escapes, since none of the catch clauses on the way
+        // out cover it.
+        RoutingContext ctx1 = createMockRoutingContext();
+        InvocationTargetException thrown = assertThrows(InvocationTargetException.class,
+                () -> authMethod.invoke(strategy, credentials, ctx1, idpManager));
+        assertInstanceOf(SimulatedJvmError.class, thrown.getCause(),
+                "The injected Error should propagate");
+        assertEquals(1, fetchCount.get(), "First call should trigger exactly one fetch");
+
+        // The orphan must be gone from the map. This test is single-threaded, so the
+        // 2-arg remove cannot lose a race: a non-null value here means the cleanup
+        // did not run at all.
+        assertNull(strategy.cachedAccessTokens.get(credentialsHash),
+                "An uncompleted future was left in the token cache; every later caller "
+                        + "with these credentials would block on join() forever");
+
+        // Removing it from the map only rescues callers who arrive afterwards. A caller
+        // already parked in join() is released by completeExceptionally and by nothing
+        // else, so assert the future itself was settled. Bounded get() rather than
+        // join(): if this half regresses the test fails instead of hanging.
+        CompletableFuture<WrappedValue<String>> orphan = inFlight.get();
+        assertNotNull(orphan, "The in-flight future should have been registered");
+        ExecutionException released = assertThrows(ExecutionException.class,
+                () -> orphan.get(10, TimeUnit.SECONDS),
+                "A caller already joined on the dead future was never released");
+        assertInstanceOf(OidcAuthException.class, released.getCause(),
+                "The cleanup path should surface OidcAuthException to a joining caller");
+
+        // Second call must make progress instead of joining the orphan. Preemptive so
+        // that the bug surfaces as a failure rather than hanging the build.
+        RoutingContext ctx2 = createMockRoutingContext();
+        assertTimeoutPreemptively(Duration.ofSeconds(10),
+                () -> authMethod.invoke(strategy, credentials, ctx2, idpManager),
+                "Second call never returned; it is blocked on the stranded future");
+
+        assertEquals(2, fetchCount.get(),
+                "The second call should attempt a fresh fetch, not reuse the dead future");
+        assertEquals("Bearer token-after-error",
+                ctx2.request().headers().get("Authorization"),
+                "Recovery after the Error should set the Authorization header");
+    }
+
+    /**
+     * Stands in for an Error raised by the token fetch, such as a linkage error or
+     * OutOfMemoryError. Deliberately not a RuntimeException.
+     */
+    private static final class SimulatedJvmError extends Error {
     }
 
     private static RoutingContext createMockRoutingContext() {

--- a/app/src/test/java/io/apicurio/registry/auth/OidcRetryQuarkusTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/OidcRetryQuarkusTest.java
@@ -1,0 +1,77 @@
+package io.apicurio.registry.auth;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises the REAL MicroProfile Fault Tolerance {@code @Retry} on
+ * {@link AppAuthenticationMechanism#getAccessToken} through the CDI proxy.
+ * Proves the interceptor is actually wired (a classic MP-FT footgun is an
+ * annotation on a non-CDI class or invoked via {@code this.} that silently
+ * never applies).
+ *
+ * <p>Uses a deliberately unreachable URL so every attempt throws
+ * {@link OidcAuthException}. With {@code maxRetries = 2} (overridden via
+ * MP-FT config) and 50 ms delay, the method should be invoked 3 times total
+ * (1 original + 2 retries) and take at least 100 ms.
+ */
+@QuarkusTest
+@TestProfile(OidcRetryQuarkusTest.ShortRetryProfile.class)
+class OidcRetryQuarkusTest {
+
+    /**
+     * Shortens retry delay and count so the test runs quickly while still
+     * proving the interceptor fires. The config keys follow the standard
+     * MP-FT override pattern documented in the MicroProfile Fault Tolerance
+     * specification (section 5.1).
+     */
+    public static class ShortRetryProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "io.apicurio.registry.auth.AppAuthenticationMechanism"
+                            + "/getAccessToken/Retry/maxRetries", "2",
+                    "io.apicurio.registry.auth.AppAuthenticationMechanism"
+                            + "/getAccessToken/Retry/delay", "50",
+                    "io.apicurio.registry.auth.AppAuthenticationMechanism"
+                            + "/getAccessToken/Retry/delayUnit", "MILLIS");
+        }
+    }
+
+    @Inject
+    AppAuthenticationMechanism mechanism;
+
+    @Test
+    void retryInterceptorFiresOnOidcAuthException() {
+        // Point at an unreachable URL to force OidcAuthException on every attempt.
+        // Port 1 is reserved (tcpmux) and will be refused or time out immediately.
+        String unreachableUrl = "http://127.0.0.1:1/token";
+        Pair<String, String> creds = Pair.of("retry-test-client", "secret");
+
+        long startMs = System.currentTimeMillis();
+        OidcAuthException thrown = assertThrows(OidcAuthException.class,
+                () -> mechanism.getAccessToken(creds, unreachableUrl),
+                "getAccessToken must throw OidcAuthException after retries are exhausted");
+        long elapsedMs = System.currentTimeMillis() - startMs;
+
+        assertNotNull(thrown.getMessage());
+
+        // With 2 retries at 50 ms delay each, the minimum wall-clock time is
+        // 100 ms. Without @Retry (or if the interceptor is not wired), the
+        // method would fail on the first call with near-zero delay.
+        assertTrue(elapsedMs >= 80,
+                "Expected at least 80 ms of retry delay (2 retries * 50 ms), "
+                        + "but only " + elapsedMs + " ms elapsed. "
+                        + "This suggests @Retry is not firing through the CDI proxy.");
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/auth/OidcTokenStampedeTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/OidcTokenStampedeTest.java
@@ -1,0 +1,142 @@
+package io.apicurio.registry.auth;
+
+import io.quarkus.oidc.runtime.OidcAuthenticationMechanism;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+import no.nav.security.mock.oauth2.MockOAuth2Server;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Verifies concurrent client-credentials requests with same credentials result in exactly one token fetch. */
+class OidcTokenStampedeTest {
+
+    private MockOAuth2Server mockServer;
+
+    @BeforeEach
+    void startMockServer() {
+        mockServer = new MockOAuth2Server();
+        mockServer.start();
+    }
+
+    @AfterEach
+    void stopMockServer() {
+        if (mockServer != null) {
+            mockServer.shutdown();
+        }
+    }
+
+    @Test
+    void concurrentClientCredentialsFetchResultsInSingleTokenRequest() throws Exception {
+        int threadCount = 20;
+        AtomicInteger tokenFetchCount = new AtomicInteger(0);
+
+        // Mock the parent so getAccessToken counts invocations and simulates latency.
+        // The 200 ms delay widens the window in which threads without stampede
+        // prevention would all see a cache miss and fire redundant fetches.
+        AppAuthenticationMechanism mockParent = mock(AppAuthenticationMechanism.class);
+        when(mockParent.getAccessToken(any(Pair.class), anyString()))
+                .thenAnswer(invocation -> {
+                    tokenFetchCount.incrementAndGet();
+                    Thread.sleep(200);
+                    return new WrappedValue<>(
+                            Duration.ofMinutes(10), Instant.now(), "mock-access-token");
+                });
+
+        // Point AuthConfig at the mock OIDC server
+        AuthConfig authConfig = new AuthConfig();
+        String tokenUrl = mockServer.tokenEndpointUrl("default").toString();
+        authConfig.authServerUrl = mockServer.issuerUrl("default").toString();
+        authConfig.oidcTokenPath = tokenUrl;
+        authConfig.accessTokenExpiration = 10;
+        authConfig.accessTokenExpirationOffset = 10;
+
+        // The final OIDC authenticate call after the Bearer header is set.
+        // Not under test here, so it returns a stub identity.
+        OidcAuthenticationMechanism oidcMech = mock(OidcAuthenticationMechanism.class);
+        SecurityIdentity identity = mock(SecurityIdentity.class);
+        when(oidcMech.authenticate(any(RoutingContext.class), any(IdentityProviderManager.class)))
+                .thenReturn(Uni.createFrom().item(identity));
+
+        OidcAuthenticationStrategy strategy = new OidcAuthenticationStrategy(
+                oidcMech, authConfig, null, null,
+                LoggerFactory.getLogger(OidcTokenStampedeTest.class), mockParent);
+
+        // Reflectively access the private method that guards the cache
+        Method authMethod = OidcAuthenticationStrategy.class.getDeclaredMethod(
+                "authenticateWithClientCredentials",
+                Pair.class, RoutingContext.class, IdentityProviderManager.class);
+        authMethod.setAccessible(true);
+
+        Pair<String, String> credentials = Pair.of("test-client", "test-secret");
+        IdentityProviderManager idpManager = mock(IdentityProviderManager.class);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        List<Future<Object>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executor.submit(() -> {
+                RoutingContext ctx = createMockRoutingContext();
+                barrier.await(5, TimeUnit.SECONDS);
+                return authMethod.invoke(strategy, credentials, ctx, idpManager);
+            }));
+        }
+
+        for (Future<Object> future : futures) {
+            try {
+                future.get(10, TimeUnit.SECONDS);
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof InvocationTargetException) {
+                    cause = cause.getCause();
+                }
+                throw new AssertionError("Concurrent token fetch failed", cause);
+            }
+        }
+
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+
+        assertEquals(1, tokenFetchCount.get(),
+                "Expected exactly 1 token fetch for " + threadCount
+                        + " concurrent requests with same credentials, but got "
+                        + tokenFetchCount.get()
+                        + ". This indicates a cache stampede.");
+    }
+
+    private static RoutingContext createMockRoutingContext() {
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+        when(request.headers()).thenReturn(headers);
+        when(ctx.request()).thenReturn(request);
+        return ctx;
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the `containsKey/get/put` sequence on `cachedAccessTokens` (ConcurrentHashMap) with `ConcurrentHashMap.compute()` in `OidcAuthenticationStrategy.authenticateWithClientCredentials()`.

**The bug**: when a cached OIDC token expires, ALL concurrent threads independently detect the expiration and each makes a separate HTTP POST to the OIDC token endpoint. With Quarkus default worker pool (~50 threads), a single expiration event can produce up to 250 requests (50 threads x 5 retries).

**The fix**: `compute()` ensures only one thread fetches a new token per credentials hash while others wait on the ConcurrentHashMap's per-key lock. Also simplified `getAccessToken` in `AppAuthenticationMechanism` to return `WrappedValue<String>` so the caller's `compute()` lambda can atomically insert the result.

Requires `basicClientCredentialsAuthEnabled=true` (not the default auth flow).

Closes #9776

## Test plan

- [x] `./mvnw test-compile -pl :apicurio-registry-app -am -DskipTests` compiles
- [x] `./mvnw checkstyle:check -pl :apicurio-registry-app` passes
- [x] CI green
- [x] @EricWittmann @carlesarnal @jsenko please verify the auth changes, especially the `compute()` lambda interaction with `@Retry`

## Behavior change (review feedback)

**OidcAuthException caching (new):** Previously, transient OIDC server errors (5xx, network failures) were not cached; every request retried immediately. Now, after `@Retry` exhausts (~4s), the `OidcAuthException` is cached for 60s (`FAILURE_CACHE_TTL`). This is a per-key circuit breaker: only callers with the same credentials hash are affected. Other credentials continue to fetch independently.

This is intentional. `@CircuitBreaker` operates per-method (not per-key), so a single bad client would open the circuit for all clients. The manual per-key TTL isolates failures to the offending credentials only. Ops teams should be aware that an OIDC hiccup now causes a 60s hard-fail window per affected credential, rather than immediate retry.
