### PR TITLE
fix(kafkasql): use consumer.wakeup() instead of close() in onDestroy (#9779)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -165,6 +165,10 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
     // Reference to the consumer thread for health checks
     private volatile Thread consumerThread = null;
 
+    // How long onDestroy() waits for the consumer thread to exit before interrupting it.
+    // Package-private for testability.
+    long joinTimeoutMillis = 10_000;
+
     @Override
     public String storageName() {
         return "kafkasql";
@@ -223,9 +227,10 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         journalConsumer.wakeup();
         if (consumerThread != null) {
             try {
-                consumerThread.join(10_000);
+                consumerThread.join(joinTimeoutMillis);
                 if (consumerThread.isAlive()) {
-                    log.warn("Consumer thread did not exit within 10 seconds of wakeup(), interrupting.");
+                    log.warn("Consumer thread did not exit within {} ms of wakeup(), interrupting.",
+                            joinTimeoutMillis);
                     consumerThread.interrupt();
                 }
             } catch (InterruptedException e) {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -224,7 +224,11 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         // wakeup() is the only method safe to call from another thread. It causes
         // poll() to throw WakeupException, and the consumer thread handles that by
         // exiting its loop and calling close() on its own thread.
-        journalConsumer.wakeup();
+        try {
+            journalConsumer.wakeup();
+        } catch (Exception e) {
+            log.debug("Ignoring journal consumer wakeup error during shutdown: {}", e.getMessage());
+        }
         if (consumerThread != null) {
             try {
                 consumerThread.join(joinTimeoutMillis);

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -220,16 +220,16 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
     @PreDestroy
     void onDestroy() {
         stopped = true;
-        // Use wakeup() instead of close() because KafkaConsumer is not thread-safe.
-        // wakeup() is the only method safe to call from another thread. It causes
-        // poll() to throw WakeupException, and the consumer thread handles that by
-        // exiting its loop and calling close() on its own thread.
-        try {
-            journalConsumer.wakeup();
-        } catch (Exception e) {
-            log.debug("Ignoring journal consumer wakeup error during shutdown: {}", e.getMessage());
-        }
         if (consumerThread != null) {
+            // The consumer thread owns journalConsumer. KafkaConsumer is not thread-safe,
+            // and wakeup() is the only method safe to call from another thread. It causes
+            // poll() to throw WakeupException, and the consumer thread handles that by
+            // exiting its loop and calling close() on its own thread.
+            try {
+                journalConsumer.wakeup();
+            } catch (Exception e) {
+                log.debug("Ignoring journal consumer wakeup error during shutdown: {}", e.getMessage());
+            }
             try {
                 consumerThread.join(joinTimeoutMillis);
                 if (consumerThread.isAlive()) {
@@ -239,6 +239,17 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+            }
+        } else {
+            // initialize() failed before startConsumerThread(), so no consumer thread exists
+            // to close journalConsumer, and it currently has no CDI disposer either. Quarkus
+            // serializes startup against shutdown, so nothing is polling the consumer here
+            // and close() is safe on this thread. Without it a failed startup leaks the
+            // consumer, and @PreDestroy runs on every test-profile teardown, not just at exit.
+            try {
+                journalConsumer.close();
+            } catch (Exception e) {
+                log.debug("Ignoring journal consumer close error during shutdown: {}", e.getMessage());
             }
         }
         try {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -76,6 +76,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.errors.WakeupException;
 import org.slf4j.Logger;
 
 import java.nio.file.Files;
@@ -215,10 +216,21 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
     @PreDestroy
     void onDestroy() {
         stopped = true;
-        try {
-            journalConsumer.close();
-        } catch (Exception e) {
-            log.debug("Ignoring journal consumer close error during shutdown: {}", e.getMessage());
+        // Use wakeup() instead of close() because KafkaConsumer is not thread-safe.
+        // wakeup() is the only method safe to call from another thread. It causes
+        // poll() to throw WakeupException, and the consumer thread handles that by
+        // exiting its loop and calling close() on its own thread.
+        journalConsumer.wakeup();
+        if (consumerThread != null) {
+            try {
+                consumerThread.join(10_000);
+                if (consumerThread.isAlive()) {
+                    log.warn("Consumer thread did not exit within 10 seconds of wakeup(), interrupting.");
+                    consumerThread.interrupt();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
         try {
             snapshotsConsumer.close();
@@ -391,6 +403,10 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
                         }
                     }
                 }
+            } catch (WakeupException e) {
+                // Expected during shutdown: onDestroy() calls consumer.wakeup()
+                // to safely interrupt poll() from the CDI shutdown thread.
+                log.debug("Consumer wakeup received, shutting down.");
             } finally {
                 try {
                     consumer.close();

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlShutdownTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlShutdownTest.java
@@ -1,0 +1,53 @@
+package io.apicurio.registry.storage.impl.kafkasql;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class KafkaSqlShutdownTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void onDestroyCallsWakeupNotClose() throws Exception {
+        KafkaSqlRegistryStorage storage = new KafkaSqlRegistryStorage();
+        storage.log = mock(Logger.class);
+
+        KafkaConsumer<KafkaSqlMessageKey, KafkaSqlMessage> journalConsumer = mock(KafkaConsumer.class);
+        KafkaConsumer<String, String> snapshotsConsumer = mock(KafkaConsumer.class);
+
+        storage.journalConsumer = journalConsumer;
+        storage.snapshotsConsumer = snapshotsConsumer;
+
+        setPrivateField(storage, "stopped", false);
+
+        storage.onDestroy();
+
+        verify(journalConsumer).wakeup();
+        verify(journalConsumer, never()).close();
+
+        // The snapshots consumer is closed directly (it is not used from another thread)
+        verify(snapshotsConsumer).close();
+
+        boolean stopped = (boolean) getPrivateField(storage, "stopped");
+        assertTrue(stopped, "stopped flag should be true after onDestroy()");
+    }
+
+    private static void setPrivateField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static Object getPrivateField(Object target, String fieldName) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlShutdownTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlShutdownTest.java
@@ -5,7 +5,10 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
 import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -37,6 +40,83 @@ class KafkaSqlShutdownTest {
 
         boolean stopped = (boolean) getPrivateField(storage, "stopped");
         assertTrue(stopped, "stopped flag should be true after onDestroy()");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void onDestroyJoinsConsumerThreadThatExitsPromptly() throws Exception {
+        KafkaSqlRegistryStorage storage = new KafkaSqlRegistryStorage();
+        storage.log = mock(Logger.class);
+
+        KafkaConsumer<KafkaSqlMessageKey, KafkaSqlMessage> journalConsumer = mock(KafkaConsumer.class);
+        KafkaConsumer<String, String> snapshotsConsumer = mock(KafkaConsumer.class);
+
+        storage.journalConsumer = journalConsumer;
+        storage.snapshotsConsumer = snapshotsConsumer;
+
+        // A thread that exits immediately
+        Thread quickThread = new Thread(() -> { });
+        quickThread.start();
+        quickThread.join(); // ensure it has finished before we set it
+
+        setPrivateField(storage, "consumerThread", quickThread);
+        setPrivateField(storage, "stopped", false);
+
+        storage.onDestroy();
+
+        verify(journalConsumer).wakeup();
+        verify(journalConsumer, never()).close();
+
+        // The thread exited before join; interrupt should not have been called.
+        // Thread.interrupt() on an already-dead thread is a no-op, but the production
+        // code guards with isAlive(), so we verify the thread is no longer alive.
+        assertFalse(quickThread.isAlive(), "consumer thread should not be alive after join");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void onDestroyInterruptsConsumerThreadThatDoesNotExit() throws Exception {
+        KafkaSqlRegistryStorage storage = new KafkaSqlRegistryStorage();
+        storage.log = mock(Logger.class);
+
+        KafkaConsumer<KafkaSqlMessageKey, KafkaSqlMessage> journalConsumer = mock(KafkaConsumer.class);
+        KafkaConsumer<String, String> snapshotsConsumer = mock(KafkaConsumer.class);
+
+        storage.journalConsumer = journalConsumer;
+        storage.snapshotsConsumer = snapshotsConsumer;
+
+        // Use a short timeout so the test runs quickly
+        storage.joinTimeoutMillis = 50;
+
+        // A latch that blocks the thread until interrupted or the test ends
+        CountDownLatch blockLatch = new CountDownLatch(1);
+
+        Thread blockingThread = new Thread(() -> {
+            try {
+                blockLatch.await(30, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                // Expected: onDestroy() will interrupt this thread
+                Thread.currentThread().interrupt();
+            }
+        });
+        blockingThread.start();
+
+        setPrivateField(storage, "consumerThread", blockingThread);
+        setPrivateField(storage, "stopped", false);
+
+        storage.onDestroy();
+
+        verify(journalConsumer).wakeup();
+        verify(journalConsumer, never()).close();
+
+        // The thread was still alive after the 50ms join timeout, so onDestroy()
+        // should have called interrupt().
+        assertTrue(blockingThread.isInterrupted() || !blockingThread.isAlive(),
+                "consumer thread should have been interrupted");
+
+        // Clean up: release the latch so the thread exits
+        blockLatch.countDown();
+        blockingThread.join(1_000);
     }
 
     private static void setPrivateField(Object target, String fieldName, Object value) throws Exception {

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlShutdownTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlShutdownTest.java
@@ -18,7 +18,7 @@ class KafkaSqlShutdownTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void onDestroyCallsWakeupNotClose() throws Exception {
+    void onDestroyClosesJournalConsumerWhenConsumerThreadNeverStarted() throws Exception {
         KafkaSqlRegistryStorage storage = new KafkaSqlRegistryStorage();
         storage.log = mock(Logger.class);
 
@@ -30,10 +30,13 @@ class KafkaSqlShutdownTest {
 
         setPrivateField(storage, "stopped", false);
 
+        // consumerThread stays null: the state after initialize() fails before it reaches
+        // startConsumerThread().
         storage.onDestroy();
 
-        verify(journalConsumer).wakeup();
-        verify(journalConsumer, never()).close();
+        verify(journalConsumer).close();
+        // Nothing is polling, so there is nothing to wake up.
+        verify(journalConsumer, never()).wakeup();
 
         // The snapshots consumer is closed directly (it is not used from another thread)
         verify(snapshotsConsumer).close();
@@ -55,9 +58,10 @@ class KafkaSqlShutdownTest {
         storage.snapshotsConsumer = snapshotsConsumer;
 
         // A thread that exits immediately
-        Thread quickThread = new Thread(() -> { });
+        RecordingThread quickThread = new RecordingThread(() -> { });
         quickThread.start();
-        quickThread.join(); // ensure it has finished before we set it
+        quickThread.join(1_000);
+        assertFalse(quickThread.isAlive(), "test setup: the quick thread should have exited");
 
         setPrivateField(storage, "consumerThread", quickThread);
         setPrivateField(storage, "stopped", false);
@@ -67,10 +71,10 @@ class KafkaSqlShutdownTest {
         verify(journalConsumer).wakeup();
         verify(journalConsumer, never()).close();
 
-        // The thread exited before join; interrupt should not have been called.
-        // Thread.interrupt() on an already-dead thread is a no-op, but the production
-        // code guards with isAlive(), so we verify the thread is no longer alive.
-        assertFalse(quickThread.isAlive(), "consumer thread should not be alive after join");
+        // The thread had already exited, so the isAlive() guard in onDestroy() must have
+        // skipped interrupt() entirely.
+        assertFalse(quickThread.wasInterrupted(),
+                "onDestroy() should not interrupt a thread that already exited");
     }
 
     @SuppressWarnings("unchecked")
@@ -91,7 +95,7 @@ class KafkaSqlShutdownTest {
         // A latch that blocks the thread until interrupted or the test ends
         CountDownLatch blockLatch = new CountDownLatch(1);
 
-        Thread blockingThread = new Thread(() -> {
+        RecordingThread blockingThread = new RecordingThread(() -> {
             try {
                 blockLatch.await(30, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
@@ -109,14 +113,44 @@ class KafkaSqlShutdownTest {
         verify(journalConsumer).wakeup();
         verify(journalConsumer, never()).close();
 
-        // The thread was still alive after the 50ms join timeout, so onDestroy()
-        // should have called interrupt().
-        assertTrue(blockingThread.isInterrupted() || !blockingThread.isAlive(),
-                "consumer thread should have been interrupted");
+        // The thread was still alive when the 50ms join expired, so onDestroy() must have
+        // called interrupt(). Assert on the recorded call rather than on isInterrupted():
+        // if the join stopped honouring joinTimeoutMillis, the thread would sit on the
+        // latch for its full 30s, exit on its own, and leave isInterrupted() false with
+        // isAlive() false too, which an "interrupted or dead" disjunction would accept.
+        assertTrue(blockingThread.wasInterrupted(),
+                "onDestroy() should interrupt a consumer thread that does not exit");
 
         // Clean up: release the latch so the thread exits
         blockLatch.countDown();
         blockingThread.join(1_000);
+    }
+
+    /**
+     * A Thread that records whether interrupt() was called on it.
+     *
+     * The recorded call is the assertable signal, not Thread.isInterrupted(). The JVM
+     * clears the interrupt flag when it delivers InterruptedException to a blocked call,
+     * so the flag is only set again if the thread's own catch block re-interrupts, and it
+     * is not reliably readable once the thread has terminated.
+     */
+    private static final class RecordingThread extends Thread {
+
+        private volatile boolean interruptCalled = false;
+
+        RecordingThread(Runnable target) {
+            super(target);
+        }
+
+        @Override
+        public void interrupt() {
+            interruptCalled = true;
+            super.interrupt();
+        }
+
+        boolean wasInterrupted() {
+            return interruptCalled;
+        }
     }
 
     private static void setPrivateField(Object target, String fieldName, Object value) throws Exception {


### PR DESCRIPTION
## Summary

Replaces `journalConsumer.close()` with `journalConsumer.wakeup()` in `KafkaSqlRegistryStorage.onDestroy()`.

**The bug**: `KafkaConsumer` is not thread-safe. The `@PreDestroy` method called `close()` from the CDI shutdown thread while the consumer thread was mid-`poll()` (5-second race window). This produces `ConcurrentModificationException`.

**The fix**: `wakeup()` is the only thread-safe method on `KafkaConsumer` (per Kafka docs). It interrupts `poll()`, causing a `WakeupException` that the consumer thread catches and exits cleanly. The consumer thread's `finally` block then calls `close()` on the correct thread. Added `consumerThread.join(10_000)` with a warning if the thread does not exit within 10 seconds.

Supersedes the existing try-catch band-aid from commit `3fe7e520`.

Closes #9779
Related: #9635

## Test plan

- [x] `./mvnw test-compile -pl :apicurio-registry-app -am -DskipTests` compiles
- [x] `./mvnw checkstyle:check -pl :apicurio-registry-app` passes
- [ ] CI green
- [ ] @EricWittmann @carlesarnal @jsenko please verify the shutdown flow: wakeup -> WakeupException -> finally -> close