### PR TITLE
ci: gate the full suite on native trust/review facts, not a bot-applied label

### DIFF
--- a/.github/PR_LIFECYCLE.md
+++ b/.github/PR_LIFECYCLE.md
@@ -1,42 +1,45 @@
 # PR Lifecycle
 
 Apicurio Registry uses an automated PR lifecycle orchestrator to manage pull requests.
-The orchestrator controls test execution, tracks PR state via labels, and provides
-comment commands for contributors and maintainers.
+The orchestrator tracks PR state via labels and provides comment commands for
+contributors and maintainers. Test execution itself is controlled natively by two
+workflows reacting directly to GitHub events (author identity, review state) — see
+[CI below](#continuous-integration).
 
 ## Lifecycle Overview
 
 Every non-draft PR moves through these states:
 
 ```
-Opened --> new --> ready-for-review --> ready-to-merge --> merged
+Opened --> ready-for-review --> ready-to-merge --> merged
 ```
+
+There is no separate triage/accept stage — every PR enters `lifecycle/ready-for-review`
+as soon as it is opened (or marked ready for review).
 
 | State | Label | What happens |
 |-------|-------|--------------|
-| **New** | `lifecycle/new` | PR just opened. A welcome message is posted. No tests run. A maintainer must triage. PRs from maintainers and trusted accounts (e.g., Renovate) skip this state. |
-| **Ready for review** | `lifecycle/ready-for-review` | Maintainer accepted the PR (or auto-accepted for trusted authors). The full test suite runs on each push. Reviewers can review. |
-| **Ready to merge** | `lifecycle/ready-to-merge` | PR is approved and all tests pass. A maintainer can merge. |
-| **Merged** | — | PR is merged. Branch may be deleted automatically. |
+| **Ready for review** | `lifecycle/ready-for-review` | PR is open and non-draft. The Quick Check fast gate runs on every push. The full verification suite runs immediately for trusted authors (maintainers and configured `auto_accept` identities, e.g. Renovate), or once the PR has an approving review for everyone else. Reviewers can review at any time. |
+| **Ready to merge** | `lifecycle/ready-to-merge` | PR is approved and the fast gate passed. Purely a status label — a maintainer can merge it with `/merge` (which enables native GitHub auto-merge; it completes once the full suite and review are both satisfied). |
+| **Merged** | — | PR is merged. The branch is deleted automatically (a repository-level GitHub setting, not something the orchestrator does). |
 
 ### Draft PRs
 
 The orchestrator ignores draft PRs entirely — no labels, no CI, no welcome message.
 Push commits and test locally as normal during draft development. Once you mark the
-PR as ready for review (non-draft), it enters `lifecycle/new` exactly like a freshly
-opened PR.
+PR as ready for review (non-draft), it enters `lifecycle/ready-for-review` exactly
+like a freshly opened PR.
 
 Converting a PR **back** to draft removes all of its `lifecycle/*` labels and stops
 CI from running on subsequent pushes — useful if you need to iterate without burning
-CI capacity. Marking it ready for review again re-enters the lifecycle at
-`lifecycle/new`, so a maintainer has to `/accept` it a second time.
+CI capacity. Marking it ready for review again re-enters the lifecycle the same way.
 
 ### Additional labels
 
 | Label | Meaning |
 |-------|---------|
-| `lifecycle/tested` | Full test suite passed for the current HEAD commit. Removed on new pushes. |
-| `lifecycle/review-approved` | PR has an approved review. Removed on new pushes or when changes are requested. |
+| `lifecycle/tested` | Quick Check fast gate passed for the current HEAD commit. Removed on new pushes. |
+| `lifecycle/full-verified` | Full verification suite passed for the current HEAD commit. Removed on new pushes or if the suite subsequently fails. |
 | `lifecycle/waiting-on-author` | PR needs action from the author (failed tests or changes requested). |
 | `lifecycle/waiting-on-maintainer` | PR needs maintainer attention (ready to review or merge). |
 | `lifecycle/stale` | No activity for 4+ days (waiting on author) or 7+ days (otherwise). PR will be closed after further inactivity (see [Stale PRs](#stale-prs)). |
@@ -49,21 +52,17 @@ CI capacity. Marking it ready for review again re-enters the lifecycle at
 1. Open a PR against `main` (draft or regular)
    - Draft PRs are ignored by the orchestrator — push and test locally as you go
 2. When ready (or if opened as non-draft), the orchestrator posts a welcome message
-   and adds `lifecycle/new`
-3. A maintainer will review and accept your PR with `/accept`
-
-### After acceptance
-
-- `/accept` moves the PR directly to `lifecycle/ready-for-review` and runs the full
-  test suite
-- Push commits as normal; the full suite re-runs on each push
-- Wait for review and test results
+   and the PR enters `lifecycle/ready-for-review`
+3. The Quick Check fast gate runs immediately; the full verification suite runs once
+   a maintainer approves the PR (no `/accept` step needed)
 
 ### After review
 
-- If changes are requested, push fixes. Tests re-run automatically.
-- Once approved and tests pass, the PR moves to `ready-to-merge`
-- A maintainer will merge it, or it merges automatically if auto-merge is enabled
+- If changes are requested, push fixes. The fast gate re-runs automatically, and the
+  full suite re-runs once re-approved (GitHub dismisses stale approvals on new pushes).
+- Once approved and the fast gate passes, the PR moves to `ready-to-merge`
+- A maintainer will merge it, or enable auto-merge with `/merge` so it merges
+  automatically once the full suite finishes
 
 ### Stale PRs
 
@@ -77,6 +76,7 @@ after 7 total days of inactivity; other PRs go stale at 7 days and close at 14 t
 | Command | Description |
 |---------|-------------|
 | `/unstale` | Remove the stale label |
+| `/retry` | Re-run the lifecycle orchestrator and retry failed tests |
 | `/assign-me` | Self-assign an open issue to volunteer for implementation |
 | `/unassign-me` | Release an issue you are currently assigned to |
 
@@ -91,28 +91,25 @@ Contributors can self-assign open issues by commenting `/assign-me` (or `/claim`
 
 ## For Maintainers
 
-### Triaging new PRs
-
-When a new PR arrives (`lifecycle/new`):
-1. Review the PR description and scope
-2. Accept with `/accept` (transitions directly to `ready-for-review`, full test
-   suite runs) or reject with `/reject [reason]`
-
 ### Managing the lifecycle
 
 | Command | Description |
 |---------|-------------|
-| `/accept` | Accept a new PR, transition to `ready-for-review` and run the full test suite |
-| `/reject [reason]` | Reject and close a new PR |
-| `/skip-review` | Skip the review requirement for small changes (tests still required) |
-| `/merge` | Merge a PR that is in `ready-to-merge` state |
-| `/auto-merge` | Toggle auto-merge (PR merges automatically when ready-to-merge is reached) |
+| `/reject [reason]` | Close a PR that should not be worked further |
+| `/merge` | Toggle native GitHub auto-merge — it merges automatically once required checks pass and the PR has an approving review |
 | `/unstale` | Remove the stale label |
+| `/retry` | Re-run the lifecycle orchestrator and retry failed tests |
+
+There is no `/accept` or `/skip-review` command any more: there is no triage stage to
+accept a PR into, and every author needs an actual approving review before a PR can
+merge — required natively by branch protection (`required_approving_review_count: 1`),
+not something a maintainer can waive per PR.
 
 ### Merge strategy
 
-PRs are merged using **rebase** by default (linear history). This can be changed to
-**squash** in `.github/pr-lifecycle.yml`. Branches are automatically deleted after merge.
+PRs are merged using **rebase** by default (linear history via `/merge`, which enables
+native GitHub auto-merge). This can be changed to **squash** in `.github/pr-lifecycle.yml`.
+Branches are deleted automatically after merge (a repository-level setting).
 
 ### Label protection
 
@@ -120,35 +117,44 @@ All `lifecycle/*` and `orchestrator/*` labels are managed exclusively by the orc
 Manual label changes will be reverted automatically. Use the appropriate slash command
 instead of adding or removing labels directly.
 
-### Auto-merge
+### Branches that fall behind `main`
 
-Use `/auto-merge` to enable automatic merging. When the PR reaches `ready-to-merge`
-(approved + tested), it will be merged automatically. Use `/auto-merge` again to disable.
+Branch protection requires PR branches to be up to date before merging. Native GitHub
+auto-merge (enabled via `/merge`) waits correctly in that case, but it does not update
+the branch for you — if a PR has been open a while and other PRs merged in the
+meantime, click **Update branch** on the PR page (or push a rebase) to let it proceed.
 
-### Branch auto-update (merge-rebase)
+## Continuous Integration
 
-When merging fails because the PR branch is behind `main` (other PRs were merged in the
-meantime), the orchestrator handles it automatically:
+Two workflows make up the whole pipeline — see `.github/workflows/README.md` for the
+full technical description. In short:
 
-1. If the branch can be cleanly rebased (`rebaseable: true`), the branch is updated
-2. Tests are **skipped** — they already passed on the previous HEAD, and a clean rebase
-   means the code is functionally identical
-3. Only the Verification Gate runs (~1-2 minutes)
-4. Once the gate passes, the merge proceeds automatically
+- **`quick-check.yaml`** — the fast gate. Runs on every push to every PR, regardless
+  of author or review state.
+- **`verify.yaml`** — the full suite (build, unit tests, CLI, SDKs, console plugin,
+  integration tests, extra tests, operator tests). Its `decide` job evaluates, live,
+  on every run:
+  - author is a maintainer or in `auto_accept` (e.g. Renovate) → runs immediately
+  - otherwise → runs once the PR has a current approving review (`reviewDecision ==
+    APPROVED`), re-evaluated automatically on every review submission
+  - `orchestrator/disabled` label → runs regardless (unless `DO NOT MERGE` is also
+    present), the legacy escape hatch for PRs excluded from the lifecycle entirely
 
-If the branch has conflicts, the orchestrator posts an error and asks the author to
-resolve them manually. If the branch falls behind again during the gate run, the
-merge falls back to standard error handling (full test suite re-run).
+This is a native-fact decision (author identity, review state), not a bot-applied
+label — there is nothing for the orchestrator to keep in sync, and no window where a
+run started before a promotion could go stale relative to it.
 
 ## Configuration
 
 The orchestrator is configured in `.github/pr-lifecycle.yml`:
 
-- **maintainers** — GitHub usernames of maintainers (controls who can use maintainer commands)
-- **auto_accept** — GitHub usernames of accounts that skip triage (auto-accepted directly to
-  `ready-for-review`). Maintainers are always auto-accepted.
+- **maintainers** — GitHub usernames of maintainers (controls who can use maintainer
+  commands, and who gets the full suite immediately per the CI section above)
+- **auto_accept** — GitHub usernames of additional trusted accounts that also get the
+  full suite immediately (e.g. Renovate), without maintainer command access
+- **max_contributor_prs** — maximum concurrent open PRs for a non-trusted author
+  before further ones are closed automatically (default: 1)
 - **merge.strategy** — `rebase` (default) or `squash`
-- **merge.delete_branch** — whether to delete the branch after merge
 - **stale.days_until_stale** — days of inactivity before marking as stale (default: 7)
 - **stale.days_until_close** — total days of inactivity before closing (default: 14)
 - **stale.days_until_stale_waiting_on_author** — days of inactivity before marking a PR
@@ -157,18 +163,9 @@ The orchestrator is configured in `.github/pr-lifecycle.yml`:
   PR blocked on the author (default: 7)
 - **welcome_message** — message posted when a PR is opened
 
-## Test Gating
-
-The orchestrator controls which tests run at each lifecycle stage:
-
-| State | Tests |
-|-------|-------|
-| `lifecycle/new` | None |
-| `lifecycle/ready-for-review` | Full suite: lint, build, unit tests, integration tests, SDK tests, extras |
-| `orchestrator/disabled` | Full suite (legacy behavior, DO NOT MERGE still works) |
-
 ## Disabling the Orchestrator
 
 The orchestrator is enabled by default on all PRs. To exclude a specific PR, a maintainer
 can add the `orchestrator/disabled` label. This reverts the PR to legacy behavior (full
 test suite on every push, `DO NOT MERGE` label support).
+</content>

--- a/.github/pr-lifecycle.yml
+++ b/.github/pr-lifecycle.yml
@@ -15,7 +15,6 @@ max_contributor_prs: 1
 
 merge:
   strategy: rebase
-  delete_branch: true
 
 stale:
   days_until_stale: 7
@@ -38,8 +37,9 @@ stale:
 welcome_message: |
   Thanks for opening this PR!
 
-  A maintainer will review and accept it shortly. In the meantime, you can
-  continue pushing changes.
+  The Quick Check gate runs on every push. The full verification suite runs
+  once a maintainer approves the PR (it runs immediately for trusted
+  authors) and is the final merge gate.
 
   **Available commands:**
   | Command | Description |
@@ -50,8 +50,5 @@ welcome_message: |
   **Maintainer commands:**
   | Command | Description |
   |---------|-------------|
-  | `/accept` | Accept the PR and transition to ready-for-review, running the full test suite |
   | `/reject [reason]` | Reject and close the PR |
-  | `/skip-review` | Skip review requirement for small changes (tests still required) |
-  | `/auto-merge` | Toggle auto-merge |
-  | `/merge` | Merge the PR |
+  | `/merge` | Toggle auto-merge — GitHub merges automatically once required checks and review pass |

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -11,31 +11,24 @@ const path = require('path');
 // ---------------------------------------------------------------------------
 
 const LABELS = {
-  NEW: 'lifecycle/new',
   READY_FOR_REVIEW: 'lifecycle/ready-for-review',
+  // Fast gate (quick-check.yaml) passed for the current HEAD.
   TESTED: 'lifecycle/tested',
+  // Approved and tested; the full suite (verify.yaml) is the remaining
+  // merge gate. Purely a status label — it does not gate anything itself.
+  // What actually gates the full suite running is native: PR author
+  // (maintainer/auto_accept run it immediately) or an approving review
+  // (everyone else), evaluated directly by verify-decide.yaml.
   READY_TO_MERGE: 'lifecycle/ready-to-merge',
-  // Set when the FULL verification suite passes for the current
-  // HEAD. Two-tier CI: lifecycle/tested comes from the fast gate
-  // (quick-check.yaml's Quick Verify job) during iteration;
-  // lifecycle/full-verified is the pre-merge gate, applied once verify.yaml
-  // (the full suite) is green.
+  // Set when the full verification suite passes for the current HEAD.
   FULL_VERIFIED: 'lifecycle/full-verified',
   WAITING_ON_AUTHOR: 'lifecycle/waiting-on-author',
   WAITING_ON_MAINTAINER: 'lifecycle/waiting-on-maintainer',
   STALE: 'lifecycle/stale',
-  REVIEW_APPROVED: 'lifecycle/review-approved',
   DISABLED: 'orchestrator/disabled',
-  AUTO_MERGE: 'orchestrator/auto-merge',
-  REVIEW_SKIPPED: 'orchestrator/review-skipped',
-  MERGE_REBASE: 'orchestrator/merge-rebase',
-  // A merge was requested (via /merge or auto-merge) while the full
-  // verification suite is still running; the merge proceeds when it passes.
-  PENDING_MERGE: 'orchestrator/merge-pending',
 };
 
 const PRIMARY_STATES = [
-  LABELS.NEW,
   LABELS.READY_FOR_REVIEW,
   LABELS.READY_TO_MERGE,
 ];
@@ -54,20 +47,14 @@ const COLORS = {
 };
 
 const LABEL_DEFS = {
-  [LABELS.NEW]:                  { color: COLORS.INFO, description: 'PR awaiting triage' },
-  [LABELS.READY_FOR_REVIEW]:     { color: COLORS.INFO, description: 'Ready for review, Quick Check gate runs on push' },
+  [LABELS.READY_FOR_REVIEW]:     { color: COLORS.INFO, description: 'In review; Quick Check gate runs on every push' },
   [LABELS.TESTED]:               { color: COLORS.SUCCESS, description: 'Quick Check gate passed for current HEAD' },
   [LABELS.FULL_VERIFIED]:        { color: COLORS.SUCCESS, description: 'Full verification suite passed for current HEAD' },
-  [LABELS.REVIEW_APPROVED]:      { color: COLORS.SUCCESS, description: 'PR has an approved review' },
-  [LABELS.READY_TO_MERGE]:       { color: COLORS.INFO, description: 'Approved and fast-gated; full suite is the merge gate' },
+  [LABELS.READY_TO_MERGE]:       { color: COLORS.INFO, description: 'Approved and fast-gated; full suite is the remaining merge gate' },
   [LABELS.WAITING_ON_AUTHOR]:    { color: COLORS.ATTENTION_STRONG, description: 'Blocked on contributor action' },
   [LABELS.WAITING_ON_MAINTAINER]:{ color: COLORS.ATTENTION, description: 'Blocked on maintainer action' },
   [LABELS.STALE]:                { color: COLORS.INACTIVE, description: 'No activity for 4+ days (waiting on author) or 7+ days' },
   [LABELS.DISABLED]:             { color: COLORS.INACTIVE, description: 'PR excluded from lifecycle orchestrator' },
-  [LABELS.AUTO_MERGE]:           { color: COLORS.INFO, description: 'Auto-merge enabled' },
-  [LABELS.REVIEW_SKIPPED]:       { color: COLORS.INFO, description: 'Review requirement skipped by maintainer' },
-  [LABELS.MERGE_REBASE]:         { color: COLORS.INFO, description: 'Branch auto-updated for merge, full suite re-running' },
-  [LABELS.PENDING_MERGE]:        { color: COLORS.INFO, description: 'Merge queued, waiting for full verification' },
 };
 
 const BOT_LOGIN = 'github-actions[bot]';
@@ -205,22 +192,29 @@ function createApi(github, owner, repo) {
       });
     },
 
-    mergePr: async (prNumber, method, commitTitle) => {
-      await github.rest.pulls.merge({
-        owner, repo, pull_number: prNumber,
-        merge_method: method,
-        commit_title: commitTitle,
-      });
+    // Native GitHub auto-merge: GitHub itself merges the PR the moment its
+    // required checks and required review are satisfied — no bot polling,
+    // no rebase-retry, no pending-merge bookkeeping. Repo already has
+    // "Automatically delete head branches" enabled, so branch cleanup is
+    // native too.
+    enableAutoMerge: async (prNumber, mergeMethod) => {
+      const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+      await github.graphql(
+        `mutation($id: ID!, $method: PullRequestMergeMethod!) {
+          enablePullRequestAutoMerge(input: { pullRequestId: $id, mergeMethod: $method }) { clientMutationId }
+        }`,
+        { id: pr.node_id, method: mergeMethod.toUpperCase() }
+      );
     },
 
-    deleteBranch: async (branch) => {
-      try {
-        await github.rest.git.deleteRef({
-          owner, repo, ref: `heads/${branch}`,
-        });
-      } catch (e) {
-        if (e.status !== 422) throw e;
-      }
+    disableAutoMerge: async (prNumber) => {
+      const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+      await github.graphql(
+        `mutation($id: ID!) {
+          disablePullRequestAutoMerge(input: { pullRequestId: $id }) { clientMutationId }
+        }`,
+        { id: pr.node_id }
+      );
     },
 
     updateBranch: async (prNumber, expectedHeadSha) => {
@@ -237,27 +231,12 @@ function createApi(github, owner, repo) {
       return data.workflow_runs[0] || null;
     },
 
-    cancelWorkflowRun: async (runId) => {
-      try {
-        await github.rest.actions.cancelWorkflowRun({ owner, repo, run_id: runId });
-      } catch (e) {
-        if (e.status !== 409) throw e;
-      }
-    },
-
     reRunWorkflow: async (runId) => {
       try {
         await github.rest.actions.reRunWorkflow({ owner, repo, run_id: runId });
       } catch (e) {
         if (e.status !== 409) throw e;
       }
-    },
-
-    getWorkflowRun: async (runId) => {
-      const { data } = await github.rest.actions.getWorkflowRun({
-        owner, repo, run_id: runId,
-      });
-      return data;
     },
 
     approveWorkflowRun: async (runId) => {
@@ -283,8 +262,9 @@ function createApi(github, owner, repo) {
 // Two-tier CI routing: the fast gate (quick-check.yaml, workflow name "Quick
 // Check") covers PR iteration; the full suite (verify.yaml — build, unit
 // tests, CLI, SDKs, console plugin, integration tests, extra tests, operator
-// tests, and on push, publishing) is the pre-merge gate and only meaningful
-// once the PR is lifecycle/ready-to-merge. verify.yaml has a single Decide
+// tests, and on push, publishing) is the pre-merge gate. It runs on its own
+// native triggers (push for trusted authors, review submission for everyone
+// else) rather than a bot-applied label. verify.yaml has a single Decide
 // job shared by every job in it, so there is exactly one workflow (and one
 // answer to "is the full suite required") to track for full-verified —
 // unlike the fast gate, which is intentionally a separate, independent
@@ -319,10 +299,11 @@ async function getFullSuiteResult(github, owner, repo, headSha, core) {
   }
   for (const run of latest.values()) {
     if (run.conclusion !== 'success') {
-      // verify.yaml's Gate job intentionally fails (not skips) while the PR
-      // is not yet lifecycle/ready-to-merge, as the only way to make the
-      // required branch-protection check honestly reflect "not satisfied
-      // yet" instead of the false-pass a skipped required job would produce
+      // verify.yaml's Gate job intentionally fails (not skips) while Decide
+      // has not required the full suite yet (author isn't trusted and the
+      // PR isn't approved), as the only way to make the required
+      // branch-protection check honestly reflect "not satisfied yet"
+      // instead of the false-pass a skipped required job would produce
       // (see verify.yaml's Gate for the full reasoning). That failure is
       // expected and must NOT be treated as a genuine full-suite failure
       // here — every job in the run other than Gate itself is either
@@ -343,24 +324,26 @@ async function getFullSuiteResult(github, owner, repo, headSha, core) {
   return { status: 'success' };
 }
 
-async function retriggerVerify(api, pr, core, { waitForRun = false, force = false } = {}) {
-  // The workflow that matters depends on lifecycle state: the fast gate
-  // (quick-check.yaml) during iteration, the full suite (verify.yaml) at
-  // ready-to-merge.
-  // force=true re-runs even a green workflow: promotion to ready-to-merge is a
-  // bot-applied label (no labeled event fires), so Quick Check/Verify must
-  // re-run for Decide to see the new state and start the full tier.
-  if (getLifecycleState(pr) === LABELS.READY_TO_MERGE) {
+// Used by /retry. Both verify.yaml and quick-check.yaml now trigger natively
+// off PR events (push, review submission) — nothing needs to force a
+// re-run purely because the bot changed a label — so this only ever
+// re-runs a workflow that is actually stuck or failed.
+async function retriggerVerify(api, pr, core, isTrustedAuthor) {
+  // The full suite is the relevant workflow once approved+tested (about to
+  // merge) or for a trusted author (it runs from the start for them);
+  // otherwise the fast gate is what /retry should be looking at.
+  const checkFullSuite = getLifecycleState(pr) === LABELS.READY_TO_MERGE || isTrustedAuthor;
+  if (checkFullSuite) {
     let found = false;
     for (const workflow of FULL_SUITE_WORKFLOW_FILES) {
-      found = (await retriggerWorkflowRun(api, pr, core, workflow, { waitForRun, force })) || found;
+      found = (await retriggerWorkflowRun(api, pr, core, workflow)) || found;
     }
     if (!found) {
       await triggerViaBranchUpdate(api, pr, core, 'the full suite');
     }
     return;
   }
-  const found = await retriggerWorkflowRun(api, pr, core, 'quick-check.yaml', { waitForRun, force });
+  const found = await retriggerWorkflowRun(api, pr, core, 'quick-check.yaml');
   if (!found) {
     await triggerViaBranchUpdate(api, pr, core, 'quick-check.yaml');
   }
@@ -389,26 +372,16 @@ async function triggerViaBranchUpdate(api, pr, core, workflow) {
 
 // Retriggers the latest run of a single workflow file for the PR's head SHA.
 // Returns true when a run existed (regardless of what was done with it).
-async function retriggerWorkflowRun(api, pr, core, workflow, { waitForRun = false, force = false } = {}) {
-  let run = null;
-
-  if (waitForRun) {
-    for (let attempt = 0; attempt < 5; attempt++) {
-      await new Promise(r => setTimeout(r, 3000));
-      run = await api.findLatestVerifyRun(pr.head.sha, workflow);
-      if (run) break;
-    }
-  } else {
-    run = await api.findLatestVerifyRun(pr.head.sha, workflow);
-  }
+async function retriggerWorkflowRun(api, pr, core, workflow) {
+  const run = await api.findLatestVerifyRun(pr.head.sha, workflow);
 
   if (!run) {
     return false;
   }
 
   // Fork PRs need workflow approval before they can run. Approve instead
-  // of re-running — the Decide step fetches current labels from the API,
-  // so the approved run will see the up-to-date lifecycle state.
+  // of re-running — Decide re-evaluates live, so the approved run will see
+  // current PR/review state.
   // GitHub represents these as status=completed, conclusion=action_required.
   if (run.conclusion === 'action_required') {
     try {
@@ -420,29 +393,16 @@ async function retriggerWorkflowRun(api, pr, core, workflow, { waitForRun = fals
     return true;
   }
 
-  // Only re-run workflows that actually need it; a green sibling is left alone
-  // unless forced (promotion re-evaluation — Decide must see the new labels).
-  if (run.conclusion === 'success' && !force) {
+  // Only re-run workflows that actually need it; a green run is left alone.
+  if (run.conclusion === 'success') {
     core.info(`PR #${pr.number} ${workflow} run ${run.id} already green, not re-triggering`);
     return true;
   }
 
   if (run.status === 'in_progress' || run.status === 'queued') {
-    core.info(`PR #${pr.number} cancelling in-progress ${workflow} run ${run.id}`);
-    await api.cancelWorkflowRun(run.id);
-
-    // Wait for the run to fully complete — gate jobs with `if: always()`
-    // keep the run alive after cancellation.
-    for (let attempt = 0; attempt < 20; attempt++) {
-      await new Promise(r => setTimeout(r, 5000));
-      const fresh = await api.getWorkflowRun(run.id);
-      if (fresh.status === 'completed') break;
-    }
+    core.info(`PR #${pr.number} ${workflow} run ${run.id} already running, not re-triggering`);
+    return true;
   }
-
-  // Allow label changes to propagate through GitHub's eventually-consistent API
-  // before re-triggering, so the scope job sees the current labels.
-  await new Promise(r => setTimeout(r, 5000));
 
   try {
     await api.reRunWorkflow(run.id);
@@ -454,8 +414,8 @@ async function retriggerWorkflowRun(api, pr, core, workflow, { waitForRun = fals
 }
 
 // Approves all Verify workflow runs awaiting approval for a PR's head SHA.
-// Called after lifecycle transitions that should enable CI (e.g. /accept)
-// to catch label-triggered runs that race with retriggerVerify.
+// Called after events that should enable CI (e.g. a fresh push) to catch
+// label-triggered or event-triggered runs that race with retriggerVerify.
 async function approvePendingVerifyRuns(api, pr, core, workflow = 'verify.yaml') {
   try {
     const runs = await api.findPendingApprovalVerifyRuns(pr.head.sha, workflow);
@@ -516,105 +476,49 @@ function hasLatestChangesRequested(reviews) {
   return latestReviewsByReviewer(reviews).some(r => r.state === 'CHANGES_REQUESTED');
 }
 
-async function performMerge(api, config, pr, core, { allowBranchUpdate = true } = {}) {
+// Enables (or, if already on, disables) native GitHub auto-merge for a PR.
+// GitHub merges automatically once its own required checks and required
+// review are satisfied — no bot polling, no rebase-retry, no
+// pending-merge/merge-rebase bookkeeping needed.
+async function setAutoMerge(api, config, pr, core) {
   const freshPr = await api.getPr(pr.number);
-  if (!hasLabel(freshPr, LABELS.TESTED) || !hasLabel(freshPr, LABELS.READY_TO_MERGE)) {
-    core.warning(`PR #${pr.number} merge aborted: state changed since merge was initiated`);
-    return false;
-  }
-
-  // Two-tier CI: lifecycle/tested comes from the fast gate. The merge itself
-  // additionally requires the full suite (lifecycle/full-verified) for this
-  // HEAD. If it is still running, queue the merge — handleTestResult
-  // completes it when the Verify workflow finishes green.
-  if (!hasLabel(freshPr, LABELS.FULL_VERIFIED)) {
-    if (!hasLabel(freshPr, LABELS.PENDING_MERGE)) {
-      await api.addLabel(pr.number, LABELS.PENDING_MERGE);
-      await api.postComment(pr.number,
-        `Merge queued: waiting for the full verification suite to pass for ` +
-        `commit ${freshPr.head.sha.substring(0, 7)}. The merge will proceed automatically.`
-      );
-    }
-    core.info(`PR #${pr.number} merge deferred until full verification passes`);
-    return false;
+  if (freshPr.auto_merge) {
+    await api.disableAutoMerge(pr.number);
+    core.info(`PR #${pr.number} auto-merge disabled`);
+    return 'disabled';
   }
 
   const strategy = config.merge?.strategy || 'rebase';
   try {
-    await api.mergePr(pr.number, strategy, freshPr.title);
-    if (config.merge?.delete_branch) {
-      await api.deleteBranch(freshPr.head.ref);
-    }
-    core.info(`PR #${pr.number} merged using ${strategy}`);
-    return true;
+    await api.enableAutoMerge(pr.number, strategy);
+    core.info(`PR #${pr.number} auto-merge enabled (${strategy})`);
+    return 'enabled';
   } catch (e) {
-    // Branch is behind but can be cleanly updated — rebase and retry.
-    // Skip for permission errors (403 / "Resource not accessible") which
-    // indicate a different problem (e.g. workflow file modifications).
-    const isPermissionError = e.status === 403 || e.message?.includes('Resource not accessible');
-    if (allowBranchUpdate && !isPermissionError) {
-      const currentPr = await api.getPr(pr.number);
-      if (currentPr.rebaseable) {
-        try {
-          await api.addLabel(pr.number, LABELS.MERGE_REBASE);
-          await api.updateBranch(pr.number, currentPr.head.sha);
-          await api.postComment(pr.number,
-            `Merge could not proceed because the branch is behind \`${currentPr.base.ref}\`. ` +
-            `The branch has been updated automatically. The full verification suite runs on ` +
-            `the updated branch and the merge will proceed once it passes.`
-          );
-          core.info(`PR #${pr.number} branch updated for merge-rebase`);
-          return false;
-        } catch (updateErr) {
-          await api.removeLabel(pr.number, LABELS.MERGE_REBASE);
-          core.warning(`PR #${pr.number} branch update failed: ${updateErr.message}`);
-        }
-      }
-    }
-
     const workflowHint = e.message?.includes('Resource not accessible')
-      ? ' This may be because the PR modifies workflow files, which requires manual merge via the GitHub UI (the `workflow` token scope is not available to GitHub Actions).'
+      ? ' This may be because the PR modifies workflow files, which requires a manual merge via the GitHub UI (the `workflow` token scope is not available to GitHub Actions).'
       : '';
-    const conflictHint = freshPr.rebaseable === false
-      ? ' The branch has conflicts with the base branch that need manual resolution.'
-      : '';
-    await api.setLifecycleState(freshPr, LABELS.READY_FOR_REVIEW);
-    await api.removeLabel(pr.number, LABELS.TESTED);
-    await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
-    await api.postComment(pr.number,
-      `Merge failed: ${e.message}\n\n` +
-      `Reverted to \`lifecycle/ready-for-review\`.${workflowHint}${conflictHint}` +
-      (workflowHint || conflictHint ? '' : ` The branch may need to be rebased. Use \`/auto-merge\` to merge automatically once approved and tested.`)
-    );
-    core.error(`PR #${pr.number} merge failed: ${e.message}`);
-    return false;
+    core.error(`PR #${pr.number} failed to enable auto-merge: ${e.message}`);
+    await api.postComment(pr.number, `Could not enable auto-merge: ${e.message}${workflowHint}`);
+    return 'error';
   }
 }
 
+// Promotes ready-for-review to ready-to-merge once approved and fast-gated.
+// Purely a status transition now — it does not gate or trigger anything:
+// the full suite already runs on its own native triggers (PR push for
+// trusted authors, review submission for everyone else), and merging (if
+// auto-merge was enabled via /merge) is entirely GitHub's own job from here.
 async function checkAndTransitionToReady(api, pr, core, reviews) {
   if (!reviews) reviews = await api.getReviews(pr.number);
   const approved = isApproved(reviews);
-  const reviewSkipped = hasLabel(pr, LABELS.REVIEW_SKIPPED);
   const tested = hasLabel(pr, LABELS.TESTED);
   const state = getLifecycleState(pr);
 
-  if ((approved || reviewSkipped) && tested && state === LABELS.READY_FOR_REVIEW) {
+  if (approved && tested && state === LABELS.READY_FOR_REVIEW) {
     await api.setLifecycleState(pr, LABELS.READY_TO_MERGE);
     await api.removeLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
     await api.removeLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
     await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
-
-    // Two-tier CI: the full suite is the pre-merge gate. The
-    // label was applied by the orchestrator, which does NOT trigger a
-    // labeled-event workflow run — kick the suite off explicitly. The PR
-    // object held by callers is stale, so refetch for correct routing.
-    const transitionedPr = await api.getPr(pr.number);
-    await retriggerVerify(api, transitionedPr, core, { force: true });
-
-    if (hasLabel(pr, LABELS.AUTO_MERGE)) {
-      core.info(`PR #${pr.number} auto-merge enabled, will merge`);
-      return 'auto-merge';
-    }
 
     // Ping reviewers/requested reviewers so they know the PR is ready
     const reviewerLogins = [...new Set(reviews.map(r => r.user.login))];
@@ -627,14 +531,14 @@ async function checkAndTransitionToReady(api, pr, core, reviews) {
     const mentionSuffix = mentions ? ` ${mentions}` : '';
 
     await api.postComment(pr.number,
-      `This PR is approved and has passed the Quick Check gate. The full verification suite is now ` +
-      `running as the final merge gate.${mentionSuffix} A maintainer can merge it with \`/merge\`, ` +
-      `or enable auto-merge with \`/auto-merge\` — the merge completes once full verification passes.`
+      `This PR is approved and has passed the Quick Check gate. The full verification suite is the ` +
+      `remaining merge gate.${mentionSuffix} A maintainer can merge it with \`/merge\` — it enables ` +
+      `auto-merge, which completes once the full suite passes and the review is still valid.`
     );
     core.info(`PR #${pr.number} is ready to merge`);
-    return 'ready-to-merge';
+    return true;
   }
-  return null;
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -646,17 +550,58 @@ async function checkAndTransitionToReady(api, pr, core, reviews) {
 const LEGACY_WIP_LABEL = 'lifecycle/wip';
 const LEGACY_SMOKE_TESTED_LABEL = 'lifecycle/smoke-tested';
 const LEGACY_TESTS_DISABLED_LABEL = 'orchestrator/tests-disabled';
+// Retired when the full suite moved from a bot-label-gated trigger to a
+// native one (maintainer/auto_accept authorship or an approving review):
+// these no longer mean anything, they are just dropped.
+const LEGACY_NEW_LABEL = 'lifecycle/new';
+const LEGACY_REVIEW_APPROVED_LABEL = 'lifecycle/review-approved';
+const LEGACY_REVIEW_SKIPPED_LABEL = 'orchestrator/review-skipped';
+const LEGACY_PENDING_MERGE_LABEL = 'orchestrator/merge-pending';
+const LEGACY_MERGE_REBASE_LABEL = 'orchestrator/merge-rebase';
+// Retired in favor of native GitHub auto-merge (checked via pr.auto_merge).
+const LEGACY_AUTO_MERGE_LABEL = 'orchestrator/auto-merge';
+const SIMPLE_RETIRED_LABELS = [
+  LEGACY_REVIEW_APPROVED_LABEL, LEGACY_REVIEW_SKIPPED_LABEL,
+  LEGACY_PENDING_MERGE_LABEL, LEGACY_MERGE_REBASE_LABEL,
+];
 
 async function migrateLegacyLabels(api, pr, core) {
   const labels = getLabelNames(pr);
-  const hasLegacyWip = labels.includes(LEGACY_WIP_LABEL);
+  let migrated = false;
+
   if (labels.includes(LEGACY_SMOKE_TESTED_LABEL)) {
     await api.removeLabel(pr.number, LEGACY_SMOKE_TESTED_LABEL);
   }
   if (labels.includes(LEGACY_TESTS_DISABLED_LABEL)) {
     await api.removeLabel(pr.number, LEGACY_TESTS_DISABLED_LABEL);
   }
-  if (!hasLegacyWip) return false;
+  for (const label of SIMPLE_RETIRED_LABELS) {
+    if (labels.includes(label)) {
+      await api.removeLabel(pr.number, label);
+      core.info(`PR #${pr.number} removed retired label ${label}`);
+    }
+  }
+  if (labels.includes(LEGACY_AUTO_MERGE_LABEL)) {
+    await api.removeLabel(pr.number, LEGACY_AUTO_MERGE_LABEL);
+    const config = loadConfig();
+    await setAutoMerge(api, config, pr, core);
+    core.info(`PR #${pr.number} migrated ${LEGACY_AUTO_MERGE_LABEL} to native auto-merge`);
+  }
+  if (labels.includes(LEGACY_NEW_LABEL)) {
+    await api.removeLabel(pr.number, LEGACY_NEW_LABEL);
+    if (!pr.draft && !getLifecycleState(pr)) {
+      await api.addLabel(pr.number, LABELS.READY_FOR_REVIEW);
+      await api.postComment(pr.number,
+        `**Lifecycle update:** the triage (\`lifecycle/new\` / \`/accept\`) stage has been removed — ` +
+        `this PR now moves straight to \`lifecycle/ready-for-review\`.`
+      );
+      migrated = true;
+    }
+    core.info(`PR #${pr.number} migrated off retired ${LEGACY_NEW_LABEL}`);
+  }
+
+  const hasLegacyWip = labels.includes(LEGACY_WIP_LABEL);
+  if (!hasLegacyWip) return migrated;
 
   await api.removeLabel(pr.number, LEGACY_WIP_LABEL);
 
@@ -676,14 +621,11 @@ async function migrateLegacyLabels(api, pr, core) {
     `**Lifecycle update:** the \`lifecycle/wip\` stage has been removed. This PR has been ` +
     `migrated to \`lifecycle/ready-for-review\` and the Quick Check gate will run.`
   );
-  await retriggerVerify(api, pr, core, { waitForRun: true });
   core.warning(`PR #${pr.number} migrated from legacy lifecycle/wip to ${LABELS.READY_FOR_REVIEW}`);
   return true;
 }
 
 async function reconcile(github, api, pr, core) {
-  const config = loadConfig();
-
   if (await migrateLegacyLabels(api, pr, core)) return;
 
   // The orchestrator ignores draft PRs entirely — nothing to reconcile,
@@ -697,27 +639,22 @@ async function reconcile(github, api, pr, core) {
 
   const state = getLifecycleState(pr);
 
-  // 1. No lifecycle label at all → initialize as new PR
+  // 1. No lifecycle label at all → recover into ready-for-review. There is
+  //    no separate triage stage any more: Quick Check already runs for every
+  //    PR on its own native trigger, and the full suite runs immediately for
+  //    trusted authors or after an approving review — neither depends on
+  //    this label, so recovering it is just a display fix.
   if (!state) {
     if (hasLabel(pr, LABELS.DISABLED)) return;
 
-    if (isAutoAccepted(config, pr.user.login)) {
-      await api.addLabel(pr.number, LABELS.READY_FOR_REVIEW);
-      await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
-      await retriggerVerify(api, pr, core);
-      core.warning(`PR #${pr.number} had no lifecycle label — initialized as ${LABELS.READY_FOR_REVIEW} (auto-accepted)`);
-    } else {
-      await api.addLabel(pr.number, LABELS.NEW);
-      await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
-      core.warning(`PR #${pr.number} had no lifecycle label — initialized as lifecycle/new`);
-    }
-
+    await api.addLabel(pr.number, LABELS.READY_FOR_REVIEW);
+    await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
     await api.postComment(pr.number,
       `**Warning:** This PR was missing a lifecycle label, which indicates the ` +
       `PR lifecycle orchestrator may have failed during initial processing. ` +
-      `The label has been restored automatically. If this PR was already accepted, ` +
-      `a maintainer may need to re-run the appropriate command (e.g. \`/accept\`).`
+      `The label has been restored automatically.`
     );
+    core.warning(`PR #${pr.number} had no lifecycle label — recovered as ${LABELS.READY_FOR_REVIEW}`);
     return;
   }
 
@@ -731,7 +668,6 @@ async function reconcile(github, api, pr, core) {
     if (hasChangesRequested) {
       await api.addLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
       await api.removeLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
-      await api.removeLabel(pr.number, LABELS.REVIEW_APPROVED);
       core.info(`PR #${pr.number} reconciler fixed waiting-on labels (changes requested)`);
     } else if (!hasChangesRequested && hasLabel(pr, LABELS.WAITING_ON_AUTHOR) && hasLabel(pr, LABELS.TESTED)) {
       // Only remove waiting-on-author if tests passed — otherwise the label
@@ -741,14 +677,8 @@ async function reconcile(github, api, pr, core) {
       core.info(`PR #${pr.number} reconciler fixed waiting-on labels (changes addressed)`);
     }
 
-    if (approved) {
-      await api.addLabel(pr.number, LABELS.REVIEW_APPROVED);
-    }
-
-    const result = await checkAndTransitionToReady(api, pr, core, reviews);
-    if (result === 'auto-merge') {
-      await performMerge(api, config, pr, core);
-    } else if (result === 'ready-to-merge') {
+    const promoted = await checkAndTransitionToReady(api, pr, core, reviews);
+    if (promoted) {
       core.info(`PR #${pr.number} reconciler transitioned to ready-to-merge`);
     }
   }
@@ -758,11 +688,9 @@ async function reconcile(github, api, pr, core) {
   if (state === LABELS.READY_TO_MERGE) {
     const reviews = await api.getReviews(pr.number);
     const approved = isApproved(reviews);
-    const reviewSkipped = hasLabel(pr, LABELS.REVIEW_SKIPPED);
 
-    if (!approved && !reviewSkipped) {
+    if (!approved) {
       await api.setLifecycleState(pr, LABELS.READY_FOR_REVIEW);
-      await api.removeLabel(pr.number, LABELS.REVIEW_APPROVED);
 
       if (hasLatestChangesRequested(reviews)) {
         await api.addLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
@@ -787,10 +715,19 @@ async function countOpenPrsByAuthor(github, owner, repo, author, excludePr) {
   return prs.filter(p => p.user.login === author && p.number !== excludePr);
 }
 
-// Puts a PR at the top of the lifecycle, fresh or after leaving draft.
+// Puts a PR at the top of the lifecycle, fresh or after leaving draft. Every
+// non-draft PR goes straight to ready-for-review — there is no separate
+// triage/accept stage; Quick Check already runs for every PR on its own
+// native trigger (fork-PR workflow approval, if configured, is GitHub's own
+// gate on whether a stranger's code runs at all), and the full suite runs
+// immediately for trusted authors or after an approving review for everyone
+// else — both decided natively by verify-decide.yaml, not by anything this
+// function does.
 // Drafts never reach here — they're ignored until marked ready for review.
 async function initNewPr(github, owner, repo, api, config, pr, core) {
-  if (!isAutoAccepted(config, pr.user.login)) {
+  const trusted = isAutoAccepted(config, pr.user.login);
+
+  if (!trusted) {
     const existingPrs = await countOpenPrsByAuthor(github, owner, repo, pr.user.login, pr.number);
     const maxPrs = config.max_contributor_prs ?? 1;
     if (existingPrs.length >= maxPrs) {
@@ -808,41 +745,27 @@ async function initNewPr(github, owner, repo, api, config, pr, core) {
     }
   }
 
-  if (isAutoAccepted(config, pr.user.login)) {
-    await api.addLabel(pr.number, LABELS.READY_FOR_REVIEW);
-    await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
-    // Trusted authors don't wait for review before the full suite runs:
-    // review-skipped makes the PR eligible for ready-to-merge as soon as the
-    // fast gate is green, and the full suite (still the merge gate) starts
-    // immediately instead of after a maintainer review.
-    await api.addLabel(pr.number, LABELS.REVIEW_SKIPPED);
-    const maintainerHint = isMaintainer(config, pr.user.login)
-      ? `\n\nReview is skipped; a maintainer can still use \`/merge\` to merge early ` +
-        `(it will wait for the full suite) or \`/auto-merge\` to merge automatically.`
-      : '';
-    const forkHint = pr.head.repo?.full_name !== `${owner}/${repo}`
-      ? `\n\n**Note (fork PR):** Review label updates may not apply automatically. ` +
-        `A maintainer can use \`/retry\` after reviewing to update the labels.`
-      : '';
+  await api.addLabel(pr.number, LABELS.READY_FOR_REVIEW);
+  await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
+
+  const forkHint = pr.head.repo?.full_name !== `${owner}/${repo}`
+    ? `\n\n**Note (fork PR):** label updates may not apply automatically. ` +
+      `A maintainer can use \`/retry\` after reviewing to update them.`
+    : '';
+
+  if (trusted) {
     await api.postComment(pr.number,
-      `PR auto-accepted (trusted author). The full verification suite starts immediately; ` +
-      `review is not required before CI.` +
-      maintainerHint + forkHint
+      `Thanks for opening this PR! As a trusted author, the full verification suite starts ` +
+      `immediately — it does not wait for a review. A maintainer's review is still required to merge.` +
+      forkHint
     );
-    core.info(`PR #${pr.number} auto-accepted for ${pr.user.login}, state=${LABELS.READY_FOR_REVIEW}, review skipped`);
-    await retriggerVerify(api, pr, core, { waitForRun: true });
+    core.info(`PR #${pr.number} opened by trusted author ${pr.user.login}, state=${LABELS.READY_FOR_REVIEW}`);
     return;
   }
 
-  await api.addLabel(pr.number, LABELS.NEW);
-  await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
-  let message = config.welcome_message.replace(/\{author\}/g, pr.user.login);
-  if (pr.head.repo?.full_name !== `${owner}/${repo}`) {
-    message += `\n**Note (fork PR):** Review label updates may not apply automatically. ` +
-      `A maintainer can use \`/retry\` after reviewing to update the labels.`;
-  }
+  const message = config.welcome_message.replace(/\{author\}/g, pr.user.login) + forkHint;
   await api.postComment(pr.number, message);
-  core.info(`PR #${pr.number} opened, set to lifecycle/new`);
+  core.info(`PR #${pr.number} opened, state=${LABELS.READY_FOR_REVIEW}`);
 }
 
 async function handlePrOpened({ github, context, core }) {
@@ -868,28 +791,6 @@ async function handlePrSynchronize({ github, context, core }) {
     return;
   }
 
-  // Orchestrator-initiated branch update for merge — preserve state.
-  // Only honour for bot-triggered syncs; if a human pushes while the
-  // label is set, abort the fast-merge flow and proceed normally.
-  if (hasLabel(pr, LABELS.MERGE_REBASE)) {
-    if (context.payload.sender?.login === BOT_LOGIN) {
-      core.info(`PR #${pr.number} orchestrator-initiated branch update for merge, preserving state`);
-      if (hasLabel(pr, LABELS.STALE)) {
-        await api.removeLabel(pr.number, LABELS.STALE);
-      }
-      // lifecycle/full-verified is SHA-scoped in meaning: the new HEAD has
-      // not been verified yet. The merge-rebase run re-adds it on success.
-      if (hasLabel(pr, LABELS.FULL_VERIFIED)) {
-        await api.removeLabel(pr.number, LABELS.FULL_VERIFIED);
-      }
-      return;
-    }
-    await api.removeLabel(pr.number, LABELS.MERGE_REBASE);
-    core.info(`PR #${pr.number} human push during merge-rebase, aborting fast-merge`);
-  }
-
-  const rerunHints = [];
-
   if (hasLabel(pr, LABELS.TESTED)) {
     await api.removeLabel(pr.number, LABELS.TESTED);
     core.info(`PR #${pr.number} new push, removed lifecycle/tested`);
@@ -897,18 +798,6 @@ async function handlePrSynchronize({ github, context, core }) {
   if (hasLabel(pr, LABELS.FULL_VERIFIED)) {
     await api.removeLabel(pr.number, LABELS.FULL_VERIFIED);
     core.info(`PR #${pr.number} new push, removed lifecycle/full-verified`);
-  }
-  if (hasLabel(pr, LABELS.PENDING_MERGE)) {
-    await api.removeLabel(pr.number, LABELS.PENDING_MERGE);
-    core.info(`PR #${pr.number} new push, removed orchestrator/merge-pending`);
-  }
-  // review-approved is not removed here — it is only removed when GitHub
-  // dismisses the review (pull_request_review dismissed event), keeping
-  // parity with GitHub's branch protection "dismiss stale reviews" setting.
-  if (hasLabel(pr, LABELS.AUTO_MERGE)) {
-    await api.removeLabel(pr.number, LABELS.AUTO_MERGE);
-    rerunHints.push('Auto-merge has been disabled — use `/auto-merge` to re-enable after tests pass.');
-    core.info(`PR #${pr.number} new push, removed orchestrator/auto-merge`);
   }
   if (hasLabel(pr, LABELS.STALE)) {
     await api.removeLabel(pr.number, LABELS.STALE);
@@ -924,25 +813,15 @@ async function handlePrSynchronize({ github, context, core }) {
     core.info(`PR #${pr.number} reverted from ready-to-merge to ready-for-review`);
   }
 
-  if (rerunHints.length > 0) {
-    await api.postComment(pr.number,
-      `New commits pushed. The test suite will re-run.\n\n` +
-      rerunHints.map(h => `- ${h}`).join('\n')
-    );
-  }
-
   const freshPr = await api.getPr(pr.number);
   await reconcile(github, api, freshPr, core);
 
-  // For fork PRs in a testable state, the synchronize event creates a new
-  // run that needs approval. Wait for it to appear, then approve.
-  const currentState = getLifecycleState(freshPr);
-  if (currentState === LABELS.READY_FOR_REVIEW || currentState === LABELS.READY_TO_MERGE) {
-    await new Promise(r => setTimeout(r, 5000));
-    const approved = await approveAllPendingCiRuns(api, freshPr, core);
-    if (approved > 0) {
-      core.info(`PR #${pr.number} approved ${approved} pending CI run(s) after push`);
-    }
+  // For fork PRs, the synchronize event creates a new run that needs
+  // approval. Wait for it to appear, then approve.
+  await new Promise(r => setTimeout(r, 5000));
+  const approved = await approveAllPendingCiRuns(api, freshPr, core);
+  if (approved > 0) {
+    core.info(`PR #${pr.number} approved ${approved} pending CI run(s) after push`);
   }
 }
 
@@ -968,8 +847,7 @@ async function handlePrConvertedToDraft({ github, context, core }) {
   await api.postComment(pr.number,
     `Converted to draft — the orchestrator ignores draft PRs, so lifecycle labels ` +
     `have been removed and CI will not run on new pushes.\n\n` +
-    `Mark the PR as ready for review to re-enter the lifecycle at \`lifecycle/new\`. ` +
-    `Note that a maintainer will need to \`/accept\` it again.`
+    `Mark the PR as ready for review to re-enter the lifecycle at \`lifecycle/ready-for-review\`.`
   );
   core.info(`PR #${pr.number} converted to draft, removed: ${toRemove.join(', ')}`);
 }
@@ -987,8 +865,31 @@ async function handlePrReadyForReview({ github, context, core }) {
     return;
   }
 
-  core.info(`PR #${pr.number} marked ready for review (was draft), entering lifecycle/new`);
+  core.info(`PR #${pr.number} marked ready for review (was draft), entering the lifecycle`);
   await initNewPr(github, owner, repo, api, config, pr, core);
+}
+
+// Fires when a review is submitted. verify.yaml (the full suite) already
+// reacts to this natively (pull_request_review: submitted) for non-trusted
+// authors; this reconciles labels (waiting-on-*, ready-to-merge) right away
+// instead of waiting for the next label-change event or the periodic sweep.
+// Fires when a review is submitted. verify.yaml has its own native
+// pull_request_review trigger (safe — GitHub gives it the same restricted,
+// secret-less fork-PR token as pull_request, and GITHUB_REF/GITHUB_SHA
+// already resolve to the PR's merge branch, same as pull_request), so it
+// re-evaluates Decide and starts the full suite on its own the moment a
+// review lands. This just keeps the display labels (waiting-on-*,
+// ready-to-merge) in sync right away instead of waiting for the next
+// label-change event or the periodic sweep.
+async function handlePrReviewSubmitted({ github, context, core }) {
+  const pr = context.payload.pull_request;
+  const { owner, repo } = context.repo;
+  const api = createApi(github, owner, repo);
+
+  if (hasLabel(pr, LABELS.DISABLED) || pr.draft) return;
+
+  const freshPr = await api.getPr(pr.number);
+  await reconcile(github, api, freshPr, core);
 }
 
 async function handleComment({ github, context, core }) {
@@ -1009,13 +910,10 @@ async function handleComment({ github, context, core }) {
   const isAuthor = actor === pr.user.login;
 
   const handlers = {
-    'accept': () => cmdAccept(api, config, core, pr, actor, maintainer, comment.id),
     'reject': () => cmdReject(api, config, core, pr, actor, maintainer, parsed.args, comment.id),
     'merge': () => cmdMerge(api, config, core, pr, actor, maintainer, comment.id),
-    'auto-merge': () => cmdAutoMerge(api, config, core, pr, actor, maintainer, comment.id),
-    'skip-review': () => cmdSkipReview(api, config, core, pr, actor, maintainer, comment.id),
     'unstale': () => cmdUnstale(api, config, core, pr, actor, isAuthor, maintainer, comment.id),
-    'retry': () => cmdRetry(github, api, core, pr, actor, isAuthor, maintainer, comment.id),
+    'retry': () => cmdRetry(github, api, config, core, pr, actor, isAuthor, maintainer, comment.id),
   };
 
   const handler = handlers[parsed.command];
@@ -1028,51 +926,12 @@ async function handleComment({ github, context, core }) {
 // Command Handlers
 // ---------------------------------------------------------------------------
 
-async function cmdAccept(api, config, core, pr, actor, maintainer, commentId) {
-  if (!maintainer) {
-    await api.addReaction(commentId, '-1');
-    await api.postComment(pr.number, `@${actor} Only maintainers can accept PRs.`);
-    return;
-  }
-
-  const state = getLifecycleState(pr);
-  if (state !== LABELS.NEW) {
-    await api.addReaction(commentId, 'confused');
-    await api.postComment(pr.number,
-      `@${actor} Cannot accept: PR is not in \`lifecycle/new\` state (current: \`${state || 'none'}\`).`
-    );
-    return;
-  }
-
-  await api.setLifecycleState(pr, LABELS.READY_FOR_REVIEW);
-  await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
-  await api.addReaction(commentId, '+1');
-  await api.postComment(pr.number,
-    `PR accepted by @${actor}. @${pr.user.login}, the full test suite will run now.\n\n` +
-    `A maintainer can use \`/auto-merge\` to merge automatically once approved and tested.`
-  );
-  core.info(`PR #${pr.number} accepted by ${actor}`);
-  await retriggerVerify(api, pr, core);
-
-  // The label change above may trigger a new run that also needs
-  // approval (fork PRs). Wait for GitHub to create it, then approve.
-  await new Promise(r => setTimeout(r, 5000));
-  await approveAllPendingCiRuns(api, pr, core);
-}
-
+// Maintainer moderation — closes a PR that should not be worked further,
+// regardless of its current lifecycle state.
 async function cmdReject(api, config, core, pr, actor, maintainer, reason, commentId) {
   if (!maintainer) {
     await api.addReaction(commentId, '-1');
     await api.postComment(pr.number, `@${actor} Only maintainers can reject PRs.`);
-    return;
-  }
-
-  const state = getLifecycleState(pr);
-  if (state !== LABELS.NEW) {
-    await api.addReaction(commentId, 'confused');
-    await api.postComment(pr.number,
-      `@${actor} Cannot reject: PR is not in \`lifecycle/new\` state (current: \`${state || 'none'}\`).`
-    );
     return;
   }
 
@@ -1081,12 +940,14 @@ async function cmdReject(api, config, core, pr, actor, maintainer, reason, comme
     `PR rejected by @${actor}.${reasonText}\n\n` +
     `@${pr.user.login}, please address the feedback and reopen if appropriate.`
   );
-  await api.setLifecycleState(pr, null);
   await api.closePr(pr.number);
   await api.addReaction(commentId, '+1');
   core.info(`PR #${pr.number} rejected by ${actor}`);
 }
 
+// Toggles native GitHub auto-merge. GitHub merges automatically once its own
+// required checks and required review are satisfied — this does not require
+// the PR to already be lifecycle/ready-to-merge; it just queues the intent.
 async function cmdMerge(api, config, core, pr, actor, maintainer, commentId) {
   if (!maintainer) {
     await api.addReaction(commentId, '-1');
@@ -1094,104 +955,16 @@ async function cmdMerge(api, config, core, pr, actor, maintainer, commentId) {
     return;
   }
 
-  const state = getLifecycleState(pr);
-  if (state !== LABELS.READY_TO_MERGE) {
-    await api.addReaction(commentId, 'confused');
-    await api.postComment(pr.number,
-      `@${actor} Cannot merge: PR is not in \`lifecycle/ready-to-merge\` state ` +
-      `(current: \`${state || 'none'}\`). The PR must be both approved and tested.`
-    );
-    return;
-  }
-
-  const merged = await performMerge(api, config, pr, core);
-  await api.addReaction(commentId, merged ? '+1' : '-1');
-}
-
-async function cmdAutoMerge(api, config, core, pr, actor, maintainer, commentId) {
-  if (!maintainer) {
-    await api.addReaction(commentId, '-1');
-    await api.postComment(pr.number, `@${actor} Only maintainers can enable auto-merge.`);
-    return;
-  }
-
-  const state = getLifecycleState(pr);
-  if (!state || state === LABELS.NEW) {
-    await api.addReaction(commentId, 'confused');
-    await api.postComment(pr.number,
-      `@${actor} Cannot enable auto-merge: PR must be accepted first.`
-    );
-    return;
-  }
-
-  if (hasLabel(pr, LABELS.AUTO_MERGE)) {
-    await api.removeLabel(pr.number, LABELS.AUTO_MERGE);
-    await api.addReaction(commentId, '+1');
+  const result = await setAutoMerge(api, config, pr, core);
+  await api.addReaction(commentId, result === 'error' ? '-1' : '+1');
+  if (result === 'disabled') {
     await api.postComment(pr.number, `Auto-merge disabled by @${actor}.`);
-    core.info(`PR #${pr.number} auto-merge disabled by ${actor}`);
-    return;
-  }
-
-  await api.addLabel(pr.number, LABELS.AUTO_MERGE);
-  await api.removeLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
-  await api.addReaction(commentId, '+1');
-
-  const approved = isApproved(await api.getReviews(pr.number));
-  const reviewSkipped = hasLabel(pr, LABELS.REVIEW_SKIPPED);
-  const needsReview = !approved && !reviewSkipped;
-
-  await api.postComment(pr.number,
-    `Auto-merge enabled by @${actor}. This PR will be merged automatically ` +
-    `when it reaches \`lifecycle/ready-to-merge\` state. Use \`/auto-merge\` again to disable.` +
-    (needsReview ? `\n\n**Note:** A review or \`/skip-review\` is still required before auto-merge can proceed.` : '')
-  );
-
-  if (state === LABELS.READY_TO_MERGE) {
-    await performMerge(api, config, pr, core);
-  }
-
-  core.info(`PR #${pr.number} auto-merge enabled by ${actor}`);
-}
-
-async function cmdSkipReview(api, config, core, pr, actor, maintainer, commentId) {
-  if (!maintainer) {
-    await api.addReaction(commentId, '-1');
-    await api.postComment(pr.number, `@${actor} Only maintainers can skip the review requirement.`);
-    return;
-  }
-
-  const state = getLifecycleState(pr);
-  if (state !== LABELS.READY_FOR_REVIEW) {
-    await api.addReaction(commentId, 'confused');
+  } else if (result === 'enabled') {
     await api.postComment(pr.number,
-      `@${actor} Cannot skip review: PR must be in \`lifecycle/ready-for-review\` state ` +
-      `(current: \`${state || 'none'}\`).`
-    );
-    return;
-  }
-
-  await api.addLabel(pr.number, LABELS.REVIEW_SKIPPED);
-  await api.removeLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
-  await api.addReaction(commentId, '+1');
-
-  const freshPr = await api.getPr(pr.number);
-  if (hasLabel(freshPr, LABELS.TESTED)) {
-    const result = await checkAndTransitionToReady(api, freshPr, core);
-    if (result === 'auto-merge') {
-      await performMerge(api, config, freshPr, core);
-      await api.postComment(pr.number,
-        `Review requirement skipped by @${actor}. PR was tested and has been auto-merged.`
-      );
-    } else if (result === 'ready-to-merge') {
-      // checkAndTransitionToReady already posted its own comment
-    }
-  } else {
-    await api.postComment(pr.number,
-      `Review requirement skipped by @${actor}. The PR will move to \`lifecycle/ready-to-merge\` ` +
-      `once tests pass.`
+      `Auto-merge enabled by @${actor}. GitHub will merge this PR automatically once all ` +
+      `required checks pass and it has an approving review. Use \`/merge\` again to disable.`
     );
   }
-  core.info(`PR #${pr.number} review skipped by ${actor}`);
 }
 
 async function cmdUnstale(api, config, core, pr, actor, isAuthor, maintainer, commentId) {
@@ -1211,7 +984,7 @@ async function cmdUnstale(api, config, core, pr, actor, isAuthor, maintainer, co
   core.info(`PR #${pr.number} unstaled by ${actor}`);
 }
 
-async function cmdRetry(github, api, core, pr, actor, isAuthor, maintainer, commentId) {
+async function cmdRetry(github, api, config, core, pr, actor, isAuthor, maintainer, commentId) {
   if (!isAuthor && !maintainer) {
     await api.addReaction(commentId, '-1');
     await api.postComment(pr.number,
@@ -1226,10 +999,11 @@ async function cmdRetry(github, api, core, pr, actor, isAuthor, maintainer, comm
   const freshPr = await api.getPr(pr.number);
   await reconcile(github, api, freshPr, core);
 
-  // The workflows that matter depend on lifecycle state: the fast gate
+  // The workflow that matters depends on lifecycle state: the fast gate
   // (quick-check.yaml) during iteration, the full suite (verify.yaml) at
-  // ready-to-merge.
-  const atMergeGate = getLifecycleState(freshPr) === LABELS.READY_TO_MERGE;
+  // ready-to-merge or for trusted authors (it runs from the start for them).
+  const isTrustedAuthor = isAutoAccepted(config, freshPr.user.login);
+  const atMergeGate = getLifecycleState(freshPr) === LABELS.READY_TO_MERGE || isTrustedAuthor;
   const workflowFiles = atMergeGate ? FULL_SUITE_WORKFLOW_FILES : ['quick-check.yaml'];
   const workflowDesc = atMergeGate ? 'full-suite' : 'quick-check.yaml';
   const latestRuns = [];
@@ -1253,7 +1027,7 @@ async function cmdRetry(github, api, core, pr, actor, isAuthor, maintainer, comm
       `Retrying: reconciled PR state and re-triggering the failed ${workflowDesc} workflow ` +
       `run(s) (previous run [${latestRun.conclusion}](${latestRun.html_url})).`
     );
-    await retriggerVerify(api, freshPr, core);
+    await retriggerVerify(api, freshPr, core, isTrustedAuthor);
     core.info(`PR #${pr.number} retry: reconciled + re-triggered ${workflowDesc} by ${actor}`);
   } else if (latestRun && latestRun.status !== 'completed') {
     await api.postComment(pr.number,
@@ -1264,7 +1038,7 @@ async function cmdRetry(github, api, core, pr, actor, isAuthor, maintainer, comm
     await api.postComment(pr.number,
       `Retrying: reconciled PR state. No ${workflowDesc} run found — attempting to trigger a fresh one.`
     );
-    await retriggerVerify(api, freshPr, core);
+    await retriggerVerify(api, freshPr, core, isTrustedAuthor);
     core.info(`PR #${pr.number} retry: reconciled + triggered fresh ${workflowDesc} by ${actor}`);
   } else {
     await api.postComment(pr.number,
@@ -1394,47 +1168,6 @@ async function handleTestResult({ github, context, core }) {
     // which is a harmless no-op re-check of verify.yaml's status.
     const asFastGate = isFastGate && state === LABELS.READY_FOR_REVIEW;
 
-    // Merge-rebase flow (full suite only): branch was auto-updated;
-    // proceed to merge once the full suite passes.
-    if (!asFastGate && state === LABELS.READY_TO_MERGE && hasLabel(pr, LABELS.MERGE_REBASE)) {
-      if (pr.head.sha !== workflowRun.head_sha) {
-        core.info(`PR #${pr.number} merge-rebase SHA mismatch, skipping`);
-        continue;
-      }
-      const suite = await getFullSuiteResult(github, owner, repo, workflowRun.head_sha, core);
-      if (suite.status === 'pending') {
-        core.info(`PR #${pr.number} merge-rebase: waiting for other full-suite workflows`);
-        continue;
-      }
-      if (suite.status === 'success') {
-        await api.removeLabel(pr.number, LABELS.MERGE_REBASE);
-        // The full suite just passed for this (rebased) HEAD — record it so
-        // performMerge's full-verified gate accepts the merge.
-        await api.addLabel(pr.number, LABELS.FULL_VERIFIED);
-        const config = loadConfig();
-        const merged = await performMerge(api, config, pr, core, { allowBranchUpdate: false });
-        if (!merged) {
-          core.warning(`PR #${pr.number} merge-rebase: merge failed after branch update`);
-        }
-      } else {
-        await api.removeLabel(pr.number, LABELS.MERGE_REBASE);
-        await api.removeLabel(pr.number, LABELS.FULL_VERIFIED);
-        if (hasLabel(pr, LABELS.PENDING_MERGE)) {
-          await api.removeLabel(pr.number, LABELS.PENDING_MERGE);
-        }
-        await api.removeLabel(pr.number, LABELS.TESTED);
-        await api.setLifecycleState(pr, LABELS.READY_FOR_REVIEW);
-        await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
-        await api.postComment(pr.number,
-          `The verification workflow failed after the branch update. ` +
-          `Reverting to \`lifecycle/ready-for-review\` for a full test run.`
-        );
-      }
-      await postDecisionSummary(github, owner, repo, workflowRun, pr.number, core);
-      await postFlakyTestsSummary(github, owner, repo, workflowRun, pr.number, core);
-      continue;
-    }
-
     if (asFastGate) {
       // A late Quick Check completion can belong to a full-tier run that
       // raced a failure revert. If the full suite (verify.yaml) already
@@ -1444,15 +1177,12 @@ async function handleTestResult({ github, context, core }) {
         core.info(`PR #${pr.number} full-suite failure recorded for this SHA, skipping fast-gate result`);
         continue;
       }
-    } else {
-      // The full suite is the pre-merge gate. While a PR is in
-      // ready-for-review these runs are no-ops (Decide skips every job),
-      // so they must not mark the PR tested.
-      if (state !== LABELS.READY_TO_MERGE) {
-        core.info(`PR #${pr.number} not in ready-to-merge state, skipping full-suite result`);
-        continue;
-      }
     }
+    // Unlike before, the full-suite branch below is NOT gated on
+    // lifecycle/ready-to-merge: verify.yaml now triggers on its own native
+    // events (push for trusted authors, review submission for everyone
+    // else), so it can legitimately complete before the fast gate/review has
+    // finished promoting the PR.
 
     if (pr.head.sha !== workflowRun.head_sha) {
       core.info(`PR #${pr.number} head SHA mismatch (PR: ${pr.head.sha}, run: ${workflowRun.head_sha}), skipping`);
@@ -1466,11 +1196,8 @@ async function handleTestResult({ github, context, core }) {
         core.info(`PR #${pr.number} fast gate passed, added lifecycle/tested`);
 
         const freshPr = await api.getPr(pr.number);
-        const result = await checkAndTransitionToReady(api, freshPr, core);
-        if (result === 'auto-merge') {
-          const config = loadConfig();
-          await performMerge(api, config, freshPr, core);
-        } else if (!result) {
+        const promoted = await checkAndTransitionToReady(api, freshPr, core);
+        if (!promoted) {
           await api.addLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
         }
       } else if (workflowRun.conclusion === 'failure') {
@@ -1490,9 +1217,8 @@ async function handleTestResult({ github, context, core }) {
         core.info(`PR #${pr.number} fast gate cancelled`);
       }
     } else {
-      // Full suite at ready-to-merge: the pre-merge gate. verify.yaml (the
-      // full suite) must be green for this SHA; a failure or cancellation
-      // fails the suite.
+      // Full suite: the pre-merge gate. verify.yaml must be green for this
+      // SHA; a failure or cancellation fails the suite.
       const suite = await getFullSuiteResult(github, owner, repo, workflowRun.head_sha, core);
       if (suite.status === 'pending') {
         core.info(`PR #${pr.number} waiting for the full-suite workflow`);
@@ -1501,34 +1227,23 @@ async function handleTestResult({ github, context, core }) {
       if (suite.status === 'success') {
         await api.addLabel(pr.number, LABELS.FULL_VERIFIED);
         core.info(`PR #${pr.number} full verification passed, added lifecycle/full-verified`);
-
-        if (hasLabel(pr, LABELS.PENDING_MERGE)) {
-          await api.removeLabel(pr.number, LABELS.PENDING_MERGE);
-          const config = loadConfig();
-          const freshPr = await api.getPr(pr.number);
-          const merged = await performMerge(api, config, freshPr, core, { allowBranchUpdate: true });
-          if (!merged) {
-            core.warning(`PR #${pr.number} pending merge did not complete after full verification`);
-          }
-        }
       } else {
         const failed = suite.failedRun;
         const verb = failed.conclusion === 'cancelled' ? 'was cancelled' : 'failed';
         await api.removeLabel(pr.number, LABELS.FULL_VERIFIED);
-        await api.removeLabel(pr.number, LABELS.TESTED);
-        if (hasLabel(pr, LABELS.PENDING_MERGE)) {
-          await api.removeLabel(pr.number, LABELS.PENDING_MERGE);
-        }
-        await api.setLifecycleState(pr, LABELS.READY_FOR_REVIEW);
-        await api.addLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
-        await api.removeLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
         await api.postComment(pr.number,
           `The full verification suite ${verb} for commit ${workflowRun.head_sha.substring(0, 7)} ` +
-          `(${failed.name}: ${failed.html_url}). ` +
-          `Reverting to \`lifecycle/ready-for-review\`. @${pr.user.login}, please check the ` +
-          `workflow run and push a fix.`
+          `(${failed.name}: ${failed.html_url}). @${pr.user.login}, please check the workflow run and push a fix.`
         );
-        core.info(`PR #${pr.number} full verification ${verb}, reverted to ready-for-review`);
+        if (state === LABELS.READY_TO_MERGE) {
+          await api.removeLabel(pr.number, LABELS.TESTED);
+          await api.setLifecycleState(pr, LABELS.READY_FOR_REVIEW);
+          await api.addLabel(pr.number, LABELS.WAITING_ON_AUTHOR);
+          await api.removeLabel(pr.number, LABELS.WAITING_ON_MAINTAINER);
+          core.info(`PR #${pr.number} full verification ${verb}, reverted to ready-for-review`);
+        } else {
+          core.info(`PR #${pr.number} full verification ${verb}`);
+        }
       }
     }
 
@@ -1965,6 +1680,7 @@ module.exports = {
   handlePrSynchronize,
   handlePrReadyForReview,
   handlePrConvertedToDraft,
+  handlePrReviewSubmitted,
   handleComment,
   handleLabelChange,
   handleTestResult,

--- a/.github/scripts/pr-lifecycle.test.js
+++ b/.github/scripts/pr-lifecycle.test.js
@@ -1,4 +1,4 @@
-// Tests for pr-lifecycle.js two-tier CI routing — run with: node --test .github/scripts/
+// Tests for pr-lifecycle.js — run with: node --test .github/scripts/
 const { test, before, after } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
@@ -43,14 +43,16 @@ async function withConfig(cfg, fn) {
 
 const SHA = 'abcdef1234567890';
 
-function makeWorld(prLabels, { approved = false, suiteRuns = [], suiteJobs = {} } = {}) {
+function makeWorld(prLabels, { approved = false, suiteRuns = [], suiteJobs = {}, autoMerge = null } = {}) {
   const labels = new Set(prLabels);
-  const calls = { added: [], removed: [], comments: [], merges: [], branchUpdates: [] };
+  const calls = { added: [], removed: [], comments: [], branchUpdates: [], graphql: [] };
 
   const pr = () => ({
     number: 42,
     title: 'test',
     draft: false,
+    node_id: 'PR_kwtest',
+    auto_merge: autoMerge,
     labels: [...labels].map(name => ({ name })),
     user: { login: 'contributor' },
     head: { sha: SHA, ref: 'feature-x' },
@@ -68,11 +70,14 @@ function makeWorld(prLabels, { approved = false, suiteRuns = [], suiteJobs = {} 
         createLabel: async () => ({}),
         updateLabel: async () => ({}),
       },
+      reactions: {
+        createForIssueComment: async () => ({}),
+      },
       pulls: {
         get: async () => ({ data: pr() }),
         list: async () => ({ data: [] }),
         listReviews: async () => ({}),
-        merge: async () => { calls.merges.push('merge'); },
+        update: async () => ({}),
         updateBranch: async () => { calls.branchUpdates.push('update'); },
       },
       actions: {
@@ -80,15 +85,16 @@ function makeWorld(prLabels, { approved = false, suiteRuns = [], suiteJobs = {} 
         listWorkflowRunsForRepo: async () => ({ data: { workflow_runs: suiteRuns } }),
         listWorkflowRunArtifacts: async () => ({}),
         // Used by getFullSuiteResult to tell a genuine full-suite failure
-        // apart from the Gate's own not-ready-to-merge-yet check failing
-        // (see suiteJobs option below). Defaults to "some other job
-        // genuinely failed" so existing greenSuite({ Verify: 'failure' })
-        // callers keep meaning a real failure without having to specify it.
+        // apart from the Gate's own not-ready-yet check failing (see
+        // suiteJobs option below). Defaults to "some other job genuinely
+        // failed" so existing greenSuite({ Verify: 'failure' }) callers keep
+        // meaning a real failure without having to specify it.
         listJobsForWorkflowRun: async ({ run_id }) => ({
           data: { jobs: suiteJobs[run_id] ?? [{ name: 'Some Job', conclusion: 'failure' }] },
         }),
       },
     },
+    graphql: async (query, vars) => { calls.graphql.push({ query, vars }); return {}; },
     // paginate: reviews list when asked for reviews, empty otherwise
     paginate: async (fn) => fn === github.rest.pulls.listReviews
       ? (approved ? [{ state: 'APPROVED', user: { login: 'maintainer-jane' } }] : [])
@@ -137,7 +143,9 @@ function greenSuite(overrides = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// PR Opened — maintainer auto-accept vs. contributor review gate
+// PR Opened — every PR goes straight to ready-for-review, no triage stage.
+// Trust (maintainer/auto_accept) only affects when the full suite runs
+// (verify-decide.yaml), not anything this handler does.
 // ---------------------------------------------------------------------------
 
 function openedPr(login) {
@@ -159,74 +167,68 @@ function openedContext(pr) {
   };
 }
 
-test('maintainer PR open: auto-accepted straight to ready-for-review + review-skipped, fast gate only (not ready-to-merge yet)', async () => {
+test('trusted-author PR open: straight to ready-for-review, trusted-author messaging', async () => {
   await withConfig({ maintainers: ['maintainer-jane'], merge: { strategy: 'rebase' } }, async () => {
     const w = makeWorld([]);
-    // retriggerVerify(waitForRun: true) polls for the quick-check.yaml run it
-    // just triggered; already-green means retriggerWorkflowRun leaves it
-    // alone instead of re-running it.
-    w.github.rest.actions.listWorkflowRuns = async () => ({
-      data: { workflow_runs: [{ id: 1, status: 'completed', conclusion: 'success', head_sha: SHA }] },
-    });
     await lifecycle.handlePrOpened({ github: w.github, context: openedContext(openedPr('maintainer-jane')), core: w.core });
 
     assert.ok(w.calls.added.includes(LABELS.READY_FOR_REVIEW));
-    assert.ok(w.calls.added.includes(LABELS.REVIEW_SKIPPED));
     assert.ok(w.calls.added.includes(LABELS.WAITING_ON_MAINTAINER));
-    assert.ok(!w.calls.added.includes(LABELS.READY_TO_MERGE),
-      'must not skip straight to ready-to-merge — the fast gate still has to pass first');
-    assert.ok(w.calls.comments.some(c => c.includes('auto-accepted')));
+    assert.ok(!w.calls.added.includes(LABELS.READY_TO_MERGE));
+    assert.ok(w.calls.comments.some(c => c.includes('trusted author')));
   });
 });
 
-test('non-maintainer PR open: lifecycle/new, waiting on a maintainer to /accept', async () => {
+test('non-trusted-author PR open: straight to ready-for-review, welcome message (no accept step)', async () => {
   const w = makeWorld([]);
   await lifecycle.handlePrOpened({ github: w.github, context: openedContext(openedPr('some-contributor')), core: w.core });
 
-  assert.ok(w.calls.added.includes(LABELS.NEW));
+  assert.ok(w.calls.added.includes(LABELS.READY_FOR_REVIEW));
   assert.ok(w.calls.added.includes(LABELS.WAITING_ON_MAINTAINER));
-  assert.ok(!w.calls.added.includes(LABELS.READY_FOR_REVIEW));
-  assert.ok(!w.calls.added.includes(LABELS.REVIEW_SKIPPED));
+  assert.ok(!w.calls.added.includes(LABELS.NEW));
+  assert.ok(w.calls.comments.some(c => c.includes('Thanks for opening this PR')));
 });
 
-test('fast gate pass + review-skipped (maintainer) promotes straight to ready-to-merge, no review required', async () => {
-  const w = makeWorld([LABELS.READY_FOR_REVIEW, LABELS.REVIEW_SKIPPED, LABELS.WAITING_ON_MAINTAINER]);
-  await lifecycle.handleTestResult({ github: w.github, context: runPayload('Quick Check', 'success'), core: w.core });
+test('non-trusted author already at max open PRs is closed automatically', async () => {
+  await withConfig({ maintainers: [], max_contributor_prs: 1, merge: { strategy: 'rebase' }, welcome_message: 'hi {author}' }, async () => {
+    const w = makeWorld([]);
+    w.github.paginate = async (fn) => fn === w.github.rest.pulls.list
+      ? [{ number: 7, user: { login: 'some-contributor' } }]
+      : [];
+    let closed = false;
+    w.github.rest.pulls.update = async ({ state }) => { closed = state === 'closed'; };
+    await lifecycle.handlePrOpened({ github: w.github, context: openedContext(openedPr('some-contributor')), core: w.core });
 
-  assert.ok(w.calls.added.includes(LABELS.TESTED));
-  assert.ok(w.calls.added.includes(LABELS.READY_TO_MERGE),
-    'review-skipped + tested must promote without waiting for a review');
-  assert.ok(w.calls.comments.some(c => c.includes('full verification suite is now')));
+    assert.ok(closed, 'PR must be closed when the author is already at the open-PR cap');
+    assert.ok(!w.calls.added.includes(LABELS.READY_FOR_REVIEW));
+  });
 });
 
-test('fast gate pass without review or skip-review stays in ready-for-review (waiting on maintainer)', async () => {
-  const w = makeWorld([LABELS.READY_FOR_REVIEW]);
-  await lifecycle.handleTestResult({ github: w.github, context: runPayload('Quick Check', 'success'), core: w.core });
+// ---------------------------------------------------------------------------
+// checkAndTransitionToReady (via Quick Check fast-gate result) — promotes to
+// ready-to-merge once approved AND fast-gated. No more review-skipped bypass:
+// every author needs an actual approving review to reach ready-to-merge,
+// consistent with branch protection now requiring one.
+// ---------------------------------------------------------------------------
 
-  assert.ok(w.calls.added.includes(LABELS.TESTED));
-  assert.ok(!w.calls.added.includes(LABELS.READY_TO_MERGE),
-    'an unreviewed, non-skipped PR must wait for an approval before the full suite runs');
-  assert.ok(w.calls.added.includes(LABELS.WAITING_ON_MAINTAINER));
-});
-
-test('fast gate pass with an approved review promotes a contributor PR to ready-to-merge', async () => {
+test('fast gate pass with an approved review promotes to ready-to-merge', async () => {
   const w = makeWorld([LABELS.READY_FOR_REVIEW], { approved: true });
   await lifecycle.handleTestResult({ github: w.github, context: runPayload('Quick Check', 'success'), core: w.core });
 
   assert.ok(w.calls.added.includes(LABELS.TESTED));
   assert.ok(w.calls.added.includes(LABELS.READY_TO_MERGE),
     'an approved review + green fast gate must promote to ready-to-merge');
+  assert.ok(w.calls.comments.some(c => c.includes('is the remaining merge gate')));
 });
 
-// ---------------------------------------------------------------------------
-// Fast gate (Quick Check workflow) — drives lifecycle/tested during review
-// ---------------------------------------------------------------------------
-
-test('Quick Check success in ready-for-review adds lifecycle/tested', async () => {
+test('fast gate pass without a review stays in ready-for-review (waiting on maintainer)', async () => {
   const w = makeWorld([LABELS.READY_FOR_REVIEW]);
   await lifecycle.handleTestResult({ github: w.github, context: runPayload('Quick Check', 'success'), core: w.core });
+
   assert.ok(w.calls.added.includes(LABELS.TESTED));
-  assert.ok(!w.calls.added.includes(LABELS.FULL_VERIFIED));
+  assert.ok(!w.calls.added.includes(LABELS.READY_TO_MERGE),
+    'an unreviewed PR must wait for an approval before being promoted');
+  assert.ok(w.calls.added.includes(LABELS.WAITING_ON_MAINTAINER));
 });
 
 test('Quick Check failure in ready-for-review sets waiting-on-author', async () => {
@@ -239,42 +241,28 @@ test('Quick Check failure in ready-for-review sets waiting-on-author', async () 
 });
 
 test('Quick Check completing at ready-to-merge is a harmless no-op re-check (not a fast-gate result)', async () => {
-  // handlePrSynchronize normally reverts ready-to-merge to ready-for-review
-  // on every new push before a Quick Check run for that push could complete,
-  // but a Quick Check completion arriving for an already-promoted SHA is
-  // possible. It must not touch lifecycle/tested (that is not what its
-  // result means once promoted) and must fall through to the full-suite
-  // check like any other event would.
   const w = makeWorld([LABELS.READY_TO_MERGE, LABELS.TESTED], { approved: true });
   await lifecycle.handleTestResult({ github: w.github, context: runPayload('Quick Check', 'success'), core: w.core });
   assert.ok(!w.calls.added.includes(LABELS.FULL_VERIFIED));
-  assert.equal(w.calls.merges.length, 0);
 });
 
 // ---------------------------------------------------------------------------
-// Full suite (Verify workflow) — the pre-merge gate
+// Full suite (Verify workflow) — now runs on its own native triggers (push
+// for trusted authors, review submission for everyone else), so its result
+// is recorded regardless of lifecycle state, not just at ready-to-merge.
 // ---------------------------------------------------------------------------
 
-test('Verify success in ready-for-review is a no-op (must not mark tested)', async () => {
-  const w = makeWorld([LABELS.READY_FOR_REVIEW]);
+test('Verify success while still in ready-for-review is recorded (trusted-author suite can finish before the fast gate)', async () => {
+  const w = makeWorld([LABELS.READY_FOR_REVIEW], { suiteRuns: greenSuite() });
   await lifecycle.handleTestResult({ github: w.github, context: runPayload('Verify', 'success'), core: w.core });
-  assert.ok(!w.calls.added.includes(LABELS.TESTED));
-  assert.ok(!w.calls.added.includes(LABELS.FULL_VERIFIED));
+  assert.ok(w.calls.added.includes(LABELS.FULL_VERIFIED));
+  assert.ok(!w.calls.added.includes(LABELS.TESTED), 'full suite result must not itself set lifecycle/tested');
 });
 
 test('Verify success at ready-to-merge adds lifecycle/full-verified when the whole suite is green', async () => {
   const w = makeWorld([LABELS.READY_TO_MERGE, LABELS.TESTED], { approved: true, suiteRuns: greenSuite() });
   await lifecycle.handleTestResult({ github: w.github, context: runPayload('Verify', 'success'), core: w.core });
   assert.ok(w.calls.added.includes(LABELS.FULL_VERIFIED));
-  assert.equal(w.calls.merges.length, 0);
-});
-
-test('Verify success at ready-to-merge completes a queued (pending) merge', async () => {
-  const w = makeWorld([LABELS.READY_TO_MERGE, LABELS.TESTED, LABELS.PENDING_MERGE], { approved: true, suiteRuns: greenSuite() });
-  await lifecycle.handleTestResult({ github: w.github, context: runPayload('Verify', 'success'), core: w.core });
-  assert.ok(w.calls.added.includes(LABELS.FULL_VERIFIED));
-  assert.ok(w.calls.removed.includes(LABELS.PENDING_MERGE));
-  assert.equal(w.calls.merges.length, 1);
 });
 
 test('full suite stays pending if the search API has not caught up with the just-completed run yet', async () => {
@@ -285,7 +273,6 @@ test('full suite stays pending if the search API has not caught up with the just
   const w = makeWorld([LABELS.READY_TO_MERGE, LABELS.TESTED], { approved: true, suiteRuns: greenSuite({ Verify: 'in_progress/' }) });
   await lifecycle.handleTestResult({ github: w.github, context: runPayload('Verify', 'success'), core: w.core });
   assert.ok(!w.calls.added.includes(LABELS.FULL_VERIFIED));
-  assert.equal(w.calls.merges.length, 0);
   assert.equal(w.calls.comments.length, 0);
 });
 
@@ -299,15 +286,16 @@ test('late Quick Check success does not promote the PR after a full-suite failur
   assert.ok(!w.calls.added.includes(LABELS.FULL_VERIFIED));
 });
 
-test('Quick Check success DOES promote a first-time PR even though an earlier not-yet-ready Verify run shows failure', async () => {
-  // Every Verify run before a PR is promoted legitimately fails its own
-  // "is this actually ready to merge" check (see verify.yaml's Gate) --
-  // that is not a real test failure and must not be confused with one.
-  // Here only "Verification Gate" failed; every other job in the run was
-  // skipped (Decide gated them on the same not-yet-ready state), so
+test('Quick Check success DOES promote a reviewed PR even though an earlier not-yet-ready Verify run shows failure', async () => {
+  // Every Verify run before Decide requires the full suite legitimately
+  // fails its own "is this actually required yet" check (see verify.yaml's
+  // Gate) — that is not a real test failure and must not be confused with
+  // one. Here only "Verification Gate" failed; every other job in the run
+  // was skipped (Decide gated them on the same not-yet-required state), so
   // getFullSuiteResult must treat this as pending, not a genuine failure,
   // and let the fast gate promote the PR normally.
-  const w = makeWorld([LABELS.READY_FOR_REVIEW, LABELS.REVIEW_SKIPPED, LABELS.WAITING_ON_MAINTAINER], {
+  const w = makeWorld([LABELS.READY_FOR_REVIEW, LABELS.WAITING_ON_MAINTAINER], {
+    approved: true,
     suiteRuns: greenSuite({ Verify: 'failure' }),
     suiteJobs: { Verify: [{ name: 'Verification Gate', conclusion: 'failure' }] },
   });
@@ -317,14 +305,20 @@ test('Quick Check success DOES promote a first-time PR even though an earlier no
 });
 
 test('Verify failure at ready-to-merge reverts to ready-for-review', async () => {
-  const w = makeWorld([LABELS.READY_TO_MERGE, LABELS.TESTED, LABELS.FULL_VERIFIED, LABELS.PENDING_MERGE], { approved: true, suiteRuns: greenSuite({ Verify: 'failure' }) });
+  const w = makeWorld([LABELS.READY_TO_MERGE, LABELS.TESTED, LABELS.FULL_VERIFIED], { approved: true, suiteRuns: greenSuite({ Verify: 'failure' }) });
   await lifecycle.handleTestResult({ github: w.github, context: runPayload('Verify', 'failure'), core: w.core });
   assert.ok(w.calls.removed.includes(LABELS.FULL_VERIFIED));
   assert.ok(w.calls.removed.includes(LABELS.TESTED));
-  assert.ok(w.calls.removed.includes(LABELS.PENDING_MERGE));
   assert.ok(w.calls.added.includes(LABELS.READY_FOR_REVIEW));
   assert.ok(w.calls.added.includes(LABELS.WAITING_ON_AUTHOR));
-  assert.equal(w.calls.merges.length, 0);
+});
+
+test('Verify failure while still in ready-for-review just clears full-verified (nothing to revert)', async () => {
+  const w = makeWorld([LABELS.READY_FOR_REVIEW], { suiteRuns: greenSuite({ Verify: 'failure' }) });
+  await lifecycle.handleTestResult({ github: w.github, context: runPayload('Verify', 'failure'), core: w.core });
+  assert.ok(w.calls.removed.includes(LABELS.FULL_VERIFIED));
+  assert.ok(!w.calls.added.includes(LABELS.WAITING_ON_AUTHOR));
+  assert.ok(w.calls.comments.some(c => c.includes('full verification suite')));
 });
 
 test('Verify result with stale SHA is ignored', async () => {
@@ -334,3 +328,147 @@ test('Verify result with stale SHA is ignored', async () => {
   await lifecycle.handleTestResult({ github: w.github, context: ctx, core: w.core });
   assert.ok(!w.calls.added.includes(LABELS.FULL_VERIFIED));
 });
+
+// ---------------------------------------------------------------------------
+// /merge — toggles native GitHub auto-merge (no more custom merge polling)
+// ---------------------------------------------------------------------------
+
+test('/merge command: maintainer enables auto-merge and posts confirmation', async () => {
+  await withConfig({ maintainers: ['maintainer-jane'], merge: { strategy: 'rebase' } }, async () => {
+    const w = makeWorld([LABELS.READY_TO_MERGE], { autoMerge: null });
+    const pr = await w.github.rest.pulls.get().then(r => r.data);
+    await lifecycle.handleComment({
+      github: w.github,
+      context: {
+        repo: { owner: 'Apicurio', repo: 'apicurio-registry' },
+        payload: {
+          comment: { id: 1, body: '/merge', user: { login: 'maintainer-jane' } },
+          issue: { number: pr.number, pull_request: {} },
+        },
+      },
+      core: w.core,
+    });
+    assert.equal(w.calls.graphql.length, 1);
+    assert.match(w.calls.graphql[0].query, /enablePullRequestAutoMerge/);
+    assert.ok(w.calls.comments.some(c => c.includes('Auto-merge enabled')));
+  });
+});
+
+test('/merge command: maintainer disables auto-merge when already enabled', async () => {
+  await withConfig({ maintainers: ['maintainer-jane'], merge: { strategy: 'rebase' } }, async () => {
+    const w = makeWorld([LABELS.READY_TO_MERGE], { autoMerge: { enabled_by: { login: 'maintainer-jane' } } });
+    await lifecycle.handleComment({
+      github: w.github,
+      context: {
+        repo: { owner: 'Apicurio', repo: 'apicurio-registry' },
+        payload: {
+          comment: { id: 1, body: '/merge', user: { login: 'maintainer-jane' } },
+          issue: { number: 42, pull_request: {} },
+        },
+      },
+      core: w.core,
+    });
+    assert.equal(w.calls.graphql.length, 1);
+    assert.match(w.calls.graphql[0].query, /disablePullRequestAutoMerge/);
+    assert.ok(w.calls.comments.some(c => c.includes('Auto-merge disabled')));
+  });
+});
+
+test('/merge command: non-maintainer is rejected', async () => {
+  await withConfig({ maintainers: ['maintainer-jane'], merge: { strategy: 'rebase' } }, async () => {
+    const w = makeWorld([LABELS.READY_TO_MERGE]);
+    await lifecycle.handleComment({
+      github: w.github,
+      context: {
+        repo: { owner: 'Apicurio', repo: 'apicurio-registry' },
+        payload: {
+          comment: { id: 1, body: '/merge', user: { login: 'random-user' } },
+          issue: { number: 42, pull_request: {} },
+        },
+      },
+      core: w.core,
+    });
+    assert.equal(w.calls.graphql.length, 0);
+    assert.ok(w.calls.comments.some(c => c.includes('Only maintainers can merge')));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /reject — maintainer moderation, works regardless of lifecycle state
+// (there is no more lifecycle/new triage stage to restrict it to)
+// ---------------------------------------------------------------------------
+
+test('/reject closes the PR for a maintainer regardless of state', async () => {
+  await withConfig({ maintainers: ['maintainer-jane'], merge: { strategy: 'rebase' } }, async () => {
+    const w = makeWorld([LABELS.READY_FOR_REVIEW]);
+    let closed = false;
+    w.github.rest.pulls.update = async ({ state }) => { closed = state === 'closed'; };
+    await lifecycle.handleComment({
+      github: w.github,
+      context: {
+        repo: { owner: 'Apicurio', repo: 'apicurio-registry' },
+        payload: {
+          comment: { id: 1, body: '/reject not a good fit', user: { login: 'maintainer-jane' } },
+          issue: { number: 42, pull_request: {} },
+        },
+      },
+      core: w.core,
+    });
+    assert.ok(closed);
+    assert.ok(w.calls.comments.some(c => c.includes('rejected') && c.includes('not a good fit')));
+  });
+});
+
+test('/reject is rejected for a non-maintainer', async () => {
+  await withConfig({ maintainers: ['maintainer-jane'], merge: { strategy: 'rebase' } }, async () => {
+    const w = makeWorld([LABELS.READY_FOR_REVIEW]);
+    let closed = false;
+    w.github.rest.pulls.update = async () => { closed = true; };
+    await lifecycle.handleComment({
+      github: w.github,
+      context: {
+        repo: { owner: 'Apicurio', repo: 'apicurio-registry' },
+        payload: {
+          comment: { id: 1, body: '/reject', user: { login: 'random-user' } },
+          issue: { number: 42, pull_request: {} },
+        },
+      },
+      core: w.core,
+    });
+    assert.ok(!closed);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy label migration — retired labels from the old bot-driven-promotion
+// design are cleaned up (or migrated to their native equivalent) on the next
+// reconcile, rather than left stuck on old PRs forever. Exercised through
+// handleReconcile (the real workflow_dispatch entry point) so these tests go
+// through the module's actual createApi, not a re-implementation of it.
+// ---------------------------------------------------------------------------
+
+function reconcileContext() {
+  return { repo: { owner: 'Apicurio', repo: 'apicurio-registry' } };
+}
+
+test('legacy lifecycle/new migrates to ready-for-review', async () => {
+  const w = makeWorld(['lifecycle/new']);
+  await lifecycle.handleReconcile({ github: w.github, context: reconcileContext(), core: w.core, prNumber: 42 });
+  assert.ok(!w.labels.has('lifecycle/new'));
+  assert.ok(w.calls.added.includes(LABELS.READY_FOR_REVIEW));
+});
+
+test('legacy orchestrator/review-skipped is just removed', async () => {
+  const w = makeWorld([LABELS.READY_FOR_REVIEW, 'orchestrator/review-skipped']);
+  await lifecycle.handleReconcile({ github: w.github, context: reconcileContext(), core: w.core, prNumber: 42 });
+  assert.ok(w.calls.removed.includes('orchestrator/review-skipped'));
+});
+
+test('legacy orchestrator/auto-merge migrates to native auto-merge', async () => {
+  const w = makeWorld([LABELS.READY_FOR_REVIEW, 'orchestrator/auto-merge'], { autoMerge: null });
+  await lifecycle.handleReconcile({ github: w.github, context: reconcileContext(), core: w.core, prNumber: 42 });
+  assert.ok(w.calls.removed.includes('orchestrator/auto-merge'));
+  assert.equal(w.calls.graphql.length, 1);
+  assert.match(w.calls.graphql[0].query, /enablePullRequestAutoMerge/);
+});
+

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,6 @@ Two top-level workflows make up the whole pipeline:
 |----------|----------|
 | `quick-check.yaml` (**Quick Check**) | The fast PR gate: **Quick Verify** (~5 min, every PR push) and a fast UI build. No lifecycle awareness, no Decide job — it always runs the same way. Drives `lifecycle/tested` while a PR is in `lifecycle/ready-for-review`. |
 | `verify.yaml` (**Verify**) | Everything else: Build (Java app + Docker images), unit tests, CLI, SDKs, console plugin, integration tests, extra tests, operator tests, and (on push to `main`) image publishing. One `decide` job, shared by every job in this workflow via `needs:`. Drives `lifecycle/full-verified`. |
-
 `verify.yaml` intentionally has a single Decide job that every other job in it
 depends on, rather than being split across several independently-triggered
 workflow files each with their own Decide. That used to be the design (four
@@ -34,11 +33,20 @@ scope** (PR labels) and **change detection** (path-based filtering) into one
 boolean output per phase, computed once and shared by every other job in the
 workflow via `needs:` and a single `if:` condition each.
 
-**Lifecycle scope** is driven by PR labels from the PR lifecycle orchestrator:
-- `lifecycle/new`, `lifecycle/ready-for-review` or no label → full suite skipped
-  (the Quick Verify fast gate in `quick-check.yaml` covers PR iteration)
-- `lifecycle/ready-to-merge` → full suite runs
+**Lifecycle scope** is a live, native-fact decision — not a PR label:
+- author is a maintainer or in `auto_accept` (e.g. Renovate) → full suite runs
+  immediately, on every push
+- otherwise → full suite runs once the PR has a current approving review
+  (`gh pr view --json reviewDecision` == `APPROVED`), re-evaluated fresh on
+  every `pull_request_review: submitted` event
+- `orchestrator/disabled` label → full suite runs regardless (unless
+  `DO NOT MERGE` is also present)
 - Push to main → always full suite
+
+Deciding this from author identity and review state instead of a bot-applied
+label (the previous `lifecycle/ready-to-merge` design) removes an entire class
+of races: there is no window where a run that started before a promotion could
+disagree with one that started after — Decide re-evaluates live, every time.
 
 **Change detection** uses `dorny/paths-filter` to determine which areas changed:
 
@@ -57,20 +65,22 @@ Push to main always runs everything regardless of change detection.
 ### Verification Gate
 
 The `gate` job in `verify.yaml` is the **single required check** for branch
-protection (alongside `Lint and Validate`, also a job in the same workflow).
-It runs with `if: always()` and aggregates every job in the same run via
-`needs.*.result`. For PR events it then does one more thing: a live,
-direct check (via `gh api`) of whether the PR actually carries
-`lifecycle/ready-to-merge` right now, and fails if it does not.
+protection. It runs with `if: always()` and aggregates every job in the same
+run via `needs.*.result`. For non-push events it then does one more thing:
+it fails outright if `needs.decide.outputs.lifecycle-ready != 'true'`.
 
-That live check exists because a skipped required job counts as "passing"
-for branch protection purposes, and every job in `verify.yaml` is skipped by
-Decide until the PR reaches `lifecycle/ready-to-merge` — without it, native
-"Merge pull request" would be unblocked the moment Decide+Gate complete for
-any PR, regardless of whether the full suite had ever actually run for the
-commit. The failure this produces during normal PR review is expected, not a
-sign of anything broken: it clears on its own once the orchestrator promotes
-the PR and force-retriggers `verify.yaml`.
+That check exists because a skipped required job counts as "passing" for
+branch protection purposes, and every job in `verify.yaml` is skipped by
+Decide whenever the full suite was not required for this run — without it,
+native "Merge pull request" would be unblocked the moment Decide+Gate
+complete for any PR, regardless of whether the full suite had ever actually
+run for the commit. Checking Decide's own output (the same static value that
+already gated every job above via `needs:`) means this cannot disagree with
+the rest of the run — there is nothing to race against, unlike a live
+re-fetch of current PR/label state would be. The failure this produces
+during normal PR review is expected, not a sign of anything broken: it
+clears on its own once the full suite subsequently runs and passes (for a
+trusted author, immediately; for everyone else, once a review lands).
 
 The PR lifecycle orchestrator (`pr-lifecycle.js`) independently tracks
 `verify.yaml`'s latest run by head SHA before applying `lifecycle/full-verified`.
@@ -79,7 +89,14 @@ This (and the single-Decide-job design above) replaces two earlier approaches:
 first, configuring 24 individual jobs as required checks, which caused skipped
 jobs to show as permanently pending; then, splitting the suite across four
 independently-triggered workflow files, which introduced cross-workflow
-Decide-disagreement races (see above).
+Decide-disagreement races (see above); then, gating Decide on a bot-applied
+`lifecycle/ready-to-merge` label with a live re-fetch in Gate to cross-check
+it, which added its own race between the live re-fetch (evaluated late, after
+every other job) and Decide (evaluated once, early) — a run could look "ready"
+by the time Gate's live check ran even though Decide itself had skipped
+everything at the start of that same run. Deciding from live author/review
+facts directly (this design) needs no live re-fetch and no bot-applied label
+at all, so there is nothing left to race.
 
 ## Unit Test Sharding
 
@@ -235,7 +252,7 @@ and tags starting with `3.`.
 
 | Workflow | Trigger | Purpose | Duration |
 |----------|---------|---------|----------|
-| `pr-lifecycle.yml` | PR events, comments, reviews, workflow_run, every 6 hours | Label-driven PR state machine. States: `new` -> `ready-for-review` -> `ready-to-merge`. Draft PRs are ignored until marked ready for review. Comment commands: `/accept`, `/reject`, `/merge`, `/auto-merge`, `/retry`. Auto-accepts maintainers. Reconciler runs after each event and on cron to fix inconsistent state. Stale detection (7-day warning, 14-day auto-close; 7-day auto-close for PRs waiting on the author). Label protection (reverts unauthorized changes). Failure notification posts a warning comment when any lifecycle job fails. | 2-5 min per event |
+| `pr-lifecycle.yml` | PR events, review submissions, comments, workflow_run, every 6 hours | Label-driven PR state machine. States: `ready-for-review` -> `ready-to-merge` (no triage stage — every PR starts at `ready-for-review`). Draft PRs are ignored until marked ready for review. Comment commands: `/reject`, `/merge` (toggles native GitHub auto-merge), `/unstale`, `/retry`. Reconciler runs after each event and on cron to fix inconsistent state. Stale detection (7-day warning, 14-day auto-close; 7-day auto-close for PRs waiting on the author). Label protection (reverts unauthorized changes). Failure notification posts a warning comment when any lifecycle job fails. | 2-5 min per event |
 | `update-openapi.yaml` | Push to main (openapi.json changes) | Auto-copies v3 OpenAPI spec to v2 path, commits if changed, then validates via `validate-openapi.yaml` | 10-15 min |
 | `update-website.yaml` | Release event, workflow_dispatch | Updates `latestRelease.json` on apicurio.github.io with release metadata | 5-10 min |
 | `publish-docs.yaml` | Push to main (docs/**), workflow_dispatch | Builds documentation via Antora playbook and publishes to apicurio.github.io | 15-30 min |

--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -4,6 +4,8 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, labeled, unlabeled]
     branches: [main]
+  pull_request_review:
+    types: [submitted]
   issue_comment:
     types: [created]
   workflow_run:
@@ -127,6 +129,40 @@ jobs:
             await handler.handlePrConvertedToDraft({ github, context, core });
 
   # ==========================================================================
+  # Review Submitted
+  # ==========================================================================
+  # Same-repo PRs only: pull_request_review gives GITHUB_TOKEN the same
+  # restricted, secret-less, read-only token for fork PRs that pull_request
+  # does (see verify.yaml's own pull_request_review trigger, which only needs
+  # to read/build/test, not write). This job needs write access to update
+  # labels, so fork PR reviews are left to the slower but still-correct path:
+  # verify.yaml's own pull_request_review trigger re-evaluates Decide and
+  # runs the full suite regardless of fork status (building/testing only
+  # needs read access), and its completion already reconciles labels via the
+  # existing workflow_run handler below.
+  pr-review-submitted:
+    name: Review Submitted
+    runs-on: ubuntu-latest
+    if: |
+      github.repository_owner == 'Apicurio' &&
+      github.event_name == 'pull_request_review' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.event.pull_request.labels.*.name, 'orchestrator/disabled')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Convert config to JSON
+        run: yq -o json .github/pr-lifecycle.yml > .github/pr-lifecycle.json
+
+      - name: Handle review submitted
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const handler = require('./.github/scripts/pr-lifecycle.js');
+            await handler.handlePrReviewSubmitted({ github, context, core });
+
+  # ==========================================================================
   # Comment Commands
   # ==========================================================================
   command:
@@ -216,7 +252,7 @@ jobs:
       github.repository_owner == 'Apicurio' &&
       failure() &&
       github.event_name != 'schedule'
-    needs: [pr-opened, pr-synchronize, pr-ready-for-review, pr-converted-to-draft, command, label-guard, test-result, reconcile]
+    needs: [pr-opened, pr-synchronize, pr-ready-for-review, pr-converted-to-draft, pr-review-submitted, command, label-guard, test-result, reconcile]
     steps:
       - name: Post warning comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/.github/workflows/verify-decide.yaml
+++ b/.github/workflows/verify-decide.yaml
@@ -121,22 +121,25 @@ jobs:
           ACTION="${{ github.event.action }}"
 
           # ── Phase 1: Lifecycle scope ──────────────────────────────────
-          # Two-tier CI: quick-check.yaml's fast gate covers PR iteration; the full
-          # suite only runs for lifecycle/ready-to-merge (pre-merge gate)
-          # and pushes to main.
+          # Two-tier CI: quick-check.yaml's fast gate covers PR iteration.
+          # The full suite runs immediately for trusted authors (maintainers
+          # and configured auto_accept identities) and, for everyone else,
+          # once the PR has a current approving review — both native facts,
+          # evaluated live, right here, once per run. Nothing downstream can
+          # end up out of sync with a bot-applied label, because there is no
+          # such label in the decision any more.
           run_tests=false
 
           if [ "$EVENT" = "push" ]; then
             run_tests=true
           else
-            # Non-lifecycle label events: skip the workflow run entirely.
-            # Unlike other PR events, we do NOT need to evaluate lifecycle
-            # state here — the workflow already ran (or will run) for the
-            # synchronize/opened event on the same SHA, so the gate result
-            # from that run is authoritative.
-            if [ "$ACTION" = "labeled" ]; then
+            # Only orchestrator/disabled matters to Decide now. Any other
+            # label add/remove is a no-op here — the workflow already ran
+            # (or will run) for the synchronize/opened event on the same
+            # SHA, so that run's Decide is authoritative for anything else.
+            if [ "$ACTION" = "labeled" ] || [ "$ACTION" = "unlabeled" ]; then
               LABEL='${{ github.event.label.name }}'
-              if [[ "$LABEL" != lifecycle/* ]]; then
+              if [ "$LABEL" != "orchestrator/disabled" ]; then
                 echo "lifecycle-ready=skip" >> "$GITHUB_OUTPUT"
                 for out in run-build run-unit-tests run-scalpel-report run-integration run-extras run-sdk run-cli run-operator run-console-plugin run-go-sdk-freshness; do
                   echo "$out=false" >> "$GITHUB_OUTPUT"
@@ -146,12 +149,13 @@ jobs:
               fi
             fi
 
-            # Fetch current labels and draft status from the API (event payload
-            # can be stale)
+            # Fetch current labels, draft status and author from the API
+            # (event payload can be stale).
             PR_NUMBER='${{ github.event.pull_request.number }}'
-            PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '{labels: [.labels[].name], draft: .draft}')
+            PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '{labels: [.labels[].name], draft: .draft, author: .user.login}')
             LABELS=$(echo "$PR_JSON" | jq -c '.labels')
             IS_DRAFT=$(echo "$PR_JSON" | jq -r '.draft')
+            AUTHOR=$(echo "$PR_JSON" | jq -r '.author')
             has_label() { echo "$LABELS" | jq -e "index(\"$1\")" > /dev/null 2>&1; }
 
             # Drafts are outside the lifecycle — no CI, regardless of any
@@ -166,10 +170,6 @@ jobs:
               exit 0
             fi
 
-            # Orchestrator-initiated branch update for merge: the full suite
-            # MUST run on the rebased SHA. The pre-rebase HEAD only passed the
-            # fast gate (two-tier CI), so there is no "already tested" shortcut.
-
             if has_label "orchestrator/disabled"; then
               if has_label "DO NOT MERGE"; then
                 run_tests=false
@@ -177,16 +177,16 @@ jobs:
                 run_tests=true
               fi
             else
-              # Two-tier CI: PR iteration is covered by the fast gate in quick-check.yaml
-              # (<= 5 min, compile + smoke). The full suite here is the
-              # pre-merge gate and only runs once a maintainer marks the PR
-              # lifecycle/ready-to-merge. lifecycle/ready-for-review no longer
-              # triggers full CI.
-              if has_label "lifecycle/ready-to-merge"; then
+              yq -o json .github/pr-lifecycle.yml > /tmp/pr-lifecycle.json
+              if jq -e --arg u "$AUTHOR" '(.maintainers + (.auto_accept // [])) | index($u) != null' /tmp/pr-lifecycle.json > /dev/null; then
                 run_tests=true
               else
-                # lifecycle/new, lifecycle/ready-for-review or no lifecycle label
-                run_tests=false
+                REVIEW_DECISION=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json reviewDecision --jq .reviewDecision)
+                if [ "$REVIEW_DECISION" = "APPROVED" ]; then
+                  run_tests=true
+                else
+                  run_tests=false
+                fi
               fi
             fi
           fi

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -8,26 +8,32 @@ name: Verify
 #
 # Two workflows make up the whole pipeline:
 #   - quick-check.yaml — the fast PR gate (Quick Verify, <= 5 min, every push)
-#   - verify.yaml (this file) — everything else, gated by Decide on
-#     lifecycle/ready-to-merge and pushes to main
+#   - verify.yaml (this file) — everything else. Decide runs it immediately
+#     for trusted authors (maintainers / configured auto_accept identities,
+#     e.g. Renovate) and, for everyone else, once the PR has a current
+#     approving review — both native facts evaluated live by Decide, not a
+#     bot-applied label, so there is no window where a stale run could
+#     mid-flight disagree with a promotion that happened after it started.
 #
 # The Verification Gate below is the single required check for branch
-# protection: it aggregates every job in this run and, for PR events, also
-# does a live check that the PR actually carries lifecycle/ready-to-merge —
-# not because it distrusts this run's own Decide (there is only one, computed
-# once, so it cannot disagree with anything), but because a skipped required
-# job counts as "passing" for branch protection, and this run itself skips
-# everything below Decide until the PR is genuinely ready to merge. Without
-# the live check, native "Merge pull request" would be unblocked the moment
-# this run's Decide+Gate complete, regardless of whether the full suite ever
-# ran for the commit.
+# protection: it aggregates every job in this run and additionally fails
+# outright if Decide did not require the full suite for this run — a skipped
+# required job otherwise counts as "passing" for branch protection, and this
+# run skips everything below Decide until the PR is genuinely trusted/
+# reviewed. That failure is expected during normal review, not a bug: it is
+# what makes the required check honestly reflect "not verified yet" instead
+# of silently passing because nothing ran.
 
 on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, reopened, synchronize, labeled]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
     branches: [main]
+  # No branches: filter here — pull_request_review does not support one.
+  # In practice every PR in this repo targets main, so this is a non-issue.
+  pull_request_review:
+    types: [submitted]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -377,50 +383,24 @@ jobs:
           fi
           echo "All jobs passed or were appropriately skipped"
 
-      # Live, direct check of the PR's CURRENT lifecycle state, cross-checked
-      # against THIS run's own Decide output. A skipped required job counts
-      # as "passing" for branch protection, and every job above is skipped
-      # unless Decide's lifecycle-ready was true when THIS run started —
-      # so checking only the live PR state is not enough: Decide is
-      # evaluated once, early, right when the run starts, while this step
-      # runs later (after every other job above has finished, however long
-      # that took). If the PR gets promoted to ready-to-merge in that
-      # window, this run's live check alone would see "ready" and pass,
-      # even though Decide already skipped every real job for this exact
-      # run because it evaluated too early to know that — a stale pass
-      # that never actually ran the suite it is reporting success for.
-      # Requiring THIS run's own Decide to also have seen ready-to-merge
-      # closes that: a stale run now fails instead, and the orchestrator's
-      # existing force-retrigger on promotion produces a fresh run whose
-      # Decide correctly sees the promoted state and runs the real jobs.
-      - name: Verify PR is actually ready to merge
-        if: github.event_name != 'push'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          DECIDE_LIFECYCLE_READY: ${{ needs.decide.outputs.lifecycle-ready }}
+      # A skipped required job counts as "passing" for branch protection, and
+      # every job above is skipped whenever Decide did not require the full
+      # suite for this run (author not yet trusted/reviewed). Checking
+      # Decide's own output — the same static value that already gated every
+      # job above via needs: — means this cannot disagree with the rest of
+      # the run: there is nothing to race against, unlike a live re-fetch of
+      # current PR state would be (Decide runs once, early; a live re-fetch
+      # here would run later, after everything above finished, and could see
+      # a promotion that happened in between — a stale pass for a suite that
+      # never actually ran). This step failing is expected throughout normal
+      # PR review — that is what makes the required check honestly reflect
+      # "not verified yet" instead of silently passing because Decide skipped
+      # everything.
+      - name: Verify this run's Decide required the full suite
+        if: github.event_name != 'push' && needs.decide.outputs.lifecycle-ready != 'true'
         run: |
-          # Mirrors verify-decide.yaml's own lifecycle-scope logic exactly
-          # (orchestrator/disabled bypasses the lifecycle label dance unless
-          # DO NOT MERGE is also present).
-          READY=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '
-            [.labels[].name] as $labels |
-            ($labels | index("lifecycle/ready-to-merge") != null) as $readyToMerge |
-            ($labels | index("orchestrator/disabled") != null) as $orchestratorDisabled |
-            ($labels | index("DO NOT MERGE") != null) as $doNotMerge |
-            if $orchestratorDisabled then (if $doNotMerge then false else true end)
-            else $readyToMerge
-            end')
-          if [ "$READY" != "true" ]; then
-            echo "::error::PR #$PR_NUMBER is not lifecycle/ready-to-merge yet — the full suite has not run for this SHA. This is expected during PR review, not a failure of anything: promotion happens automatically once the fast gate (Quick Check) passes (immediately for trusted/auto-accepted authors, or after an approving review for everyone else), and this Gate will pass once the full suite subsequently completes for the promoted commit."
-            exit 1
-          fi
-          if [ "$DECIDE_LIFECYCLE_READY" != "true" ]; then
-            echo "::error::PR #$PR_NUMBER is lifecycle/ready-to-merge right now, but THIS run's own Decide evaluated earlier (before promotion) and saw lifecycle-ready=$DECIDE_LIFECYCLE_READY, so every real job above was skipped. This run is stale and cannot retroactively claim to have run the suite it skipped. A fresh run with up-to-date Decide output is required — the orchestrator's force-retrigger on promotion should already produce one; use /retry if it has not appeared."
-            exit 1
-          fi
-          echo "PR #$PR_NUMBER is lifecycle/ready-to-merge and this run's own Decide agrees"
+          echo "::error::Decide did not require the full suite for this run (lifecycle-ready=${{ needs.decide.outputs.lifecycle-ready }}) — the author is not yet trusted/reviewed, so every job above was skipped. This is expected during PR review, not a failure: the full suite runs immediately for trusted authors, or once an approving review lands for everyone else, and this Gate passes once it subsequently completes."
+          exit 1
 
   # ============================================================================
   # PUBLISH: Push images (only on push to main)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,16 +77,18 @@ Because we are all humans, and to ensure Apicurio Registry is stable for everyon
 
 CI runs in two tiers:
 
-1. **Fast gate** (`CI` workflow, ~5 min): runs on every non-draft push. Compiles the
-   project (including test sources) and runs the pure unit tests plus a curated app
-   smoke set. This is what gives you rapid feedback while iterating.
-2. **Full verification**: the complete suite, split across per-phase workflows —
-   `CI` (unit-test shards, SDKs, CLI, console plugin), `Integration Tests`
-   (storage matrix), `Extra Tests` (additional checks), and `Verify` (operator
-   tests, image publishing, and the cross-workflow Verification Gate). It runs when
-   a maintainer marks the PR `lifecycle/ready-to-merge` (and on every push to
-   `main`), and all four workflows must pass before the merge completes. If any
-   fails, the PR returns to `lifecycle/ready-for-review` automatically.
+1. **Fast gate** (`Quick Check` workflow, ~5 min): runs on every push to every PR,
+   regardless of author or review state. Compiles the project (including test
+   sources) and runs the pure unit tests plus a curated app smoke set. This is what
+   gives you rapid feedback while iterating.
+2. **Full verification** (`Verify` workflow): the complete suite — build, unit
+   tests, CLI, SDKs, console plugin, integration tests, extra tests, operator
+   tests, and the Verification Gate (the single required check for merging). It
+   runs immediately for maintainers and other trusted authors (e.g. Renovate), or
+   once your PR has an approving review otherwise — not gated by any label a
+   maintainer has to apply. It also always runs on every push to `main`. If it
+   fails, the PR reverts to `lifecycle/ready-for-review` and `lifecycle/tested` is
+   cleared so it's clear a fresh fast-gate pass and review are needed again.
 
 ### Tests and documentation are not optional
 


### PR DESCRIPTION
## What

Replaces the `lifecycle/ready-to-merge`-gated full suite with a live decision based on facts GitHub already tracks:

- **Maintainers and configured `auto_accept` identities** (e.g. Renovate) get the full suite (`verify.yaml`) immediately, on every push.
- **Everyone else** gets it once their PR has a current approving review (`gh pr view --json reviewDecision` == `APPROVED`), re-evaluated fresh on every `pull_request_review: submitted` event.

## Why

This removes the root cause of every full-suite race fixed this cycle (#9772, #9783, #9788): promotion used to be an asynchronous bot-applied label with no natural trigger of its own, so a run that started *before* promotion could disagree with one that started *after*. There is no such label any more — Decide evaluates live, every run, so nothing can go stale relative to it.

Verification Gate's existing "fail if Decide didn't require the suite" check needed **no changes** — it already correctly turns "skipped because not yet trusted/reviewed" into a real failure, regardless of what feeds `lifecycle-ready`.

Also drops **"Lint and Validate"** from branch protection's required checks: it was gated by the same Decide output with no anti-skip-pass guard, so it has been trivially skip-passing since a PR's first push. Verification Gate's aggregation already covers its real result — it was providing zero actual protection.

## Consequences of no longer needing a bot-driven promotion step

- **`/accept` and the `lifecycle/new` triage stage are gone** — every PR enters `ready-for-review` directly.
- **`/skip-review` and `orchestrator/review-skipped` are gone** — they only ever bypassed human review for the full suite's benefit; branch protection now requires an approving review to merge regardless (`required_approving_review_count: 1`), so the bypass was already dead code.
- **`/auto-merge` is folded into `/merge`** (toggles native GitHub auto-merge via the `enablePullRequestAutoMerge`/`disablePullRequestAutoMerge` GraphQL mutations, both verified against the live GraphQL schema) — GitHub merges automatically once its own required checks and review are satisfied, so `performMerge`'s custom rebase-retry/pending-merge polling is gone along with `orchestrator/auto-merge`, `orchestrator/merge-pending`, and `orchestrator/merge-rebase`.
- **`lifecycle/review-approved` is gone** — redundant with GitHub's own review state.

Labels go from 13 to 8, commands from 7 to 4. A legacy-label migration path in `migrateLegacyLabels` handles PRs still carrying any of the retired labels.

`pr-lifecycle.yml` gets a new `pull_request_review`-triggered job, scoped to same-repo PRs only (fork PRs get the same restricted, secret-less token under `pull_request_review` as they do under `pull_request` — confirmed against GitHub's docs — so this job would fail to write labels for them; those still get correctly reconciled once `verify.yaml`'s own review-triggered run completes, via the existing `workflow_run` handler). This makes `waiting-on-*`/`ready-to-merge` labels update immediately instead of waiting for the next label-change event or the 6-hour cron sweep.

## Validation

- `node --test .github/scripts/pr-lifecycle.test.js`: 23/23 passing (rewritten to match the new behavior, including new coverage for `/merge`'s auto-merge toggle, `/reject`'s simplified state-free moderation, and legacy-label migration).
- All touched YAML validated with `yaml.safe_load`.
- Verified live against GitHub's actual API/docs rather than assuming: `pull_request_review`'s permission model and `GITHUB_REF`/`GITHUB_SHA` resolution (same restricted, fork-safe behavior as `pull_request`), the `enablePullRequestAutoMerge`/`disablePullRequestAutoMerge` GraphQL mutations and `PullRequestMergeMethod` enum, the REST `auto_merge`/`node_id` PR fields, and `gh pr view --json reviewDecision`.
- Branch protection updated live: required status checks now just `["Verification Gate"]`.

## Docs updated

`.github/PR_LIFECYCLE.md`, `.github/workflows/README.md`, `.github/pr-lifecycle.yml`'s `welcome_message`, and `CONTRIBUTING.md` (the latter was also describing a stale pre-#9772 four-workflow model).