### PR TITLE
fix: resolve two consistently-failing CI tests (Debezium cross-class contamination, HttpCompressionTest TOCTOU)

### DIFF
--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/HttpCompressionTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/HttpCompressionTest.java
@@ -104,26 +104,27 @@ public class HttpCompressionTest extends AbstractResourceTestBase {
         String artifactId = "testKillSwitchDisablesCompressionAtRuntime";
         String content = largeJsonSchemaContent();
         createArtifact(GROUP, artifactId, ArtifactType.JSON, content, ContentTypes.APPLICATION_JSON);
+        byte[] expectedRawBody = content.getBytes(StandardCharsets.UTF_8);
 
-        // @Dynamic properties read through ConfigProvider at request time; system properties
-        // may not reach the app depending on the surefire classloader strategy, so poll until
-        // the toggle actually takes effect.
+        // @Dynamic properties are resolved through a config source chain that is only
+        // eventually consistent with a bare System.setProperty (it may not be visible to the app
+        // immediately, depending on the surefire classloader strategy, and — separately — a
+        // DB-backed dynamic-config cache with its own invalidation timing sits ahead of System
+        // properties in resolution order). A single probe request confirming the toggle applied,
+        // followed by a second unprotected request assuming that state still holds, is exactly a
+        // TOCTOU gap onto that eventual consistency. Retry the whole "request + assert" as one
+        // unit instead, so a momentary flicker back just costs a retry, not a test failure.
         System.setProperty("apicurio.rest.compression.enabled", "false");
         try {
-            io.apicurio.registry.utils.tests.TestUtils.retry(() -> {
-                var probe = given().config(NO_AUTO_DECODE).header("Accept-Encoding", "gzip")
+            byte[] rawBody = io.apicurio.registry.utils.tests.TestUtils.retry(() -> {
+                var response = given().config(NO_AUTO_DECODE).header("Accept-Encoding", "gzip")
                         .pathParam("groupId", GROUP).pathParam("artifactId", artifactId)
                         .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/branch=latest/content");
-                org.junit.jupiter.api.Assertions.assertNull(probe.getHeader("Content-Encoding"),
-                        "response is still compressed after disabling the kill switch");
-            }, "kill switch off takes effect", 10);
-            byte[] rawBody = given().config(NO_AUTO_DECODE).header("Accept-Encoding", "gzip")
-                    .pathParam("groupId", GROUP).pathParam("artifactId", artifactId)
-                    .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/branch=latest/content")
-                    .then().statusCode(200).header("Content-Encoding", nullValue()).extract()
-                    .asByteArray();
+                response.then().statusCode(200).header("Content-Encoding", nullValue());
+                return response.asByteArray();
+            });
 
-            assertArrayEquals(content.getBytes(StandardCharsets.UTF_8), rawBody);
+            assertArrayEquals(expectedRawBody, rawBody);
         } finally {
             System.clearProperty("apicurio.rest.compression.enabled");
             // Poll until the re-enable takes effect so the following tests are not order-dependent

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/DebeziumAvroBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/DebeziumAvroBaseIT.java
@@ -48,10 +48,31 @@ public abstract class DebeziumAvroBaseIT extends ApicurioRegistryBaseIT {
     protected Connection dbConnection;
     protected List<String> createdTables = new ArrayList<>();
 
-    // Class-level connector that is shared across all test methods in a test class
-    protected static String sharedConnectorName;
-    protected static String sharedTopicPrefix;
-    protected static String tablePrefix;
+    // Class-level connector that is shared across all test methods in a test class.
+    // Instance fields, NOT static: @TestInstance(Lifecycle.PER_CLASS) (see
+    // ApicurioRegistryBaseIT) gives each test class exactly one instance, reused across all
+    // of its own @Test methods — but junit-platform.properties runs distinct test classes
+    // concurrently in the same JVM (mode.classes.default=concurrent). Since Java static
+    // fields have ONE identity shared by every subclass instance regardless of which
+    // concrete class it belongs to, declaring these static meant every concurrently-running
+    // Debezium test class (MySQL/PostgreSQL x Integration/LocalConverters, 4 total) stomped
+    // on the same connector name/topic prefix/table prefix throughout its entire lifetime,
+    // not just at setup — producing exactly the symptoms seen in CI: "connector already
+    // exists" 409s, tables colliding ("column already exists" / duplicate key), and consumers
+    // reading another class's events (wrong CDC counts, rules "already exists"). Instance
+    // fields give each concurrently-running class its own isolated copy.
+    protected String sharedConnectorName;
+    protected String sharedTopicPrefix;
+    protected String tablePrefix;
+    // This class's own stable numeric id, captured once in setup(). Subclasses that need a
+    // unique-but-stable derived number (e.g. MySQL's database.server.id) must use this, not a
+    // fresh connectorCounter.get() — the counter keeps moving as sibling classes run
+    // concurrently, so re-reading it later can race and collide with another class's value.
+    protected int classId;
+    // Global across all Debezium test classes, intentionally: this is what guarantees
+    // sharedConnectorName/classId are unique across concurrently-running classes in the first
+    // place. Safe to stay static/shared — only ever incremented, never read-then-cached
+    // elsewhere except into the per-instance classId field above.
     protected static final AtomicInteger connectorCounter = new AtomicInteger(0);
 
     // Kafka Connect connector registration/deletion is not safe to run concurrently across
@@ -117,7 +138,7 @@ public abstract class DebeziumAvroBaseIT extends ApicurioRegistryBaseIT {
         }
 
         // Create a single shared connector for this test class that watches all tables
-        int classId = connectorCounter.incrementAndGet();
+        classId = connectorCounter.incrementAndGet();
         sharedConnectorName = "connector-" + classId;
         sharedTopicPrefix = "test" + classId;
         tablePrefix = "tbl" + classId + "_";

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/mysql/DebeziumMySQLAvroBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/mysql/DebeziumMySQLAvroBaseIT.java
@@ -88,8 +88,11 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
                                                                    String tableIncludeList) {
         String dockerAccessibleRegistryUrl = getContainerAccessibleRegistryUrl();
 
-        // MySQL requires unique server ID for each connector
-        int serverId = 10000 + connectorCounter.get();
+        // MySQL requires unique server ID for each connector. Use this class's own stable
+        // classId (captured once in DebeziumAvroBaseIT.setup()), not connectorCounter.get() —
+        // the counter keeps moving as sibling Debezium test classes register concurrently, so
+        // re-reading it here could race and collide with another class's server-id.
+        int serverId = 10000 + classId;
 
         // Schema history topic for tracking DDL changes
         String schemaHistoryTopic = "schema-history-" + connectorName.replace("-", "_");


### PR DESCRIPTION
## What

Fixes two tests that have been failing consistently in CI (found via PR #9795's h2-debezium and app-rest-v3 runs):

1. `DebeziumMySQLAvroIntegrationIT` / `DebeziumPostgreSQLAvroLocalConvertersIT` (h2-debezium): 2 failures + 12 errors across all 4 Debezium test classes — "connector already exists" 409s, table collisions, wrong CDC event counts, "rule already exists" errors.
2. `HttpCompressionTest.testKillSwitchDisablesCompressionAtRuntime` (app-rest-v3): `Expected header "Content-Encoding" was not null, was "gzip"`.

## 1. Debezium test cross-class contamination

**Root cause:** `DebeziumAvroBaseIT` declared `sharedConnectorName`, `sharedTopicPrefix`, and `tablePrefix` as **static** fields, commented as "shared across all test methods in a test class." That's correct for one class under `@TestInstance(Lifecycle.PER_CLASS)` — but `junit-platform.properties` runs distinct test classes **concurrently** in the same JVM (`mode.classes.default=concurrent`, parallelism 4). Java static fields have one identity shared by every subclass, so all 4 Debezium test classes (MySQL/PostgreSQL × Integration/LocalConverters) running at once stomped on the same connector name/topic prefix/table prefix throughout their entire lifetime, not just at setup.

**Fix:** made these instance fields. Under `PER_CLASS` lifecycle this still means one instance per class (correctly shared across that class's own test methods), but each concurrently-running class now gets its own isolated copy.

**Related fix:** `DebeziumMySQLAvroBaseIT` derived its MySQL `database.server.id` from a fresh `connectorCounter.get()` call rather than the class's own captured id — two classes registering around the same time could read the same/shifted counter value and collide on their server-id. Added a stable per-instance `classId` field (captured once in `setup()`) and used it for both the connector identity and the server-id derivation. `connectorCounter` itself stays static/shared intentionally (that's what guarantees uniqueness across classes in the first place) — the bug was only in caching its *derived* values in static fields too.

## 2. HttpCompressionTest TOCTOU race

The test polls (with retry) until a probe request confirms the kill switch took effect, then makes a **second, unprotected** request assuming that state still holds. `apicurio.rest.compression.enabled` is a `@Dynamic` property, explicitly architected as only eventually consistent with a bare `System.setProperty` — it resolves through a config source chain where a DB-backed dynamic-config source (ordinal 450) sits ahead of System properties (ordinal 400), cached with no TTL and invalidated only on write or a scheduled detection job. A single confirmed-then-trust-it-later check is inherently flaky against that, regardless of the exact trigger.

**Fix:** retry the whole "make the request and assert on it" as one unit instead of trusting a separate probe. A momentary flicker now costs a retry, not a failure.

## Validation

- Both modified integration-tests files compile cleanly against the module's resolved classpath (`javac` using `dependency:build-classpath`'s output — a full module build needs docker/packaging not available in this environment).
- `HttpCompressionTest`: ran **5/5 clean local runs** (8/8 tests passing each time) reproducing the exact scenario that failed in CI.
- `./mvnw checkstyle:check -pl app` and `./mvnw -Pintegration-tests checkstyle:check -pl integration-tests`: both clean.
- Full integration-tests verification (Debezium/Kafka Connect infra) depends on CI.