### PR TITLE
fix(operator): resolve namespace-teardown race and parallelize Local Tests

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -256,7 +256,7 @@ and tags starting with `3.`.
 | `update-openapi.yaml` | Push to main (openapi.json changes) | Auto-copies v3 OpenAPI spec to v2 path, commits if changed, then validates via `validate-openapi.yaml` | 10-15 min |
 | `update-website.yaml` | Release event, workflow_dispatch | Updates `latestRelease.json` on apicurio.github.io with release metadata | 5-10 min |
 | `publish-docs.yaml` | Push to main (docs/**), workflow_dispatch | Builds documentation via Antora playbook and publishes to apicurio.github.io | 15-30 min |
-| `operator.yaml` | Push/PR to main (operator/**) | Operator CI: build + push temp images to ttl.sh (8h TTL), 8-group test matrix on Minikube (smoke, kafka, auth, database, feature, feature-setup, OLM v0, OLM v1), publish to Quay.io on push. Cancels in-progress on new push | 45-90 min |
+| `operator.yaml` | Push/PR to main (operator/**) | Operator CI: build + push temp images to ttl.sh (8h TTL), 9-group test matrix on Minikube (smoke, kafka, auth, database, feature-a, feature-b, feature-setup, OLM v0, OLM v1) plus a single-JVM "Local Tests" run of the full IT suite against the same Minikube cluster, publish to Quay.io on push only. Cancels in-progress on new push | 45-90 min |
 | `image-scan.yaml` | Daily at 06:00 UTC, workflow_dispatch | Trivy vulnerability scan on `latest-snapshot` image (CRITICAL + HIGH severity). Results uploaded to GitHub Security tab as SARIF | 5-10 min |
 
 ## Reusable Workflows

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -108,11 +108,37 @@ jobs:
           retention-days: 1
 
   operator-test-local:
-    name: Local Tests
+    name: Local Tests (${{ matrix.name }})
     runs-on: ubuntu-latest
     needs: operator-build
-    # Only run local tests on push to main
-    if: inputs.publish
+    # Same JUnit @Tag groups as Remote Tests below, minus the OLM ones — OLM
+    # install/upgrade is a remote-cluster-only concept (subscribing to a
+    # catalog), not applicable to the in-process "local" operator. Sharded
+    # into separate jobs/runners/Minikube instances rather than JVM-level
+    # parallelism: the Makefile deliberately forces -T1 because @QuarkusTest
+    # local-mode instances cannot safely share one JVM, but separate jobs
+    # have no such restriction — each gets its own JVM and its own cluster.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: smoke
+            groups: "smoke"
+          - name: kafka
+            groups: "kafka"
+          - name: auth
+            groups: "auth"
+            excluded-groups: "kafka"
+          - name: database
+            groups: "database"
+          - name: feature-a
+            groups: "feature-a"
+            excluded-groups: "feature-setup"
+          - name: feature-b
+            groups: "feature-b"
+            excluded-groups: "feature-setup"
+          - name: feature-setup
+            groups: "feature-setup"
     steps:
 
       - name: Checkout ${{ github.ref }}
@@ -124,6 +150,12 @@ jobs:
           java-version: '21'
           distribution: temurin
           cache: maven
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: operator-build-artifacts
+          path: operator/
 
       - name: Download Docker images
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -174,12 +206,28 @@ jobs:
           docker push "$REGISTRY_GITOPS_SYNC_IMAGE"
           docker push "$IMAGE"
 
-      # Makefile enforces -T1 (single-threaded) because operator @QuarkusTest tests require sequential execution.
       # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks under -T
-      - name: Build and run local tests on Minikube
+      # -Dfailsafe.rerunFailingTestsCount=1: retry failed tests once as a safety net for
+      #   transient resource-related flakes, same as Remote Tests below.
+      - name: Run ${{ matrix.name }} local tests on Minikube
         working-directory: operator
         run: |
-          make BUILD_OPTS="--no-transfer-progress -Daether.syncContext.named.factory=noop" build
+          make BUILD_OPTS="--no-transfer-progress -Daether.syncContext.named.factory=noop -Dfailsafe.rerunFailingTestsCount=1" \
+            GROUPS="${{ matrix.groups }}" \
+            EXCLUDED_GROUPS="${{ matrix.excluded-groups }}" \
+            test-local-group
+
+      - name: Parse Flaky Tests
+        if: always()
+        run: |
+          python3 .github/scripts/parse-flaky-tests.py --reports-dir . --output-file flaky-tests-operator-local-${{ matrix.name }}.json
+
+      - name: Upload Flaky Tests Artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: flaky-tests-operator-local-${{ matrix.name }}
+          path: flaky-tests-operator-local-${{ matrix.name }}.json
 
   operator-test:
     name: Remote Tests (${{ matrix.name }})

--- a/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/ConfluentCompatApiWithGroupsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/ConfluentCompatApiWithGroupsTest.java
@@ -82,10 +82,20 @@ public class ConfluentCompatApiWithGroupsTest extends AbstractResourceTestBase {
         Assertions.assertNotNull(amd);
 
         // Invalid subject format
-        given().when().contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
-                .body(SCHEMA_SIMPLE_WRAPPED)
-                .post(getBasePath() + "/subjects/{subject}/versions", "invalid-subject-format").then()
-                .statusCode(400);
+        // Retried: this specific call has intermittently hung for ~30s with a client-side
+        // SocketTimeoutException in CI. Traced the server-side handling
+        // (SubjectsResourceImpl.registerSchemaUnderSubject -> AbstractResource.getGA) and
+        // confirmed a malformed subject is rejected by a single, synchronous
+        // String.indexOf check before any lock, storage, or I/O call is reached -- there is
+        // no code path there that plausibly takes 30+ seconds. This points to HTTP
+        // connection-pool/keep-alive-level flakiness (e.g. a stale pooled connection reused
+        // from the two prior calls above) rather than an application bug.
+        TestUtils.retry(() -> {
+            given().when().contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                    .body(SCHEMA_SIMPLE_WRAPPED)
+                    .post(getBasePath() + "/subjects/{subject}/versions", "invalid-subject-format").then()
+                    .statusCode(400);
+        }, "invalid subject format returns 400", 3);
     }
 
     @Test

--- a/integration-tests/src/test/java/io/apicurio/deployment/KafkaSqlDeploymentManager.java
+++ b/integration-tests/src/test/java/io/apicurio/deployment/KafkaSqlDeploymentManager.java
@@ -1,5 +1,6 @@
 package io.apicurio.deployment;
 
+import com.microsoft.kiota.ApiException;
 import io.apicurio.registry.client.RegistryClientFactory;
 import io.apicurio.registry.client.common.RegistryClientOptions;
 import io.apicurio.registry.rest.client.RegistryClient;
@@ -16,6 +17,7 @@ import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -123,15 +125,51 @@ public class KafkaSqlDeploymentManager {
 
     private static void createArtifactWithRule(RegistryClient client, String groupId, String content) {
         String artifactId = UUID.randomUUID().toString();
-        CreateArtifact createArtifact = TestUtils.clientCreateArtifact(artifactId,
-                ArtifactType.AVRO, content, ContentTypes.APPLICATION_JSON);
-        client.groups().byGroupId(groupId).artifacts().post(createArtifact,
-                config -> config.headers.add("X-Registry-ArtifactId", artifactId));
-        CreateRule createRule = new CreateRule();
-        createRule.setRuleType(RuleType.VALIDITY);
-        createRule.setConfig("SYNTAX_ONLY");
-        client.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).rules()
-                .post(createRule);
+        try {
+            // The two REST calls below are independent HTTP requests that can land on
+            // different KafkaSQL replicas; a replica's local consumer may not yet have
+            // caught up to a create-artifact message a moment ago produced (and applied)
+            // on a different replica, and a slow/overloaded replica can also bounce a
+            // request outright. Retry the pair as a unit -- and tolerate 409 (already
+            // exists) on either call, since a retry can land after a previous attempt's
+            // write actually succeeded server-side even though its response was lost.
+            TestUtils.retry(() -> {
+                createArtifactTolerateConflict(client, groupId, artifactId, content);
+                createRuleTolerateConflict(client, groupId, artifactId);
+            }, "seed artifact+rule " + artifactId, 10);
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Failed to seed artifact " + artifactId + " in group " + groupId, e);
+        }
+    }
+
+    private static void createArtifactTolerateConflict(RegistryClient client, String groupId,
+            String artifactId, String content) {
+        try {
+            CreateArtifact createArtifact = TestUtils.clientCreateArtifact(artifactId, ArtifactType.AVRO,
+                    content, ContentTypes.APPLICATION_JSON);
+            client.groups().byGroupId(groupId).artifacts().post(createArtifact,
+                    config -> config.headers.add("X-Registry-ArtifactId", artifactId));
+        } catch (ApiException e) {
+            if (e.getResponseStatusCode() != HttpURLConnection.HTTP_CONFLICT) {
+                throw e;
+            }
+        }
+    }
+
+    private static void createRuleTolerateConflict(RegistryClient client, String groupId,
+            String artifactId) {
+        try {
+            CreateRule createRule = new CreateRule();
+            createRule.setRuleType(RuleType.VALIDITY);
+            createRule.setConfig("SYNTAX_ONLY");
+            client.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).rules()
+                    .post(createRule);
+        } catch (ApiException e) {
+            if (e.getResponseStatusCode() != HttpURLConnection.HTTP_CONFLICT) {
+                throw e;
+            }
+        }
     }
 
     private static void deleteRegistryDeployment() {

--- a/integration-tests/src/test/java/io/apicurio/deployment/KafkaSqlDeploymentManager.java
+++ b/integration-tests/src/test/java/io/apicurio/deployment/KafkaSqlDeploymentManager.java
@@ -75,7 +75,13 @@ public class KafkaSqlDeploymentManager {
         var client = RegistryClientFactory.create(RegistryClientOptions.create(registryBaseUrl, vertx)
                 // Seeding runs against a registry that may still be converging; the read-idle
                 // timeout kills stalled connections and retries must cover a slow redeploy.
-                .requestTimeout(10_000, 60_000).retry(true, 5, 1_000));
+                // KafkaSQL applies every one of these 1000 concurrent creates through a single
+                // ordered consumer thread, so a request near the tail of that backlog can
+                // legitimately wait well past a "normal" request's timeout under loaded CI --
+                // a shorter deadline here previously produced a client-side connection-closed
+                // error that silently aborted seeding partway through (see the incident this
+                // comment was added for: 999/1000 artifacts, snapshot never triggered).
+                .requestTimeout(10_000, 180_000).retry(true, 5, 1_000));
 
         // Thousands of sequential blocking calls take 20+ minutes on a loaded CI
         // runner (this read as "the job hangs" more than once); fan out instead.

--- a/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
+++ b/integration-tests/src/test/java/io/apicurio/deployment/RegistryDeploymentManager.java
@@ -39,6 +39,14 @@ public class RegistryDeploymentManager implements TestExecutionListener {
     // deployment) in the same JVM.
     private static final AtomicBoolean DEPLOYED = new AtomicBoolean(false);
 
+    // Set when handleInfraDeployment() throws below. testPlanExecutionStarted() cannot
+    // abort the JUnit Platform launcher's test plan from a TestExecutionListener callback,
+    // so a failure here used to be logged and silently ignored: tests then ran against a
+    // half-seeded/never-restarted deployment and failed with confusing, unrelated
+    // assertion errors far away from the actual root cause. ApicurioRegistryBaseIT checks
+    // this in its @BeforeAll so every test class fails fast with the real error instead.
+    private static volatile Throwable deploymentFailure;
+
     static List<LogWatch> logWatch;
 
     static String testLogsIdentifier;
@@ -85,6 +93,7 @@ public class RegistryDeploymentManager implements TestExecutionListener {
                 handleInfraDeployment();
             } catch (Exception e) {
                 LOGGER.error("Error starting registry deployment", e);
+                deploymentFailure = e;
             }
 
             // Namespace cleanup must not run at test-plan end either: that method
@@ -108,6 +117,22 @@ public class RegistryDeploymentManager implements TestExecutionListener {
             }
         } catch (Exception e) {
             LOGGER.error("Exception closing log watchers", e);
+        }
+    }
+
+    /**
+     * Fails fast, with the real root cause, if test-infra deployment failed during
+     * testPlanExecutionStarted(). Must be called from every test class's setup (see
+     * ApicurioRegistryBaseIT#prepareRestAssured) since a TestExecutionListener cannot itself
+     * abort the test plan it was notified about.
+     */
+    public static void verifyDeploymentSucceeded() throws Exception {
+        if (deploymentFailure != null) {
+            throw new IllegalStateException(
+                    "Registry test-infra deployment failed during test-plan startup; "
+                            + "no tests can run against a broken/incomplete deployment. "
+                            + "See the 'Error starting registry deployment' log entry for the root cause.",
+                    deploymentFailure);
         }
     }
 

--- a/integration-tests/src/test/java/io/apicurio/tests/ApicurioRegistryBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/ApicurioRegistryBaseIT.java
@@ -2,6 +2,7 @@ package io.apicurio.tests;
 
 import com.microsoft.kiota.ApiException;
 import io.apicurio.deployment.PortForwardManager;
+import io.apicurio.deployment.RegistryDeploymentManager;
 import io.apicurio.registry.client.RegistryClientFactory;
 import io.apicurio.registry.client.common.RegistryClientOptions;
 import io.apicurio.registry.rest.client.RegistryClient;
@@ -96,6 +97,11 @@ public class ApicurioRegistryBaseIT implements TestSeparator, Constants {
 
     @BeforeAll
     void prepareRestAssured() throws Exception {
+        // Fail fast, with the real error, if test-infra setup failed rather than let every
+        // test class run against a broken/incomplete deployment and fail on unrelated,
+        // confusing assertions (see RegistryDeploymentManager#verifyDeploymentSucceeded).
+        RegistryDeploymentManager.verifyDeploymentSucceeded();
+
         vertx = Vertx.vertx();
         authServerUrlConfigured = Optional
                 .ofNullable(ConfigProvider.getConfig().getConfigValue("quarkus.oidc.token-path").getValue())

--- a/integration-tests/src/test/java/io/apicurio/tests/ConfluentBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/ConfluentBaseIT.java
@@ -5,12 +5,14 @@ import io.apicurio.tests.utils.Constants;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInfo;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -23,8 +25,24 @@ public abstract class ConfluentBaseIT extends ApicurioRegistryBaseIT {
 
     @BeforeAll
     void confluentBeforeAll(TestInfo info) throws Exception {
+        // The (baseUrl, cacheCapacity) constructor builds a RestService that never calls
+        // configure(...) (CachedSchemaRegistryClient only does so if the configs map is
+        // non-null AND non-empty), leaving httpConnectTimeoutMs/httpReadTimeoutMs at their
+        // uninitialized 0 -- interpreted by HttpURLConnection as an INFINITE timeout -- and
+        // retries disabled (RetryExecutor(0, 0, 0)). A single stalled connection during a
+        // sequential batch of calls (e.g. createAndDeleteMultipleSchemas' 50 creates + 50
+        // deletes) then has nothing to make it fail and retry, hanging until only this
+        // test suite's blunt global JUnit timeout eventually kills it. Passing a non-empty
+        // configs map (even for the client's own already-sensible defaults: 60s connect/read
+        // timeout, 3 retries) forces that configure(...) call to actually happen.
+        Map<String, String> restConfigs = Map.of(SchemaRegistryClientConfig.HTTP_CONNECT_TIMEOUT_MS,
+                String.valueOf(SchemaRegistryClientConfig.HTTP_CONNECT_TIMEOUT_MS_DEFAULT),
+                SchemaRegistryClientConfig.HTTP_READ_TIMEOUT_MS,
+                String.valueOf(SchemaRegistryClientConfig.HTTP_READ_TIMEOUT_MS_DEFAULT),
+                SchemaRegistryClientConfig.MAX_RETRIES_CONFIG,
+                String.valueOf(SchemaRegistryClientConfig.MAX_RETRIES_DEFAULT));
         confluentService = new CachedSchemaRegistryClient(
-                ApicurioRegistryBaseIT.getRegistryApiUrl() + "/ccompat/v7", 3);
+                ApicurioRegistryBaseIT.getRegistryApiUrl() + "/ccompat/v7", 3, restConfigs);
         clearAllConfluentSubjects();
     }
 

--- a/integration-tests/src/test/java/io/apicurio/tests/migration/DataMigrationIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/migration/DataMigrationIT.java
@@ -54,7 +54,14 @@ public class DataMigrationIT extends ApicurioRegistryBaseIT {
     public void migrate() throws Exception {
         Vertx vertx = Vertx.vertx();
         var dest = RegistryClientFactory.create(
-                RegistryClientOptions.create(ApicurioRegistryBaseIT.getRegistryV3ApiUrl(), vertx).retry());
+                RegistryClientOptions.create(ApicurioRegistryBaseIT.getRegistryV3ApiUrl(), vertx)
+                        // Without an explicit read-idle timeout a single stalled connection (seen once
+                        // in CI as a Netty IllegalReferenceCountException around this client's traffic)
+                        // has nothing to make it fail and be retried -- it simply waits forever, and the
+                        // only thing that ever stops it is this test method's 10-minute global JUnit
+                        // timeout, which then aborts the whole verification loop instead of just the one
+                        // stuck request.
+                        .requestTimeout(10_000, 60_000).retry());
 
         given().when().contentType("application/zip").body(migrateDataToImport)
                 .post("/apis/registry/v2/admin/import").then().statusCode(204).body(anything());

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/DebeziumAvroBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/DebeziumAvroBaseIT.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.rnorth.ducttape.TimeoutException;
 import org.rnorth.ducttape.unreliables.Unreliables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -294,7 +296,7 @@ public abstract class DebeziumAvroBaseIT extends ApicurioRegistryBaseIT {
             throws Exception {
         List<GenericRecord> records = new ArrayList<>();
 
-        Unreliables.retryUntilTrue((int) timeout.getSeconds(), TimeUnit.SECONDS, () -> {
+        pollUntilTrue(timeout, () -> {
             consumer.poll(Duration.ofMillis(500)).forEach(record -> {
                 try {
                     if (record.value() == null || record.value().length < 5) {
@@ -326,7 +328,7 @@ public abstract class DebeziumAvroBaseIT extends ApicurioRegistryBaseIT {
             String expectedData) throws Exception {
         List<GenericRecord> records = new ArrayList<>();
 
-        Unreliables.retryUntilTrue((int) timeout.getSeconds(), TimeUnit.SECONDS, () -> {
+        pollUntilTrue(timeout, () -> {
             consumer.poll(Duration.ofMillis(500)).forEach(record -> {
                 try {
                     if (record.value() == null || record.value().length < 5) {
@@ -354,10 +356,49 @@ public abstract class DebeziumAvroBaseIT extends ApicurioRegistryBaseIT {
         return records;
     }
 
+    /**
+     * Repeatedly calls {@code check} on the CALLING thread until it returns true or the timeout
+     * elapses, then throws the same {@link TimeoutException} type Unreliables.retryUntilTrue
+     * would have thrown.
+     *
+     * Deliberately does NOT delegate to Unreliables.retryUntilTrue/retryUntilSuccess: those
+     * submit the retry loop to a separate, shared daemon thread pool
+     * (org.rnorth.ducttape.timeouts.Timeouts#getWithTimeout) and, on timeout, simply give up
+     * waiting on the Future WITHOUT cancelling it — the submitted loop keeps running in the
+     * background until its own next doContinue check. Every caller here polls this class's
+     * shared, mutable, non-thread-safe `consumer` field, which the next test's @BeforeEach
+     * reassigns (after closing the old one). A timed-out test's leaked background thread can
+     * still be mid-poll() when that happens, and end up calling poll()/close() concurrently on
+     * whichever consumer `this.consumer` now refers to — producing "KafkaConsumer is not safe
+     * for multi-threaded access" and cascading failures through every later test in the class
+     * (observed in CI: one timeout in test N caused all of tests N+1..11 to fail). Polling on
+     * the calling thread has no such leak: once the deadline is hit, nothing from this call
+     * touches the consumer again.
+     */
+    protected void pollUntilTrue(Duration timeout, Callable<Boolean> check) throws Exception {
+        long deadlineNanos = System.nanoTime() + timeout.toNanos();
+        Exception lastException = null;
+        while (System.nanoTime() < deadlineNanos) {
+            try {
+                if (check.call()) {
+                    return;
+                }
+                lastException = null;
+            }
+            catch (Exception e) {
+                lastException = e;
+            }
+        }
+        if (lastException != null) {
+            throw new TimeoutException("Timeout waiting for result with exception", lastException);
+        }
+        throw new TimeoutException(new RuntimeException("Not ready yet"));
+    }
+
     protected void waitForConsumerReady(Duration timeout) throws Exception {
         log.info("Waiting for consumer to complete partition assignment...");
 
-        Unreliables.retryUntilTrue((int) timeout.getSeconds(), TimeUnit.SECONDS, () -> {
+        pollUntilTrue(timeout, () -> {
             consumer.poll(Duration.ofMillis(100));
             boolean hasAssignment = !consumer.assignment().isEmpty();
 
@@ -367,6 +408,7 @@ public abstract class DebeziumAvroBaseIT extends ApicurioRegistryBaseIT {
             else {
                 log.debug("Consumer waiting for partition assignment...");
             }
+
 
             return hasAssignment;
         });

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/mysql/DebeziumMySQLAvroBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/mysql/DebeziumMySQLAvroBaseIT.java
@@ -10,7 +10,6 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.rnorth.ducttape.unreliables.Unreliables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.mysql.MySQLContainer;
@@ -23,7 +22,6 @@ import java.sql.Statement;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -292,7 +290,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
         executeUpdate("INSERT INTO " + table3 + " (sku, stock_count) VALUES ('SKU-123', 50)");
 
         List<ConsumerRecord<byte[], byte[]>> allRecords = new ArrayList<>();
-        Unreliables.retryUntilTrue(120, TimeUnit.SECONDS, () -> {
+        pollUntilTrue(Duration.ofSeconds(120), () -> {
             consumer.poll(Duration.ofMillis(500)).forEach(allRecords::add);
             return allRecords.size() >= 3;
         });
@@ -606,7 +604,7 @@ public abstract class DebeziumMySQLAvroBaseIT extends DebeziumAvroBaseIT {
         }
 
         List<ConsumerRecord<byte[], byte[]>> allRecords = new ArrayList<>();
-        Unreliables.retryUntilTrue(120, TimeUnit.SECONDS, () -> {
+        pollUntilTrue(Duration.ofSeconds(120), () -> {
             consumer.poll(Duration.ofSeconds(1)).forEach(allRecords::add);
             log.info("Consumed {} records so far", allRecords.size());
             return allRecords.size() >= totalRows;

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/postgresql/DebeziumPostgreSQLAvroBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/postgresql/DebeziumPostgreSQLAvroBaseIT.java
@@ -9,7 +9,6 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.rnorth.ducttape.unreliables.Unreliables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.postgresql.PostgreSQLContainer;
@@ -23,7 +22,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -334,7 +332,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
         executeUpdate("INSERT INTO " + table3 + " (sku, stock_count) VALUES ('SKU-123', 50)");
 
         List<ConsumerRecord<byte[], byte[]>> allRecords = new ArrayList<>();
-        Unreliables.retryUntilTrue(20, TimeUnit.SECONDS, () -> {
+        pollUntilTrue(Duration.ofSeconds(20), () -> {
             consumer.poll(Duration.ofMillis(500)).forEach(allRecords::add);
             return allRecords.size() >= 3;
         });
@@ -657,7 +655,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
         }
 
         List<ConsumerRecord<byte[], byte[]>> allRecords = new ArrayList<>();
-        Unreliables.retryUntilTrue(60, TimeUnit.SECONDS, () -> {
+        pollUntilTrue(Duration.ofSeconds(60), () -> {
             consumer.poll(Duration.ofSeconds(1)).forEach(allRecords::add);
             log.info("Consumed {} records so far", allRecords.size());
             return allRecords.size() >= totalRows;

--- a/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/postgresql/DebeziumPostgreSQLAvroBaseIT.java
+++ b/integration-tests/src/test/java/io/apicurio/tests/serdes/apicurio/debezium/postgresql/DebeziumPostgreSQLAvroBaseIT.java
@@ -529,10 +529,18 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
     public void testPostgreSQLSpecificTypes() throws Exception {
         String tableName = getTableName("pg_types_test");
         String topicName = getTopicNameForTable(tableName);
+        // The ENUM type is a schema-global object, not scoped to this table -- unlike
+        // tableName above it wasn't namespaced per test-class instance, so the two
+        // concrete subclasses of this base class (DebeziumPostgreSQLAvroIntegrationIT and
+        // DebeziumPostgreSQLAvroLocalConvertersIT) running concurrently as separate JUnit
+        // test classes could race on the shared literal name "mood": one class's
+        // DROP TYPE ... CASCADE could drop the other's still-in-use column (or whole
+        // table) mid-test, surfacing as "column ... does not exist" further down.
+        String moodType = tablePrefix + "mood";
 
         try (Statement stmt = getDatabaseConnection().createStatement()) {
-            stmt.execute("DROP TYPE IF EXISTS mood CASCADE");
-            stmt.execute("CREATE TYPE mood AS ENUM ('happy', 'sad', 'neutral')");
+            stmt.execute("DROP TYPE IF EXISTS " + moodType + " CASCADE");
+            stmt.execute("CREATE TYPE " + moodType + " AS ENUM ('happy', 'sad', 'neutral')");
         }
 
         createTable(tableName,
@@ -540,7 +548,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
                         "id SERIAL PRIMARY KEY, " +
                         "data_json JSONB, " +
                         "tags TEXT[], " +
-                        "user_mood mood, " +
+                        "user_mood " + moodType + ", " +
                         "user_id UUID, " +
                         "created_at TIMESTAMPTZ" +
                         ")");
@@ -552,7 +560,7 @@ public abstract class DebeziumPostgreSQLAvroBaseIT extends DebeziumAvroBaseIT {
         try (PreparedStatement stmt = getDatabaseConnection().prepareStatement(
                 "INSERT INTO " + tableName +
                         " (data_json, tags, user_mood, user_id, created_at) " +
-                        "VALUES (?::jsonb, ?::text[], ?::mood, ?::uuid, NOW())")) {
+                        "VALUES (?::jsonb, ?::text[], ?::" + moodType + ", ?::uuid, NOW())")) {
             stmt.setString(1, "{\"key\": \"value\", \"number\": 42}");
             stmt.setArray(2, getDatabaseConnection().createArrayOf("text", new String[]{ "tag1", "tag2", "tag3" }));
             stmt.setObject(3, "happy", java.sql.Types.OTHER);

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -269,6 +269,16 @@ build: ## TODO
 	mvn clean install $(BUILD_OPTS_EXT)
 
 
+GROUPS ?=
+EXCLUDED_GROUPS ?=
+
+.PHONY: test-local-group
+test-local-group: ## Run local (in-process operator) tests filtered by JUnit tag groups
+	mvn verify $(BUILD_OPTS_EXT) \
+		$(if $(GROUPS),-Dgroups=$(GROUPS)) \
+		$(if $(EXCLUDED_GROUPS),-DexcludedGroups=$(EXCLUDED_GROUPS))
+
+
 .PHONY: test-remote-all
 test-remote-all: ## TODO
 	# Do not run `mvn clean` when not necessary.
@@ -279,9 +289,6 @@ else
 endif
 	mvn verify $(subst -pl controller -am,,$(BUILD_OPTS_EXT)) -Dtest.operator.deployment-type=remote -Dtest.operator.catalog-image=$(CATALOG_IMAGE)
 
-
-GROUPS ?=
-EXCLUDED_GROUPS ?=
 
 .PHONY: test-remote-group
 test-remote-group: ## Run remote tests filtered by JUnit tag groups

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
@@ -575,6 +575,18 @@ public abstract class ITBase implements OperatorTestContext {
         if (cleanup) {
             log.info("Deleting namespace : {}", namespace);
             assertThat(client.namespaces().withName(namespace).delete()).isNotNull();
+            // Namespace deletion is asynchronous: the API server only removes the namespace
+            // object once every resource inside it — including cluster-wide-scoped ones like
+            // Ingress hostnames — has actually been garbage-collected. The delete call above
+            // only confirms the request was accepted, not that cleanup finished. Without
+            // waiting here, the next test class to run (e.g. the Keycloak-based auth tests,
+            // which all reuse the same Ingress hostname) can start before this namespace's
+            // Ingress is actually gone, and get rejected by the ingress admission webhook for
+            // a "host already defined" conflict that has nothing to do with its own test.
+            await().atMost(MEDIUM_DURATION).untilAsserted(() -> {
+                assertThat(client.namespaces().withName(namespace).get()).isNull();
+            });
+            log.info("Namespace {} fully terminated", namespace);
         }
         client.close();
     }

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import static io.apicurio.registry.operator.it.ITBase.MEDIUM_DURATION;
 import static io.apicurio.registry.operator.it.ITBase.SHORT_DURATION;
 import static io.apicurio.registry.operator.it.ITBase.setDefaultAwaitilityTimings;
+import static io.apicurio.registry.operator.it.OLMTestUtils.waitForCatalogPodReady;
 import static io.apicurio.registry.operator.resource.Labels.getOperatorManagedLabels;
 import static io.apicurio.registry.operator.utils.K8sCell.k8sCell;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -137,12 +138,20 @@ public abstract class OLMITBase implements OperatorTestContext {
 
             createResource("olmv0/catalog-source.yaml");
 
-            await().ignoreExceptions().until(() -> {
-                return client.pods().inNamespace(namespace).list().getItems().stream().filter(
-                                pod -> pod.getMetadata().getName().startsWith("apicurio-registry-operator-catalog"))
-                        .anyMatch(pod -> pod.getStatus().getConditions().stream()
-                                .anyMatch(c -> "Ready".equals(c.getType()) && "True".equals(c.getStatus())));
-            });
+            // A Ready catalog pod is not immediately routable: the Service endpoints (and
+            // kube-proxy rules) lag by a beat behind pod readiness. package-server polls this
+            // catalog over that Service to sync the PackageManifest that
+            // ChannelValidationOLMITTest and the subscription resolver both read; querying it
+            // before the endpoints are actually programmed is a proven source of a stale-read
+            // race (see #9818, #9722). The previous pod-only readiness wait here let the
+            // Subscription (and any early PackageManifest read) race package-server's first
+            // successful sync against this catalog, intermittently observing a defaultChannel
+            // that "matches no catalog we build" -- i.e. genuinely stale data, not bad catalog
+            // content. waitForCatalogPodReady is the same helper already proven for this exact
+            // race in UpgradeOLMITTest/CatalogDiscovery; it was just never wired into this base
+            // setup, which is what every OLM v0 test (including ChannelValidationOLMITTest)
+            // actually runs through.
+            waitForCatalogPodReady(client, namespace);
 
             createResource(getOperatorGroupResourcePath());
             createResource("olmv0/subscription.yaml");


### PR DESCRIPTION
## What

Four independent CI-flakiness fixes found while validating the operator changes.

### 1. Operator: namespace-teardown race + Local Tests parallelization

Fixes the operator's "Local Tests" CI job, which has been failing consistently on `main` and taking ~52 minutes sequentially.

**Race condition (the actual bug):** `ITBase.afterAll()` only checked that the namespace-delete API call was accepted:

```java
assertThat(client.namespaces().withName(namespace).delete()).isNotNull();
```

Kubernetes namespace deletion is asynchronous — the API server only removes the namespace object once everything inside it (including cluster-wide-scoped resources like Ingress hostnames) has actually been garbage-collected. `AuthITTest`, `AuthzITTest`, and `AuthTLSITTest` all install Keycloak using the same hardcoded Ingress hostname (`simple-keycloak.apps.cluster.example` — required because `AuthTLSITTest`'s TLS cert has that hostname baked into its SAN, so making the hostname unique per test would also require regenerating a matching cert; rejected as materially riskier than fixing the actual race). Without waiting for teardown to finish, the next Auth test's Ingress creation could lose a race against the previous one's still-in-flight namespace deletion and get rejected by the ingress-nginx admission webhook — exactly the CI failure: `host ... already defined in ingress <stale-namespace>/keycloak`.

**Fix:** wait for the namespace to actually disappear before `afterAll()` returns, instead of just checking the delete call was accepted.

**Runtime: sequential → sharded matrix.** These IT tests already carry the same JUnit `@Tag` groups (`SMOKE`, `KAFKA`, `AUTH`, `DATABASE`, `FEATURE_A/B`, `FEATURE_SETUP`) that "Remote Tests" already uses for its 9-way parallel matrix. "Local Tests" instead ran all ~30 IT classes sequentially in **one** job/JVM, because the Makefile deliberately forces `-T1` (`@QuarkusTest` local-mode instances can't safely share one JVM) — but that constraint is about concurrency *within* a JVM, not across separate CI jobs. Added a `test-local-group` Makefile target (mirrors `test-remote-group`) and turned `operator-test-local` into the same kind of matrix as `operator-test`, minus the OLM-only groups. Also enabled it for operator-touching PRs, not just push to main (`operator-test` already had no such restriction).

**Validated against a real Minikube cluster** (podman driver, arm64), reusing already-built `quay.io/apicurio/apicurio-registry:latest-snapshot` images loaded via `minikube image load`:
- `make -n GROUPS=auth EXCLUDED_GROUPS=kafka test-local-group` — confirmed the generated Maven command.
- **AUTH group**: 3/3 passed, including `AuthTLSITTest` — the exact test that failed in CI. Log confirms the fix: `Namespace test-42e210e fully terminated` completes before the next test's Ingress create.
- **SMOKE group**: 6/6 passed, confirming the sharding mechanism generalizes.
- Checkstyle clean.

### 2. Integration tests: leaked Unreliables retry threads racing the Debezium Kafka consumer

A follow-up CI run (after the cross-class isolation fix in #9798) showed `DebeziumMySQLAvroIntegrationIT` failing **10/10** tests, several with:

```
KafkaConsumer is not safe for multi-threaded access.
currentThread(name: ForkJoinPool-1-worker-2, id: 46) otherThread(id: 302)
```

**Root cause** (confirmed against the actual `org.rnorth.ducttape` source, not guessed): `Unreliables.retryUntilTrue`/`retryUntilSuccess` submits its retry loop to a separate, shared daemon thread pool and enforces the timeout with a plain `future.get(timeout, unit)` — on timeout it just throws and returns, **without cancelling** the future. The submitted loop keeps running in the background. `consumeAvroEvents`/`waitForConsumerReady` (and 4 duplicated call sites in the MySQL/PostgreSQL subclasses) all poll the shared, mutable `consumer` field through this mechanism — and since the next test's `@BeforeEach` reassigns that field, a single timed-out test can leave a leaked background thread that's still mid-`poll()` when the next test starts using the newly-assigned consumer, producing exactly the observed cross-thread violation and cascading through every subsequent test in the class.

**Fix:** replaced all 6 call sites with a new `pollUntilTrue()` that polls on the *calling* thread with an explicit deadline, instead of delegating to `Unreliables`' separate-thread-pool implementation. Once the deadline is hit, nothing from that call touches the consumer again. Left `waitForConnectorReady`/`waitForSchemaInRegistry` on `Unreliables` as-is — they only make stateless HTTP calls, not shared mutable state, so they don't have this failure mode.

**Validated:** `org.rnorth.ducttape.TimeoutException`'s constructors were confirmed against the library source before use. All touched files compile cleanly against the module's resolved classpath; checkstyle clean. Full validation depends on CI given the Kafka/Debezium infrastructure this suite needs.

### 3. Integration tests: swallowed test-infra deployment errors reported as unrelated test failures

`KafkaSqlSnapshottingIT.testRecoverFromSnapshot` intermittently failed with `expected: <1000> but was: <999>`. Traced through a full CI log to a completely different bug than a snapshot/restore defect:

The bulk 1000-artifact seeding step (`KafkaSqlDeploymentManager.prepareSnapshotData`) hit a client-side `HttpClosedException` on one of the 1000 concurrent creates — KafkaSQL applies every write through a single ordered consumer thread, so a request near the tail of that backlog can legitimately exceed a "normal" request's read-idle timeout under loaded CI. That exception aborted seeding entirely: the snapshot was never triggered and the deployment was never torn down/restored. But `RegistryDeploymentManager.testPlanExecutionStarted` (a JUnit `TestExecutionListener` callback, which cannot itself abort the test plan it was notified about) just logged the failure and returned normally:

```java
try {
    handleInfraDeployment();
} catch (Exception e) {
    LOGGER.error("Error starting registry deployment", e);
}
```

JUnit then proceeded to run every test class against the original, never-snapshotted deployment, producing the confusing 999-vs-1000 assertion failure far away from the actual cause.

**Fix:**
- `RegistryDeploymentManager` now records the exception and exposes `verifyDeploymentSucceeded()`.
- `ApicurioRegistryBaseIT` (the shared `@BeforeAll` for every integration test class) calls it first, so any infra setup failure surfaces immediately and clearly instead of as a misleading downstream test failure.
- Widened the bulk-seeding client's read-idle timeout (60s → 180s) to give the single-threaded KafkaSQL consumer more headroom under CI load, reducing how often the underlying transient timeout happens at all.

**Validated:** targeted `javac` compile of all three touched files against the module's resolved classpath succeeds cleanly; `checkstyle:check` on `integration-tests` passes with no violations.

**Follow-up:** re-running this PR's own CI after the above fix landed surfaced a *second*, distinct transient failure in the same bulk-seeding path — this time the fail-fast fix worked exactly as intended, immediately reporting the real root cause instead of a misleading assertion. The new failure was a `ProblemDetails` (HTTP error) thrown from the create-rule call, ~19s into seeding the "default" group. `createArtifactWithRule` issues two independent HTTP requests (create artifact, then create its rule) that can each land on a different KafkaSQL replica behind the Kubernetes Service; a replica's local consumer may not yet have caught up to a create-artifact message applied moments ago on a different replica, and any replica can also be too overloaded to answer during a 1000-request concurrent burst — neither case is retried by the SDK's own retry handler, which only retries connection-level failures, never HTTP error responses.

Fixed by retrying the artifact+rule pair as one unit and tolerating 409 (already exists) on either call, since a retry can land after a previous attempt's write actually succeeded server-side even though its response was lost or delayed. Same validation as above (targeted `javac` compile + `checkstyle:check`, both clean).

### 4. Two flaky-test retries flagged by this PR's own CI

Once the run went fully green, the orchestrator's automated flaky-test-retry detector flagged three tests that failed once but passed on Failsafe's automatic rerun. Two had concrete, fixable root causes:

- **`DebeziumPostgreSQLAvroBaseIT.testPostgreSQLSpecificTypes`** creates a Postgres ENUM type using the literal, unnamespaced name `mood` and later `DROP TYPE IF EXISTS mood CASCADE`s it. Unlike the table name in the same test (already namespaced via `tablePrefix`, unique per test-class instance), the type name is schema-global and shared verbatim by both concrete subclasses of this base class — `DebeziumPostgreSQLAvroIntegrationIT` and `DebeziumPostgreSQLAvroLocalConvertersIT` — which run concurrently as separate JUnit test classes. One class's `DROP TYPE ... CASCADE` can drop the other's still-in-use column (or whole table) mid-test, surfacing as `column ... does not exist`. Fixed by namespacing the type name with the same `tablePrefix` used for the table itself.
- **`DataMigrationIT.migrate`** timed out against the global 10-minute JUnit safety net (`-Djunit.jupiter.execution.timeout.default=10m`, added in #9722 to fail hung tests fast), killed mid-way through a small (~80 iteration) sequential verification loop, right after a Netty `IllegalReferenceCountException` appeared in the logs around this client's traffic. The migration destination client had no explicit `requestTimeout`, so a single stalled connection had nothing to make it fail and be retried — only the blunt 10-minute global timeout could ever unstick it, aborting the whole loop instead of just the one stuck request. Added the same `requestTimeout(10_000, 60_000)` pattern already used elsewhere in this suite (e.g. `ApicurioRegistryBaseIT`'s own client), so a stalled request fails and gets retried by the client's own `retry()` within seconds instead of minutes.

The third (`ConfluentCompatApiWithGroupsTest.testCreateSubject`, a `SocketTimeoutException` on a malformed-subject POST) was investigated but not fixed: tracing the exact server-side code path (`SubjectsResourceImpl.registerSchemaUnderSubject` → `AbstractResource.getGA`) shows the malformed-subject case is a synchronous, in-memory fail-fast check (one `String.indexOf`, then an immediate `BadRequestException`) with no plausible way to take 30+ seconds on its own. This points to HTTP connection-pool/keep-alive-level flakiness (e.g. a stale pooled connection reused across the two prior successful calls in the same test) rather than an application bug, and wasn't fixed speculatively without a live repro.

**Validated:** targeted `javac` compile of both touched files against the module's resolved classpath succeeds cleanly; `checkstyle:check` on `integration-tests` passes with no violations.

### 5. Second round: one more real fix, one confirmed-recurring test given a targeted mitigation

Re-running CI after fix #4 landed: both concrete fixes held (neither test flaked again), but the flaky-test detector caught two more:

- **`SchemasConfluentIT.createAndDeleteMultipleSchemas`** timed out against the same global 10-minute safety net, stuck partway through a sequential batch of 50 schema creates + 50 subject deletes via the Confluent `SchemaRegistryClient`. Traced into `io.confluent:kafka-schema-registry-client` 8.0.0 source: the `(baseUrl, cacheCapacity)` `CachedSchemaRegistryClient` constructor builds a `RestService` whose `configure(...)` is only ever invoked if the configs map passed to the client is both non-null *and* non-empty — left unconfigured, `httpConnectTimeoutMs`/`httpReadTimeoutMs` stay at their uninitialized `0`, which `HttpURLConnection` treats as an **infinite** timeout, and the retry executor is built as `RetryExecutor(0, 0, 0)` (no retries at all). A single stalled connection anywhere in the 100-call batch then has nothing to make it fail and retry. Fixed in the shared `ConfluentBaseIT` base class (used by every Confluent-compat IT, not just this one) by passing a non-empty configs map with the client's own already-sensible defaults (60s connect/read timeout, 3 retries), which forces `configure(...)` to actually run.
- **`ConfluentCompatApiWithGroupsTest.testCreateSubject`** flaked a *second* time with the exact same signature as fix #4's investigation (client-side `SocketTimeoutException`, ~30s, on the same malformed-subject call). Given the business-logic explanation was already ruled out and the failure is now confirmed recurring rather than one-off noise, wrapped just this call in `TestUtils.retry(...)` — the same pattern already used elsewhere in this suite for intermittent, unexplained CI-level HTTP flakiness — rather than continuing to speculate about the exact root cause without a live repro.

**Validated:** targeted `javac` compiles against each module's (`integration-tests`, `app`) resolved classpath succeed cleanly; `checkstyle:check` passes with no violations on both modules.

### 6. Fixes #9818: OLM v0 catalog Service-endpoint race in `ChannelValidationOLMITTest`

`ChannelValidationOLMITTest.testDefaultChannel` intermittently reads a stale `PackageManifest.status.defaultChannel` (`"3.3.x"` instead of the expected rolling channel `"3.x"`), burning the full `await()` timeout across all `@RetryTest` attempts before failing — tracked separately in #9818, flagged in this PR's own community review as explicitly *not* covered by section 3's fix.

#9722 already diagnosed and fixed this same class of race for `UpgradeOLMITTest`/`CatalogDiscovery`: a catalog pod reaching `Ready` is not immediately routable, since its Service endpoints (and kube-proxy rules) lag a beat behind pod readiness; `package-server` polls the catalog over that Service to sync `PackageManifest`, and querying/subscribing before the endpoints are actually programmed races that first sync. The fix was a `waitForCatalogPodReady()` helper that waits for both pod readiness *and* programmed Service endpoints — but it was only ever wired into `UpgradeOLMITTest` and `CatalogDiscovery`.

`OLMITBase.setupOLMResources()` — the `@BeforeAll` setup that every OLM v0 test actually runs through, including `ChannelValidationOLMITTest` — still had its own separate, older inline wait that only checked pod readiness, not endpoints, before creating the OperatorGroup and Subscription. This is exactly the same unfixed race, just in the one place the helper was never applied. Replaced the inline pod-only wait with `waitForCatalogPodReady(client, namespace)`, so the Subscription (and any subsequent `PackageManifest` read) can no longer be created before the catalog is actually routable.

**Validated:** targeted `javac` compile against the `operator/olm-tests` module's resolved classpath (`-Dfull` profile) succeeds cleanly; `checkstyle:check` passes with no violations.




