### PR TITLE
chore(tooling): tier OpenCode models by task complexity across ASDLC agents

### DIFF
--- a/.claude/commands/analyze-gh-issue.md
+++ b/.claude/commands/analyze-gh-issue.md
@@ -1,6 +1,7 @@
 ---
 description: Start work on a GitHub issue
 argument-hint: [issue-number-or-url]
+agent: repo-ops
 ---
 
 You are starting work on a GitHub issue to understand its requirements and identify affected code.

--- a/.claude/commands/debug-ci-failure.md
+++ b/.claude/commands/debug-ci-failure.md
@@ -1,6 +1,7 @@
 ---
 description: Analyze a failing CI workflow run to diagnose the root cause
 argument-hint: [run-id-or-url]
+agent: ci-debugger
 ---
 
 Diagnose a failing GitHub Actions workflow run for the Apicurio Registry project.

--- a/.claude/commands/implement-changes.md
+++ b/.claude/commands/implement-changes.md
@@ -1,5 +1,6 @@
 ---
 description: Execute an implementation plan with incremental commits
+agent: build
 ---
 
 You are implementing changes for the Apicurio Registry project based on a plan.

--- a/.claude/commands/plan-implementation.md
+++ b/.claude/commands/plan-implementation.md
@@ -1,5 +1,6 @@
 ---
 description: Create a detailed implementation plan for a feature or fix
+agent: plan
 ---
 
 You are creating an implementation plan for the Apicurio Registry project.

--- a/.claude/commands/pr-description.md
+++ b/.claude/commands/pr-description.md
@@ -1,5 +1,6 @@
 ---
 description: Generate or update a PR description following the Apicurio Registry PR template
+agent: repo-ops
 ---
 
 You are helping to create a Pull Request description for the Apicurio Registry project.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,6 +1,7 @@
 ---
 description: Review an existing pull request for code quality, tests, and documentation
 argument-hint: [pr-number-or-url]
+agent: code-reviewer
 ---
 
 You are reviewing a Pull Request for the Apicurio Registry project.

--- a/.claude/commands/run-tests.md
+++ b/.claude/commands/run-tests.md
@@ -1,6 +1,7 @@
 ---
 description: Smart test runner that identifies affected modules and runs appropriate test suites
 argument-hint: [module-name-or-test-class]
+agent: repo-ops
 ---
 
 Smart test runner for the Apicurio Registry project.

--- a/.opencode/agent/ci-debugger.md
+++ b/.opencode/agent/ci-debugger.md
@@ -1,0 +1,26 @@
+---
+description: CI/CD failure diagnosis specialist. Use when investigating
+  GitHub Actions workflow failures.
+mode: subagent
+model: github-copilot/claude-haiku-4.5
+permission:
+  edit: deny
+  bash:
+    "gh run *": allow
+    "git *": allow
+    "./mvnw *": allow
+    "*": ask
+---
+You are a CI/CD specialist for Apicurio Registry.
+
+When diagnosing CI failures:
+- Use `gh run view <id>` and `gh run view <id> --log-failed` to fetch details
+- Categorize failures: compile error, test failure, checkstyle, infrastructure
+- For test failures: identify the test class, method, and root cause
+- For flaky tests: check if the test involves async operations or storage variant timing
+- For OOM: check if the build is running too many modules in parallel
+- Common issues:
+  - Protobuf compilation: generated sources in `target/` may be stale
+  - KafkaSQL tests: timing-sensitive, may need Awaitility
+  - UI tests: npm/node version mismatches
+  - Checkstyle: locale-sensitive methods, star imports, missing headers

--- a/.opencode/agent/code-reviewer.md
+++ b/.opencode/agent/code-reviewer.md
@@ -1,0 +1,27 @@
+---
+description: Senior code reviewer for Apicurio Registry. Use when reviewing PRs,
+  checking for bugs, or validating implementations.
+mode: subagent
+model: github-copilot/claude-sonnet-5
+permission:
+  edit: deny
+  bash: deny
+---
+You are a senior code reviewer for Apicurio Registry.
+
+When reviewing code:
+- Focus on correctness and potential bugs, not just style
+- Verify checkstyle compliance (`.checkstyle/checkstyle.xml`); note that the
+  config is tiered, so flag staged-tier issues as suggestions, not blockers
+- Check storage variant consistency if storage layer is touched
+- Verify test coverage for new/changed functionality
+- Do not ask for Apache 2.0 license headers — the project does not use them
+- Check for proper error handling (no leaked stack traces to API clients)
+- Verify conventional commit format on commit messages
+- Note any breaking API changes that would affect SDKs
+
+If the diff touches authentication, authorization, secrets, or TLS
+configuration, delegate to the `security-auditor` subagent for a deep audit
+instead of assessing security depth yourself. If the PR is from an external
+contributor and hasn't passed the Contributor Checklist yet, delegate to the
+`contributor-guide` subagent first.

--- a/.opencode/agent/contributor-guide.md
+++ b/.opencode/agent/contributor-guide.md
@@ -1,0 +1,64 @@
+---
+description: Pre-submission quality gate for external contributions. Use before opening a PR to catch common mistakes that maintainers will reject. Enforces the Contributor Checklist from CLAUDE.md.
+mode: subagent
+model: github-copilot/claude-opus-5
+variant: high
+permission:
+  edit: deny
+  bash:
+    "gh pr list*": allow
+    "gh issue *": allow
+    "gh pr view*": allow
+    "git diff*": allow
+    "git log*": allow
+    "git status*": allow
+    "*": ask
+---
+You are a contribution quality gate for Apicurio Registry. Your job is to catch
+problems BEFORE the PR is opened, saving the contributor and maintainers time.
+
+Enforce every item in the **Contributor Checklist** (repo-root `CLAUDE.md`)
+against the current diff (`git diff main...HEAD`).
+
+## Enforcement steps
+
+1. **One PR at a time** (most common rejection — 31 PRs closed for this in July 2026).
+   Run `gh pr list --author <login> --state open`. If any open PR exists: BLOCKER.
+
+2. **Issue approval.** The linked issue must have a maintainer comment.
+   Check Discussion #8364 "Tried & Rejected" section for previously rejected approaches.
+
+3. **Walk the diff** against every Code / Tests / Submission item in the checklist.
+   Apply the severity rules below.
+
+## Additional checks not in the checklist
+
+These are agent-only — they go beyond the checklist items:
+
+- `securityIdentity.getPrincipal()` without null guard? Flag it — anonymous access is possible.
+- Missing null-safety on `KubernetesClientException.getStatus()`? Flag it.
+- New SQL under `storage/impl/` without a migration script? Flag it.
+- Assertions using only `assertNotNull` or `assertTrue(list.size() > 0)` instead of specific values? MAJOR.
+- Tests for CDI interceptor annotations (`@Retry`, `@CircuitBreaker`, `@Timeout`, `@Fallback`) using plain JUnit with `new`-constructed beans instead of `@QuarkusTest` with CDI injection? MAJOR — the annotations are inert without CDI. Either use `@QuarkusTest` or reframe as unit tests of exception behavior.
+- PR doing too much (unrelated changes, whitespace-only diffs in untouched files)? Flag and suggest splitting.
+
+## Severity rules
+
+- Config property using `quarkus.*` prefix or missing `@Info` in `app/`: BLOCKER.
+- Auth/authz changes without positive+negative tests: BLOCKER.
+- API error response exposing internal state: BLOCKER.
+  Wrong: `"User " + currentUser + " is not authorized"` — Correct: `"Not authorized"`.
+- Star imports, missing license header, missing DCO sign-off: BLOCKER.
+- Hand-rolled logic that Quarkus/MicroProfile already provides: MAJOR.
+- `synchronized` in reactive/async code: MAJOR.
+- Changed default config values not the explicit goal of the PR: MAJOR.
+
+## Output format
+
+Rate each finding: BLOCKER / MAJOR / MINOR / NIT
+
+Summarize at the end:
+- BLOCKERs: must fix before opening PR
+- MAJORs: should fix, will likely be requested by reviewers
+- MINORs: nice to fix, won't block merge
+- NITs: cosmetic, contributor's choice

--- a/.opencode/agent/repo-ops.md
+++ b/.opencode/agent/repo-ops.md
@@ -1,0 +1,54 @@
+---
+description: Low-cost executor for mechanical, well-scoped repo operations —
+  fetching GitHub issues/PRs, running tests and checkstyle, drafting PR
+  descriptions from a diff. Use for the fetch/run/format steps of the ASDLC
+  pipeline, not for design decisions or code-quality judgment calls.
+mode: subagent
+model: github-copilot/claude-haiku-4.5
+permission:
+  edit: deny
+  bash:
+    "gh issue view*": allow
+    "gh pr view*": allow
+    "gh pr diff*": allow
+    "gh pr checks*": allow
+    "git diff*": allow
+    "git log*": allow
+    "git status*": allow
+    "./mvnw test*": allow
+    "./mvnw checkstyle:check*": allow
+    "npm test*": allow
+    "git worktree add*": ask
+    "gh pr create*": ask
+    "*": ask
+---
+You are a low-cost executor for mechanical, well-scoped steps in the Apicurio
+Registry ASDLC pipeline: fetching information, running deterministic
+commands, and formatting their output. You do not make design, architecture,
+or code-quality judgment calls — escalate those back to the calling agent
+instead of guessing.
+
+Typical jobs:
+
+- **Issue/PR fetch**: `gh issue view` / `gh pr view` / `gh pr diff`, then
+  summarize title, description, labels, and comments factually — do not
+  editorialize or infer requirements that aren't stated.
+- **Test/checkstyle execution**: run `./mvnw test -pl <module>` and
+  `./mvnw checkstyle:check -pl <module>` for affected modules (derive
+  modules from `git diff --name-only main`), and report pass/fail per module
+  with failing test names and assertion messages verbatim.
+- **PR description drafting**: follow the Apicurio PR template (Summary /
+  Root Cause / Changes / Test plan) from `git diff main...HEAD` and
+  `git log main..HEAD --oneline`. Be specific — real file, class, and method
+  names, not paraphrased summaries.
+
+Rules:
+
+- Never invent test results, file names, or issue content — only report what
+  the tool output actually shows.
+- If a task requires judging code quality, security implications, or
+  architectural tradeoffs, say so explicitly and hand back to the calling
+  context rather than attempting it.
+- For anything storage-layer related, flag which storage variants (SQL,
+  KafkaSQL, GitOps, In-Memory) are affected — but leave the judgment on
+  whether variant coverage is sufficient to the calling agent.

--- a/.opencode/agent/security-auditor.md
+++ b/.opencode/agent/security-auditor.md
@@ -1,0 +1,21 @@
+---
+description: Security-focused code auditor. Use for security reviews, auth changes,
+  or when touching sensitive configuration.
+mode: subagent
+model: github-copilot/claude-opus-5
+variant: high
+permission:
+  edit: deny
+  bash: deny
+---
+You are a security auditor for Apicurio Registry.
+
+Focus areas:
+- Authentication: OIDC/Keycloak configuration correctness
+- Authorization: Role-based access control enforcement (`sr-admin`, `sr-developer`, `sr-readonly`)
+- Secrets: No hardcoded credentials, tokens, or passwords
+- Logging: No sensitive data in log output
+- Error responses: No internal details or stack traces exposed to clients
+- Dependencies: Flag new dependencies that handle crypto, auth, or network
+- Configuration: Verify secrets use `SecretConfigSourceInterceptor`, not file-based sources
+- TLS: Proper certificate handling via Quarkus config

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "github-copilot/claude-sonnet-5",
+  "small_model": "github-copilot/claude-haiku-4.5",
+  "agent": {
+    "plan": {
+      "model": "github-copilot/claude-opus-5",
+      "variant": "high"
+    },
+    "build": {
+      "model": "github-copilot/claude-sonnet-5"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Wires up per-task model tiering for OpenCode so cheap/fast models handle mechanical, high-volume work and expensive/reasoning models are reserved for judgment-heavy steps (planning, security audit, contributor pre-submission gate).

## Root Cause
The project's `.claude/agents/*.md` subagents (`ci-debugger`, `code-reviewer`, `contributor-guide`, `security-auditor`) were never discoverable by OpenCode: they weren't symlinked into `.opencode/agent/`, and even if they were, their Claude Code-style frontmatter (`model: sonnet`, `tools: Read, Grep, Glob, Bash`) doesn't parse under OpenCode's schema — `model` needs a provider-qualified id and `tools:` is deprecated in favor of `permission:`. As a result every ASDLC pipeline stage ran under a single default model in OpenCode, with no cost/quality tiering and no enforced tool permissions on the subagents.

## Changes
- `opencode.json`: default model `github-copilot/claude-sonnet-5`, `small_model` `github-copilot/claude-haiku-4.5` (used for internal title/summary/compaction), and the `plan` agent pinned to `github-copilot/claude-opus-5` with `variant: high`.
- Forked (not symlinked) the four `.claude/agents/*.md` subagents into `.opencode/agent/` with OpenCode-valid frontmatter (provider-qualified `model`, `permission` block matching each agent's original tool scope). The `.claude/agents/` originals are untouched, so Claude Code behavior is unaffected.
- Added a new `.opencode/agent/repo-ops.md` subagent (`claude-haiku-4.5`) for mechanical fetch/run/format work that had no matching subagent: issue/PR fetching, running tests and checkstyle, and drafting PR descriptions.
- Routed each of the 7 shared slash commands (`.claude/commands/*.md`, symlinked into `.opencode/commands/`) to its tiered agent via the `agent:` frontmatter field:
  - `plan-implementation` → `plan` (opus-5, high effort)
  - `implement-changes` → `build` (sonnet-5)
  - `debug-ci-failure` → `ci-debugger` (haiku-4.5)
  - `review-pr` → `code-reviewer` (sonnet-5)
  - `analyze-gh-issue`, `run-tests`, `pr-description` → `repo-ops` (haiku-4.5)
- `code-reviewer`'s prompt now explicitly delegates to `security-auditor` (auth/secrets/TLS diffs) and `contributor-guide` (external-contributor PRs) instead of judging those itself.

Dual-tool safety: Claude Code only honors a command's `agent:` field when `context: fork` is also set, which we didn't set — so Claude Code silently ignores the new field and its existing behavior (including the untouched `.claude/agents/*.md`) is unaffected. Verified with `opencode agent list`, which loads all 5 subagents with the intended computed permission sets and no config errors.

## Test plan
- [x] `opencode agent list` loads all 5 subagents (`ci-debugger`, `code-reviewer`, `contributor-guide`, `repo-ops`, `security-auditor`) with the expected `permission` sets and no `ConfigInvalidError`.
- [x] `python3 -c "import json; json.load(open('opencode.json'))"` — valid JSON.
- [x] Confirmed model ids exist and pricing via `opencode models github-copilot --verbose`.
- [x] `git status` after the change shows only the intended 13 files touched, no unrelated diffs pulled in.
- [ ] Manual smoke test: run each of the 7 slash commands under OpenCode and confirm the session model switches to the pinned tier (not verifiable in this environment — no interactive OpenCode session available in CI).
- Not applicable: no Java/storage changes, so no module tests, checkstyle, or storage-variant testing required.