### PR TITLE
fix(ci): share kiota binary across SDK modules and force Maven release update policy

### DIFF
--- a/.github/ci-settings.xml
+++ b/.github/ci-settings.xml
@@ -10,7 +10,7 @@
                     <id>central</id>
                     <name>Google Maven Central</name>
                     <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
-                    <releases><enabled>true</enabled></releases>
+                    <releases><enabled>true</enabled><updatePolicy>always</updatePolicy></releases>
                     <snapshots><enabled>false</enabled></snapshots>
                 </repository>
                 <!-- Fallback: True Maven Central -->
@@ -18,7 +18,7 @@
                     <id>central-fallback</id>
                     <name>True Maven Central</name>
                     <url>https://repo.maven.apache.org/maven2/</url>
-                    <releases><enabled>true</enabled></releases>
+                    <releases><enabled>true</enabled><updatePolicy>always</updatePolicy></releases>
                     <snapshots><enabled>false</enabled></snapshots>
                 </repository>
             </repositories>
@@ -27,14 +27,14 @@
                     <id>central</id>
                     <name>Google Maven Central</name>
                     <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
-                    <releases><enabled>true</enabled></releases>
+                    <releases><enabled>true</enabled><updatePolicy>always</updatePolicy></releases>
                     <snapshots><enabled>false</enabled></snapshots>
                 </pluginRepository>
                 <pluginRepository>
                     <id>central-fallback</id>
                     <name>True Maven Central</name>
                     <url>https://repo.maven.apache.org/maven2/</url>
-                    <releases><enabled>true</enabled></releases>
+                    <releases><enabled>true</enabled><updatePolicy>always</updatePolicy></releases>
                     <snapshots><enabled>false</enabled></snapshots>
                 </pluginRepository>
             </pluginRepositories>

--- a/java-sdk/client-v2/pom.xml
+++ b/java-sdk/client-v2/pom.xml
@@ -16,6 +16,17 @@
     <projectRoot>${project.basedir}/../..</projectRoot>
   </properties>
   <dependencies>
+    <!-- Build-ordering dependency: forces Maven to build client before client-v2
+         so the kiota binary is downloaded exactly once to the shared folder before
+         this module's kiota generate goal runs.  Without this, -T 1C can schedule
+         both modules concurrently and they race on Files.copy (ETXTBSY).
+         Marked optional so consumers of client-v2 do not pull client transitively. -->
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-java-sdk</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>io.apicurio</groupId>
       <artifactId>apicurio-registry-java-sdk-common</artifactId>

--- a/java-sdk/client-v2/pom.xml
+++ b/java-sdk/client-v2/pom.xml
@@ -201,6 +201,7 @@
               <kiotaVersion>${kiota.version}</kiotaVersion>
               <kiotaTimeout>${kiota.timeout}</kiotaTimeout>
               <baseURL>${kiota.base.url}</baseURL>
+              <targetBinaryFolder>${kiota.binary.folder}</targetBinaryFolder>
               <file>${project.build.directory}/openapi-v2-filtered.json</file>
               <namespace>io.apicurio.registry.rest.client.v2</namespace>
               <clientClass>RegistryClient</clientClass>

--- a/java-sdk/client-v2/pom.xml
+++ b/java-sdk/client-v2/pom.xml
@@ -16,10 +16,15 @@
     <projectRoot>${project.basedir}/../..</projectRoot>
   </properties>
   <dependencies>
-    <!-- Build-ordering dependency: forces Maven to build client before client-v2
-         so the kiota binary is downloaded exactly once to the shared folder before
-         this module's kiota generate goal runs.  Without this, -T 1C can schedule
-         both modules concurrently and they race on Files.copy (ETXTBSY).
+    <!-- Build-ordering dependency: forces Maven to build client before client-v2,
+         so the kiota binary is downloaded once into the shared folder before this
+         module's kiota generate goal runs.  The ordering is required rather than a
+         precaution.  KiotaMojo 0.0.38 returns early when the destination file
+         already exists, and it publishes the binary with a plain Files.copy into
+         that final path, so the file is visible while it is still partly written.
+         A second execution on the same folder can therefore take the early return,
+         mark a partial file executable and run it.  Under -T 1C the two modules
+         would otherwise be free to run their kiota goals at the same time.
          Marked optional so consumers of client-v2 do not pull client transitively. -->
     <dependency>
       <groupId>io.apicurio</groupId>

--- a/java-sdk/client-v2/pom.xml
+++ b/java-sdk/client-v2/pom.xml
@@ -21,10 +21,8 @@
          module's kiota generate goal runs.  The ordering is required rather than a
          precaution.  KiotaMojo 0.0.38 returns early when the destination file
          already exists, and it publishes the binary with a plain Files.copy into
-         that final path, so the file is visible while it is still partly written.
-         A second execution on the same folder can therefore take the early return,
-         mark a partial file executable and run it.  Under -T 1C the two modules
-         would otherwise be free to run their kiota goals at the same time.
+         that final path, so a module whose kiota goal runs at the same time (which
+         -T 1C allows) can see a partly written file, mark it executable and run it.
          Marked optional so consumers of client-v2 do not pull client transitively. -->
     <dependency>
       <groupId>io.apicurio</groupId>

--- a/java-sdk/client/pom.xml
+++ b/java-sdk/client/pom.xml
@@ -71,6 +71,7 @@
           <kiotaVersion>${kiota.version}</kiotaVersion>
           <kiotaTimeout>${kiota.timeout}</kiotaTimeout>
           <baseURL>${kiota.base.url}</baseURL>
+          <targetBinaryFolder>${kiota.binary.folder}</targetBinaryFolder>
           <file>../../common/src/main/resources/META-INF/openapi.json</file>
           <namespace>io.apicurio.registry.rest.client</namespace>
           <clientClass>RegistryClient</clientClass>

--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,7 @@
     <kiota.version>1.28.0</kiota.version>
     <kiota.timeout>60</kiota.timeout><!-- Execution timeout, not download timeout. -->
     <kiota.base.url>https://github.com/microsoft/kiota/releases/download</kiota.base.url>
+    <kiota.binary.folder>${session.executionRootDirectory}/target/kiota-binary</kiota.binary.folder>
 
     <!-- Groovy scripting -->
     <groovy.version>5.1.1</groovy.version>


### PR DESCRIPTION
Fixes #10107

## Summary

Two unrelated CI changes.

### 1. The kiota binary is downloaded once per build instead of once per module

`kiota-maven-plugin` defaults `targetBinaryFolder` to `${project.build.directory}/kiota/`, which is per module, so `java-sdk/client` and `java-sdk/client-v2` each download and unpack the same 1.28.0 binary. Both modules now point at one shared folder under the execution root, and a reactor ordering dependency from `client-v2` onto `client` keeps their kiota executions from overlapping on it.

That ordering is required rather than a precaution. `downloadAndExtract` returns early when the destination already exists, and it copies the binary straight into its final path instead of moving it into place atomically, so the file is visible while it is still partly written. Two executions sharing a path can therefore mark a partial binary executable and run it. Sharing the folder is what makes that reachable for these two modules, and serialising them is what prevents it.

### 2. Quarkus plugin resolution failure

The Google Maven Central mirror can lag behind Maven Central for newly published artifacts, and a cached negative lookup then blocks the build. `<updatePolicy>always</updatePolicy>` on the four release entries in `ci-settings.xml` addresses that.

## What this does not do

An earlier version of this description claimed the first change fixes the kiota `Text file busy` failure. It does not, and the claim was wrong on its premise, because the two modules had no shared binary path before this PR and so had no cross-module race to eliminate. That flake is tracked separately in #10108 and stays open. Its mechanism is now identified as descriptor inheritance across a concurrent `ProcessBuilder.start()`, which is JDK-8068370, and an earlier claim in that issue ruling descriptor inheritance out has been corrected there. This PR removes one of the two download-and-exec sequences per build, and nothing more.

## Changes

- `pom.xml`: added the `kiota.binary.folder` property
- `java-sdk/client/pom.xml`: added `<targetBinaryFolder>` to kiota-maven-plugin
- `java-sdk/client-v2/pom.xml`: same, plus an `<optional>true</optional>` dependency on `apicurio-registry-java-sdk` to force reactor ordering. Optional so consumers of `client-v2` do not pull `client` transitively.
- `.github/ci-settings.xml`: added `<updatePolicy>always</updatePolicy>` to all 4 release entries

## Test plan

- [x] `./mvnw test-compile -pl java-sdk/client -am -DskipTests` compiles
- [x] `./mvnw checkstyle:check -pl java-sdk/client` passes
- [x] Reactor order verified: `client` before `client-v2`, no cycle
- [x] Every check except `Validate PR` passed on `d218ad8b`, and the gate that failed is the issue link this description now carries. The follow-up commit changes only an XML comment.

