### PR TITLE
fix(limits): decouple property size validation from count check and evaluate UTF-8 byte length

### DIFF
--- a/app/src/main/java/io/apicurio/registry/limits/RegistryLimitsService.java
+++ b/app/src/main/java/io/apicurio/registry/limits/RegistryLimitsService.java
@@ -9,6 +9,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.slf4j.Logger;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -237,19 +238,23 @@ public class RegistryLimitsService {
                     && labels.size() > registryLimitsConfiguration.getMaxArtifactPropertiesCount()) {
 
                 errorMessages.add(MAX_LABELS_EXCEEDED_MSG);
+            }
 
-            } else if (isLimitEnabled(RegistryLimitsConfiguration::getMaxPropertyKeySizeBytes)
+            if (isLimitEnabled(RegistryLimitsConfiguration::getMaxPropertyKeySizeBytes)
                     || isLimitEnabled(RegistryLimitsConfiguration::getMaxPropertyValueSizeBytes)) {
 
                 labels.entrySet().forEach(e -> {
 
-                    if (isLimitEnabled(RegistryLimitsConfiguration::getMaxPropertyKeySizeBytes) && e.getKey()
-                            .length() > registryLimitsConfiguration.getMaxPropertyKeySizeBytes()) {
+                    if (isLimitEnabled(RegistryLimitsConfiguration::getMaxPropertyKeySizeBytes)
+                            && e.getKey() != null
+                            && e.getKey().getBytes(StandardCharsets.UTF_8).length > registryLimitsConfiguration
+                                    .getMaxPropertyKeySizeBytes()) {
                         errorMessages.add(MAX_LABEL_KEY_SIZE_EXCEEDED_MSG);
                     }
 
                     if (isLimitEnabled(RegistryLimitsConfiguration::getMaxPropertyValueSizeBytes)
-                            && e.getValue().length() > registryLimitsConfiguration
+                            && e.getValue() != null
+                            && e.getValue().getBytes(StandardCharsets.UTF_8).length > registryLimitsConfiguration
                                     .getMaxPropertyValueSizeBytes()) {
                         errorMessages.add(MAX_LABEL_VALUE_SIZE_EXCEEDED_MSG);
                     }

--- a/app/src/test/java/io/apicurio/registry/limits/RegistryLimitsServiceUnitTest.java
+++ b/app/src/test/java/io/apicurio/registry/limits/RegistryLimitsServiceUnitTest.java
@@ -1,0 +1,69 @@
+package io.apicurio.registry.limits;
+
+import io.apicurio.registry.storage.dto.EditableArtifactMetaDataDto;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+public class RegistryLimitsServiceUnitTest {
+
+    private RegistryLimitsService limitsService;
+    private RegistryLimitsConfiguration config;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        limitsService = new RegistryLimitsService();
+        config = new RegistryLimitsConfiguration();
+
+        setField(config, "maxArtifactPropertiesCount", 1L);
+        setField(config, "maxPropertyKeySizeBytes", 4L);
+        setField(config, "maxPropertyValueSizeBytes", 4L);
+
+        setField(limitsService, "registryLimitsConfiguration", config);
+    }
+
+    private void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    @Test
+    public void testDecoupledLabelCountAndSizeValidation() {
+        // 2 labels (exceeds max properties count of 1) and keys of length 5 (exceeds key size limit of 4)
+        Map<String, String> labels = Map.of(
+                "key01", "val1",
+                "key02", "val2"
+        );
+
+        EditableArtifactMetaDataDto meta = new EditableArtifactMetaDataDto();
+        meta.setLabels(labels);
+
+        LimitsCheckResult result = limitsService.checkMetaData(meta);
+        Assertions.assertFalse(result.isAllowed());
+        String msg = result.getMessage();
+        // Should contain BOTH label count exceeded message AND label key size exceeded message
+        Assertions.assertTrue(msg.contains("Maximum number of labels exceeded"), "Expected count message in: " + msg);
+        Assertions.assertTrue(msg.contains("Maximum label key size exceeded"), "Expected key size message in: " + msg);
+    }
+
+    @Test
+    public void testUtf8ByteLengthValidation() {
+        // Single label (count = 1, allowed)
+        // Key "key" length 3 chars / 3 bytes (allowed)
+        // Value "€" (Euro symbol) is 1 char but 3 bytes in UTF-8.
+        // "a€" is 2 chars, but 1 + 3 = 4 bytes (allowed if max is 4 bytes).
+        // "ab€" is 3 chars, but 1 + 1 + 3 = 5 bytes (exceeds 4 bytes limit).
+        Map<String, String> labels = Map.of("key", "ab€");
+
+        EditableArtifactMetaDataDto meta = new EditableArtifactMetaDataDto();
+        meta.setLabels(labels);
+
+        LimitsCheckResult result = limitsService.checkMetaData(meta);
+        Assertions.assertFalse(result.isAllowed());
+        Assertions.assertTrue(result.getMessage().contains("Maximum label value size exceeded"));
+    }
+}


### PR DESCRIPTION
Closes #9809 

What was wrong?

1. Property Size Check Was Being Skipped:  When metadata had more properties than maxArtifactPropertiesCount, the registry reported a property count error, but because of an else if block, it skipped checking if any property key or value exceeded the size limit.
2. Wrong Size Calculation:  Key and value lengths were measured using character count (String.length()) instead of UTF-8 byte length (getBytes().length). Emojis and multi-byte Unicode characters could bypass the configured byte size limits.

What was fixed?

1. Decoupled Validation Checks:  Removed else if so property count and key/value size validations run independently.
2. UTF-8 Byte Length Enforcement:  Updated key/value size checks to use getBytes(StandardCharsets.UTF_8).length to strictly enforce byte size limits.
3. Unit Tests Added:  Added unit tests covering decoupled validation and UTF-8 byte length calculations.