### PR TITLE
docs: fix apicurio.registry.auto-register.if-exists values and default

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/assembly-configuring-kafka-client-serdes.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-configuring-kafka-client-serdes.adoc
@@ -323,9 +323,9 @@ The `DefaultSchemaResolver` uses the following properties to configure how to lo
 |`false`
 |`AUTO_REGISTER_ARTIFACT_IF_EXISTS`
 |`apicurio.registry.auto-register.if-exists`
-|Used by serializers only. Configures the behavior of the client when a conflict occurs while creating an artifact because the artifact already exists. Available values are `FAIL`, `UPDATE`, `RETURN`, or `RETURN_OR_UPDATE`.
+|Used by serializers only. Configures the behavior of the client when a conflict occurs while creating an artifact because the artifact already exists. Available values are `FAIL`, `CREATE_VERSION`, or `FIND_OR_CREATE_VERSION`.
 |`String`
-|`RETURN_OR_UPDATE`
+|`FIND_OR_CREATE_VERSION`
 |`CHECK_PERIOD_MS`
 |`apicurio.registry.check-period-ms`
 |Used by serializers and deserializers. Specifies how long to cache artifacts before auto-eviction (milliseconds). If set to zero, artifacts are fetched every time.


### PR DESCRIPTION


The Kafka client SerDes config reference still listed the removed Registry 2.x enum values (`FAIL`, `UPDATE`, `RETURN`, `RETURN_OR_UPDATE`) and the old default `RETURN_OR_UPDATE`.

The actual 3.x implementation (`schema-resolver/.../config/SchemaResolverConfig.java:60-61,437`) only accepts `FAIL`, `CREATE_VERSION`, `FIND_OR_CREATE_VERSION`, with default `FIND_OR_CREATE_VERSION`.

This updates the table to match the current code, so users copying the old value don't get a config the resolver rejects.
