### PR TITLE
feat(test): add /apicurio-test-quality skill and 30-pattern test failure catalog

### DIFF
--- a/.claude/skills/apicurio-test-quality/SKILL.md
+++ b/.claude/skills/apicurio-test-quality/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: apicurio-test-quality
+description: Score-based test quality review using the project's 30-pattern catalog (P1-P30). Detects concurrency hazards, timing flakes, CI waste, lifecycle bugs, correctness gaps, and race test quality in changed test files. Labels (concurrency, timing, waste, lifecycle, correctness, hygiene, race) enable targeted agent sweeps. Run before committing test code.
+---
+
+# Test Quality: Pattern-Based Scoring Review
+
+Analyze changed test files against the project's 30 documented test failure patterns
+(P1-P30, see `claudedocs/test-fix-pattern-catalog.md`). Each pattern detector produces
+a score; violations below threshold block submission. Patterns are labeled for targeted
+agent sweeps: `concurrency`, `timing`, `waste`, `lifecycle`, `correctness`, `hygiene`, `race`.
+
+## When to use
+
+- Before committing any change that touches `**/src/test/**`
+- As part of the DoD (after /simplify, before /code-review)
+- On CI as a PR quality gate
+
+## Phase 1: Identify Test Changes
+
+```bash
+# Changed test files in the current diff
+git diff --name-only HEAD | grep -E 'src/test/.*\.java$'
+# Or vs main for PR scope
+git diff main...HEAD --name-only | grep -E 'src/test/.*\.java$'
+```
+
+If no test files are changed, report "No test files in diff, score: 10/10" and stop.
+
+Read the full content of each changed test file (not just the diff). Also read the
+production code they test (to understand shared state, lifecycle, config properties).
+Read the pattern catalog from `claudedocs/test-fix-pattern-catalog.md`.
+
+**IMPORTANT**: Collect all file contents in Phase 1 BEFORE launching agents. The detector
+agents may not have shell access (e.g., `code-reviewer` has only Read/Grep/Glob). You
+must pass the file contents directly in each agent's prompt. Never instruct an agent to
+run `git show` or `git diff`; instead, inline the content you already read.
+
+## Phase 2: Launch Pattern Detector Agents
+
+Use the Agent tool to launch **four** detector agents concurrently. Pass each agent
+the **full file contents** (inlined in the prompt) AND the relevant pattern descriptions.
+Do NOT use `subagent_type: code-reviewer` (it lacks Bash). Use default agents or
+`general-purpose`.
+
+Each agent scores every changed test file on a 0-10 scale for its pattern group.
+- **10**: no violations detected
+- **7-9**: minor concerns (advisory)
+- **4-6**: violations found, should fix
+- **0-3**: critical violations, must fix before merge
+
+Each finding must include: file, line, pattern ID, severity, and a concrete fix suggestion.
+
+### Agent 1: Concurrency Safety [labels: `concurrency`] (P1, P5, P6, P7, P12)
+
+Detect test code that will break under JUnit 5 class-level parallel execution.
+
+- **P1 (Static Field Contamination)**: Mutable static fields in test classes that extend
+  a shared base class. Under `@TestInstance(PER_CLASS)` with concurrent classes, static
+  fields collide. Score 0 if mutable static state AND parallel classes are enabled.
+- **P5 (Shared Infra Lifecycle)**: `@AfterAll`/`@AfterEach` tearing down shared
+  infrastructure without reference-counting.
+- **P6 (Registration Collision)**: Hardcoded resource names (connectors, topics, rules)
+  without per-class uniqueness or serialization.
+- **P7 (Count Assertion with Noise)**: `assertEquals(N, size())` without filtering
+  by test-specific content.
+- **P12 (Shared Mutable DTO)**: `private static final` DTOs mutated via setters across
+  tests. `final` prevents reassignment but not mutation.
+
+### Agent 2: Timing and CI Waste [labels: `timing`, `waste`] (P2, P4, P9, P17, P21, P24, P27, P28)
+
+Detect test code that will flake under CI load or waste CI time.
+
+- **P2 (TOCTOU Assertions)**: Poll-then-assert as separate operations. Fix: wrap in
+  `await().untilAsserted()`.
+- **P4 (Unbounded Wait)**: `await()` without `atMost()`, `Thread.sleep()` without retry,
+  `future.get()` without timeout, `latch.await()` without timeout, `CompletableFuture.get()`
+  without timeout. ALSO detect hand-rolled poll loops (`while + Thread.sleep` without
+  a deadline or max-iteration guard).
+- **P9 (Eventually-Consistent Config)**: `System.setProperty` on `@Dynamic` config
+  followed by immediate assertion without retry.
+- **P17 (Fixed-Sleep Flush Wait)**: `Thread.sleep(N)` for eventually-consistent operations
+  instead of Awaitility. Bounded but wasteful.
+- **P21 (Redundant Pre-Wait)**: `Thread.sleep()` immediately before a retry loop that
+  already handles the wait. Pure CI time waste.
+- **P24 (Sleep-Then-Assert-Stable)**: `Thread.sleep(30-60s)` for negative assertions
+  ("nothing changed"). Fix: `await().during().atMost().untilAsserted()`.
+- **P27 (Side Effects in Awaitility Lambda)**: Mutating operations (create, insert, register)
+  inside `await().untilAsserted()` execute on every retry. Separate mutation from polling.
+- **P28 (Awaitility Error Swallowing)**: `await().until(() -> expr)` swallows exceptions
+  and retries. Use `untilAsserted()` when the lambda can throw unexpected errors.
+- **P29 (Async-Treated-as-Sync)**: An async operation (K8s delete, container stop) treated
+  as complete because the API returned 200. Must poll for actual completion. Look for
+  `delete()` or `stop()` calls on K8s/Docker resources followed by no wait/poll.
+
+### Agent 3: Infrastructure, Lifecycle, and Hygiene [labels: `lifecycle`, `hygiene`] (P8, P11, P14, P16, P19, P22, P23)
+
+Detect test infrastructure mismanagement and code hygiene issues.
+
+- **P8 (Failsafe Rerun Breakage)**: `@AfterAll` destroying deployment. Reruns start with
+  dead infra.
+- **P11 (KafkaConsumer Shutdown)**: Direct `consumer.close()` from wrong thread.
+- **P14 (Unclosed Consumer Leak)**: KafkaConsumer in `@BeforeAll` with no `@AfterAll` close.
+- **P16 (Silent Cleanup Failure)**: `catch (Exception ignored) {}` in cleanup or setup code.
+  Also check `TestExecutionListener` implementations that swallow setup exceptions.
+- **P30 (Third-Party Thread Leak)**: `Unreliables.retryUntilTrue/retryUntilSuccess` with a
+  shared mutable resource (consumer, producer). The library leaks background threads that
+  continue accessing the resource after timeout. Replace with caller-thread poll loop.
+- **P19 (Reflective CDI Bypass)**: `Field.setAccessible(true)` OR `Method.setAccessible(true)`
+  to inject mocks or invoke private methods. Brittle against renames.
+- **P22 (Orphaned Disabled Test)**: `@Disabled` with no issue reference. Dead code.
+- **P23 (Unbounded Recursive Retry)**: Recursive retry with no counter. StackOverflowError.
+
+### Agent 4: Correctness and Race Quality [labels: `correctness`, `race`] (P3, P10, P13, P15, P18, P20, P25, P26)
+
+Evaluate test correctness and race condition testing quality.
+
+- **P3 (Non-Deterministic Race Tests)**: Threading without deterministic coordination.
+  Score 10 for Byteman/CyclicBarrier; score 0 for "hope-based" threading.
+- **P10 (Stampede Test Completeness)**: Needs: latency, barrier, exact count assertion.
+- **P13 (Assertion-Free Test)**: Zero assertions; only verifies "no exception thrown."
+- **P15 (Cross-Test Event Bleed)**: Shared consumer accumulates events across tests.
+- **P18 (Untyped Exception Expectation)**: `fail()+catch(ignored)` instead of `assertThrows`.
+- **P20 (Silent Validation Sink)**: Validation helper catches exceptions and returns normally.
+- **P25 (Benchmark as Test)**: `@Test` on benchmark methods with no assertions.
+- **P26 (Existence-Only Assertion)**: Only `assertNotNull`, no value checks.
+
+## Phase 3: Score and Report
+
+Wait for all four agents. Aggregate findings into a scored report:
+
+```
+## Test Quality Report
+
+**Overall Score**: X.X / 10.0
+**Verdict**: PASS (>= 7.0) | WARN (5.0-6.9) | FAIL (< 5.0)
+
+### Scores by Category
+| Category | Labels | Patterns | Score | Findings |
+|----------|--------|----------|-------|----------|
+| Concurrency Safety | `concurrency` | P1,P5,P6,P7,P12 | X/10 | N findings |
+| Timing & CI Waste | `timing`,`waste` | P2,P4,P9,P17,P21,P24,P27,P28,P29 | X/10 | N findings |
+| Infra, Lifecycle & Hygiene | `lifecycle`,`hygiene` | P8,P11,P14,P16,P19,P22,P23,P30 | X/10 | N findings |
+| Correctness & Race Quality | `correctness`,`race` | P3,P10,P13,P15,P18,P20,P25,P26 | X/10 | N findings |
+
+### Findings (by severity)
+[For each finding: pattern ID, file:line, description, fix suggestion]
+```
+
+The overall score is the weighted average:
+- Concurrency Safety: weight 3 (most common failure class)
+- Timing & Consistency: weight 3
+- Infra & Lifecycle: weight 2
+- Race Test Quality: weight 2
+
+## Phase 4: Fix (if score < 7.0)
+
+For each finding scored 6 or below, apply the fix directly. Use the pattern catalog
+(`claudedocs/test-fix-pattern-catalog.md`) for the fix template.
+
+After fixing, re-run the affected detectors to verify the score improved.
+
+## Scoring Calibration
+
+The scores are calibrated against the project's actual history:
+- **Score 3 or below**: the exact pattern that caused PR #9798, #9757, or #9722 failures
+- **Score 5-6**: a pattern that caused flaky tests (retried but not deterministic)
+- **Score 7-8**: minor concern, unlikely to cause CI failure but not best practice
+- **Score 9-10**: clean, follows all documented patterns
+
+## Pattern Reference
+
+Full catalog with examples, mechanisms, fix templates, and labels:
+`claudedocs/test-fix-pattern-catalog.md`
+
+30 patterns (P1-P30) extracted from 30+ PRs, a 661-file codebase sweep, and a clean-room
+validation run (August 2026). Clean-room validation: 62.5% true-positive rate, zero false
+positives. Known gaps: hand-rolled poll loops (P4), reflective method invocation (P19).
+
+Labels: `concurrency`, `timing`, `waste`, `lifecycle`, `correctness`, `hygiene`, `race`.
+
+To run a targeted sweep by label (e.g., only timing/waste patterns):
+pass `--labels timing,waste` to focus the agents on those pattern groups.

--- a/.opencode/skills/apicurio-test-quality
+++ b/.opencode/skills/apicurio-test-quality
@@ -1,0 +1,1 @@
+../../.claude/skills/apicurio-test-quality

--- a/claudedocs/byteman-testing-guide.md
+++ b/claudedocs/byteman-testing-guide.md
@@ -1,0 +1,161 @@
+# Byteman: Deterministic Concurrency Testing for Apicurio Registry
+
+## What is Byteman?
+
+Byteman is a JVM bytecode injection tool that lets you insert Java code into any method (yours, a library's, the JDK's) at runtime, without recompiling. Among the things you can inject: thread-blocking and thread-releasing operations that let you control exactly when a thread pauses and when it resumes.
+
+This makes it the right tool when the question is: "what happens if thread B reads exactly while thread A is stopped at this point?" Race conditions that are nearly impossible to trigger in normal testing become deterministic, reproducible, and fast.
+
+Byteman is a Red Hat project (Andrew Dinn), actively maintained, Apache 2.0 licensed, and works on JDK 21.
+
+## Why not the alternatives?
+
+| Tool | What it does | Why it's not enough for us |
+|---|---|---|
+| **Lincheck** (JetBrains) | Model-checks isolated concurrent data structures | Right for verifying linearizability of a queue or map. Wrong for injecting scheduling into an application's own flow (Quarkus + JDBC + CDI). |
+| **JCStress** (OpenJDK) | Memory-model micro-tests | Too low level. We need to freeze inside `createArtifactVersion`, not test `volatile` visibility. |
+| **vmlens** | Detects races that happen to be observed during a run | It detects; it does not force. We need the race to happen 100% of the time, not hope to observe it. |
+| **CyclicBarrier + Thread.sleep** | Coordinates test threads at a coarse level | Good for stampede tests (see `OidcTokenStampedeTest`), but cannot freeze a thread at a precise bytecode point inside production code. |
+
+Byteman fills the gap: it freezes a thread at an exact point in production code, by construction, every time.
+
+## How it works: ECA rules
+
+A Byteman rule says: **when** execution reaches a point (Event), **if** a condition is true (Condition), **do** these expressions (Action).
+
+The event can be `AT ENTRY`, `AT EXIT`, `AT LINE n`, `AT INVOKE method`, and more. Actions can read/write fields, call methods, sleep, or block the thread.
+
+Here is the rule we use to test the `createArtifactVersion` race:
+
+```
+RULE freeze first writer
+CLASS io.apicurio.registry.storage.impl.sql.AbstractSqlRegistryStorage
+METHOD createArtifactVersion(...)
+AT ENTRY
+IF NOT flagged("writer-entered")
+DO flag("writer-entered");
+   java.lang.System.setProperty("byteman.writerFrozen", "true");
+   waitFor("versionOrder-race", 10000)
+ENDRULE
+
+RULE release frozen writer
+CLASS io.apicurio.registry.storage.impl.sql.AbstractSqlRegistryStorage
+METHOD createArtifactVersion(...)
+AT EXIT
+IF flagged("writer-entered") AND NOT flagged("writer-released")
+DO flag("writer-released");
+   signalWake("versionOrder-race", true)
+ENDRULE
+```
+
+Rule 1 fires on the first thread to enter the method, sets a system property (so the test can observe it), and blocks the thread with `waitFor`. Rule 2 fires when a second thread exits the same method, releasing the first thread with `signalWake`.
+
+The result: Thread A is frozen before it touches the database, Thread B creates its version freely, and only then Thread A resumes. This is not a race you hope to trigger. It is a race you construct.
+
+## What we tested with it
+
+### The versionOrder duplicate bug (#9775)
+
+`createArtifactVersion` computed the next `versionOrder` via `MAX(versionOrder)` without holding a row-level lock. Two concurrent version creations for the same artifact could both read `MAX = 5` and both insert `versionOrder = 6`. Silent data corruption.
+
+The fix adds `SELECT ... FOR UPDATE` to serialize concurrent version creation at the database level. The Byteman test proves the fix works:
+
+1. Thread A enters `createArtifactVersion` and is frozen by the Byteman rule
+2. Thread B creates a version concurrently (gets `versionOrder = 2`)
+3. Thread A is released and creates its version (gets `versionOrder = 3`, not 2)
+4. The test asserts both versions have distinct `versionOrder` values
+
+Without the fix, both threads would get `versionOrder = 2`. The test fails deterministically before the fix and passes deterministically after it.
+
+## The test pattern: freeze + volatile flag + spin
+
+The pattern has three components that work together:
+
+**Byteman rule**: freezes a thread at the race window and sets a flag before blocking.
+
+**Test reader thread**: spins on the flag (with a bail-out timeout), confirming the writer is frozen before exercising the race.
+
+**Observable effect assertion**: the test asserts the flag was set, proving the Byteman rule fired. Without this, a broken rule (typo in class name, method signature changed) would silently disable the injection, and the test would "pass" because the race was never attempted.
+
+```java
+// Thread B spins until Thread A is frozen
+long deadline = System.currentTimeMillis() + 5000;
+while (!"true".equals(System.getProperty("byteman.writerFrozen"))) {
+    Thread.sleep(50);
+    if (System.currentTimeMillis() > deadline) {
+        throw new AssertionError("Timed out waiting for Byteman rule to fire");
+    }
+}
+
+// Assert the rule actually fired
+assertEquals("true", System.getProperty("byteman.writerFrozen"),
+    "Byteman rule should have set the writerFrozen flag");
+```
+
+### The fix validation twin
+
+The same test with the fix applied must pass. The Byteman rule still tries to force the interleaving, but the `SELECT ... FOR UPDATE` lock makes the interleaving harmless. This is the real value over detection tools: you do not have to wait for the race to happen again to know your fix works.
+
+## How to run it
+
+```bash
+# Run the Byteman concurrency test
+./mvnw test -pl :apicurio-registry-app -Pbyteman -Dtest=ConcurrentVersionCreationTest
+
+# Run with a different Byteman script
+./mvnw test -pl :apicurio-registry-app -Pbyteman -Dbyteman.script=byteman/other-test.btm -Dtest=OtherTest
+```
+
+The `-Pbyteman` Maven profile:
+- Adds `org.jboss.byteman:byteman:4.0.27` as a test dependency
+- Loads the Byteman agent via `-javaagent` in the surefire argLine
+- Sets `byteman.agent=true` so `@EnabledIfSystemProperty` gates the test
+
+Without `-Pbyteman`, the test is skipped. The normal test suite is unaffected.
+
+## How to write a new Byteman test
+
+1. **Find the window**: identify the "publishes partial state, then completes state" sequence in the production code. For `createArtifactVersion`, it was: read `MAX(versionOrder)`, then insert the new version.
+
+2. **Write the freeze rule** (`.btm` file in `src/test/resources/byteman/`):
+   - Target the class and method where the race happens
+   - Use `AT ENTRY` to freeze before any work, or `AT INVOKE` / `AT LINE` for a more precise point
+   - Use `flagged()` guards so only the first thread is frozen
+   - Set an observable flag (system property) before calling `waitFor`
+   - Use `waitFor(key, TIMEOUT)` with a timeout to keep the test finite
+
+3. **Write the test** (`@QuarkusTest`, `@EnabledIfSystemProperty`):
+   - Thread A calls the production method (gets frozen by the rule)
+   - Thread B spins on the observable flag, then exercises the race
+   - Assert the observable effect (rule fired) and the correctness invariant (no duplicates)
+
+4. **Verify both directions**:
+   - Before the fix: the test fails deterministically (the race causes the invariant violation)
+   - After the fix: the test passes deterministically (the fix makes the forced interleaving harmless)
+
+## Traps we learned from
+
+**Early signals are lost (BYTEMAN-38).** If `signalWake(key)` fires before anyone is in `waitFor(key)`, the signal is lost and the wait blocks forever. Always use `waitFor(key, TIMEOUT)` and treat the timeout as a test failure.
+
+**Rule errors do not fail the build.** A mistyped class name or method signature disables the rule silently. The test "passes" because the injection never happened. Always assert an observable effect of the injection in the test (the `writerFrozen` flag check).
+
+**`signal()` and `setFlag()` do not exist.** The correct names are `signalWake()` and `flag()`. Use `-Dorg.jboss.byteman.verbose=true` during development to see rule parsing and typechecking output.
+
+**Nested classes.** Use `Outer$Inner` syntax for inner class names in the rule CLASS field.
+
+## Project integration
+
+| Component | Location |
+|---|---|
+| Byteman rules | `app/src/test/resources/byteman/*.btm` |
+| Byteman tests | `app/src/test/java/.../ConcurrentVersionCreationTest.java` |
+| Maven profile | `app/pom.xml`, `<profile id="byteman">` |
+| Script path property | `-Dbyteman.script=byteman/<name>.btm` |
+| Test gate | `@EnabledIfSystemProperty(named = "byteman.agent", matches = "true")` |
+
+## References
+
+- Byteman homepage: https://byteman.jboss.org/ (includes the Programmer's Guide PDF)
+- GitHub: https://github.com/bytemanproject/byteman
+- Current version: 4.0.27 (verified on JDK 21, works with Quarkus)
+- PR #9789: the versionOrder race fix and Byteman test

--- a/claudedocs/test-fix-pattern-catalog.md
+++ b/claudedocs/test-fix-pattern-catalog.md
@@ -1,0 +1,643 @@
+# Test Fix Pattern Catalog: Apicurio Registry
+
+**Date**: 2026-08-24 (updated with full-codebase sweep results)
+**Source**: 30+ PRs (May-August 2026) + full codebase sweep of 661 test files
+**Patterns**: 33 (11 original + 15 from sweep + 2 from clean-room + 2 from PR #9800 + 3 from epic #9807)
+
+This catalog documents recurring test failure classes and their proven fixes, extracted
+from real CI fixes and a full-codebase pattern sweep. Each pattern has a unique ID, labels
+for agent-based filtering, and a fix template.
+
+## Labels
+
+Labels classify patterns for targeted agent sweeps:
+
+| Label | Meaning | Patterns |
+|---|---|---|
+| `concurrency` | Breaks under parallel class/method execution | P1, P5, P6, P7, P12, P30 |
+| `timing` | Flakes under CI load or slow machines | P2, P4, P9, P17, P21, P24, P27, P29 |
+| `lifecycle` | Infra setup/teardown mismanagement | P5, P8, P11, P14, P16, P30 |
+| `correctness` | Test passes but does not verify what it claims | P7, P13, P18, P20, P26, P27, P28, P29 |
+| `waste` | Burns CI time without improving reliability | P17, P21, P24, P25 |
+| `hygiene` | Code quality, maintainability, dead code | P19, P22, P23 |
+| `race` | Race condition testing quality | P3, P10, P15 |
+
+## Pattern 1: Static Field Cross-Class Contamination
+**Labels**: `concurrency`
+
+**Failure class**: Tests pass individually but fail when run concurrently. Symptoms include "already exists" 409s, duplicate key violations, wrong event counts.
+
+**Mechanism**: JUnit 5 with `@TestInstance(PER_CLASS)` and `parallel.mode.classes.default=concurrent` runs multiple test classes in the same JVM simultaneously. Static fields are shared across ALL subclasses, so classes that inherit from a common base stomp on each other's state.
+
+**Fix**: Convert static fields to instance fields. Under `PER_CLASS` lifecycle, instance fields are still shared across methods within one class but isolated between classes.
+
+**Gotcha**: A static counter used for uniqueness (e.g., connector IDs) should stay static (that is what guarantees cross-class uniqueness). The bug is caching its *derived* values in static fields. Capture derived values as instance fields in `@BeforeAll`.
+
+**PRs**: #9798 (Debezium connector names), #9757 (KafkaFacade lifecycle), #8452 (operator ITBase)
+
+---
+
+## Pattern 2: TOCTOU (Check-Then-Act) in Test Assertions
+**Labels**: `timing`, `correctness`
+
+**Failure class**: Test polls until a condition is true, then makes a SEPARATE request assuming the condition still holds. Fails intermittently.
+
+**Mechanism**: The probed state is eventually-consistent (e.g., `@Dynamic` config properties, Kafka consumer offsets). The state can revert between the probe and the assertion.
+
+**Fix**: Retry the whole "make the request AND assert on it" as one atomic unit. Use Awaitility or a retry loop around the complete operation, not just the probe.
+
+```java
+// BAD: probe, then trust
+await().until(() -> probeCompressionDisabled());
+response = makeRequest();  // state might have changed!
+assertNull(response.header("Content-Encoding"));
+
+// GOOD: retry the whole assertion
+await().untilAsserted(() -> {
+    Response r = makeRequest();
+    assertNull(r.header("Content-Encoding"));
+});
+```
+
+**PRs**: #9798 (HttpCompressionTest), #8225 (KafkaSQL snapshot assertions)
+
+---
+
+## Pattern 3: Deterministic Race Reproduction with Byteman
+**Labels**: `race`
+
+**Failure class**: A race condition exists in production code but is nearly impossible to trigger in tests because it requires precise thread interleaving.
+
+**Mechanism**: Byteman injects thread coordination (freeze/release) at exact bytecode points, forcing the interleaving that triggers the race. The test does not rely on scheduler luck.
+
+**Fix template**: "Freeze + volatile flag + spin" pattern:
+1. Byteman rule freezes Thread A at the race window (`waitFor(key, timeout)`)
+2. Rule sets a volatile flag (`writerFrozen = true`) BEFORE blocking
+3. Thread B spins on the flag (with bail-out timeout), confirming Thread A is frozen
+4. Thread B exercises the race, then signals Thread A to resume
+5. Assert the observable effect (the flag was set, proving the rule fired)
+
+**Twin test**: Same Byteman rule with the fix applied must make the forced interleaving harmless.
+
+**Infrastructure**: Maven `-Pbyteman` profile, `@EnabledIfSystemProperty(named="byteman.agent")`, configurable script path via `-Dbyteman.script=byteman/<name>.btm`.
+
+**Key traps**:
+- BYTEMAN-38: `signalWake` before `waitFor` loses the signal. Always use `waitFor(key, TIMEOUT)`.
+- Rule errors are silent (disabled rule, test "passes" because injection never happened). Always assert an observable effect.
+- `signal()` and `setFlag()` do NOT exist. Use `signalWake()` and `flag()`.
+
+**PRs**: #9789 (versionOrder race, SELECT FOR UPDATE fix)
+
+---
+
+## Pattern 4: Unbounded Wait / Missing Timeout
+**Labels**: `timing`, `waste`
+
+**Failure class**: Test hangs indefinitely in CI (3+ hours), eventually killed by GitHub Actions runner timeout.
+
+**Mechanism**: A wait operation (HTTP request, consumer poll, Kafka Connect readiness) has no timeout or an insufficient one. Under CI load, the operation takes longer than expected and blocks forever.
+
+**Fix**: Add explicit timeouts at every wait layer:
+1. **HTTP client**: connect timeout + read-idle timeout (`RegistryClientOptions.requestTimeout(10_000, 60_000)`)
+2. **JUnit**: `junit.jupiter.execution.timeout.default=10m`
+3. **Job**: `timeout-minutes: 45` on CI jobs
+4. **Awaitility**: explicit `atMost()` on every `await()`
+
+**PRs**: #9722 (Vert.x WebClient timeouts, JUnit 10m timeout), #8511 (operator Kafka test timeouts), #8158 (KafkaSQL startup 120s), #8651 (Awaitility timeouts)
+
+---
+
+## Pattern 5: Shared Infrastructure Lifecycle Race
+**Labels**: `concurrency`, `lifecycle`
+
+**Failure class**: A test class tears down shared infrastructure (Kafka, Strimzi, database) while another test class is still using it. Symptoms: connection refused, consumer errors, NPEs.
+
+**Mechanism**: Infrastructure is started once (static/shared) but cleanup is per-class. Under parallel execution, Class A's `@AfterAll` tears down the infra while Class B is still running.
+
+**Fix**: Reference-count the shared resource. The first class to request it starts it; the last class to release it stops it. Teardown only on JVM shutdown.
+
+```java
+// KafkaFacade: synchronized start/stop with reference counting
+private static final AtomicInteger refCount = new AtomicInteger(0);
+public synchronized void start() { if (refCount.incrementAndGet() == 1) doStart(); }
+public synchronized void stop()  { if (refCount.decrementAndGet() == 0) doStop();  }
+```
+
+**Alternative**: Install infrastructure once per JVM in a shared namespace (Strimzi cluster-wide), and give each test class its own namespace for CRs.
+
+**PRs**: #9757 (KafkaFacade ref-counting), #9722 (Strimzi cluster-wide install), #8652 (dedicated Kafka CR resources)
+
+---
+
+## Pattern 6: Resource Registration Collision Under Parallelism
+**Labels**: `concurrency`
+
+**Failure class**: Parallel test classes register the same named resource (connector, topic, rule) and get 409 Conflict.
+
+**Mechanism**: Multiple classes use the same resource name (hardcoded or derived from a shared counter) and register concurrently.
+
+**Fix**: Serialize registration with a lock, OR use unique per-class names.
+
+```java
+// Debezium: serialize connector register/delete across classes
+private static final Object CONNECTOR_LOCK = new Object();
+@BeforeAll void setup() {
+    synchronized (CONNECTOR_LOCK) {
+        registerConnector(uniqueConnectorName);
+        waitForConnectorReady();
+    }
+}
+```
+
+**PRs**: #9757 (Debezium connector lock), #9757 (local-converter mount AtomicBoolean)
+
+---
+
+## Pattern 7: Assertion on Exact Count with Background Noise
+**Labels**: `concurrency`, `correctness`
+
+**Failure class**: Test asserts `events.size() == 3` but gets 4 or 5 because parallel tests or internal mechanisms (snapshots, admin operations) inject extra events.
+
+**Mechanism**: The count includes events from other test classes running concurrently, or from infrastructure operations (KafkaSQL snapshots, health checks).
+
+**Fix**: Filter by test-specific content before counting.
+
+```java
+// BAD: count all events
+assertEquals(3, consumeAvroEvents(topic, 3, 60));
+
+// GOOD: count only events with our specific value
+assertEquals(3, consumeAvroEvents(topic, 3, 60, insertedValue));
+```
+
+**PRs**: #9757 (recovery test event counting)
+
+---
+
+## Pattern 8: Failsafe Rerun in Deployed Environment
+**Labels**: `lifecycle`
+
+**Failure class**: Failsafe `rerunFailingTestsCount=1` re-executes failing tests but they all fail with connection-refused on the rerun.
+
+**Mechanism**: The first test plan's `@AfterAll` tears down the deployed namespace. The rerun starts in the same JVM but the infrastructure is gone.
+
+**Fix**: Deploy once per JVM, clean up only on JVM shutdown (shutdown hook), not per-test-plan.
+
+**PRs**: #9722 (RegistryDeploymentManager lifecycle)
+
+---
+
+## Pattern 9: Eventually-Consistent Config in Tests
+**Labels**: `timing`
+
+**Failure class**: Test sets a config property and immediately asserts the effect. Fails intermittently.
+
+**Mechanism**: Config properties go through a source chain (DB-backed dynamic config at ordinal 450, System properties at 400) with caching. A `System.setProperty` write may not be visible until the cache refreshes.
+
+**Fix**: Wrap the complete config-change-then-assert cycle in a retry:
+
+```java
+System.setProperty("apicurio.feature.enabled", "false");
+await().atMost(30, SECONDS).untilAsserted(() -> {
+    Response r = callEndpoint();
+    assertEquals(404, r.statusCode());
+});
+```
+
+**PRs**: #9798 (HttpCompressionTest dynamic toggle)
+
+---
+
+## Pattern 10: Mock Object Thread Safety (Stampede Testing)
+**Labels**: `race`
+
+**Failure class**: Need to verify that concurrent requests produce exactly N calls to a shared resource (e.g., one token fetch instead of 20).
+
+**Mechanism**: Standard Mockito mocking with `CyclicBarrier` synchronization to ensure all threads start simultaneously, then `AtomicInteger` inside the mock's answer to count invocations. Add artificial latency in the mock to widen the stampede window.
+
+**Fix template**:
+
+```java
+AtomicInteger fetchCount = new AtomicInteger(0);
+when(mock.getToken(any())).thenAnswer(inv -> {
+    fetchCount.incrementAndGet();
+    Thread.sleep(200);  // widen the window
+    return new Token("mock");
+});
+
+CyclicBarrier barrier = new CyclicBarrier(threadCount);
+// launch threadCount threads, each awaiting the barrier then calling the method
+// assert fetchCount.get() == 1
+```
+
+**PRs**: #9790 (OidcTokenStampedeTest with mock-oauth2-server)
+
+---
+
+## Pattern 11: KafkaConsumer Shutdown Race
+**Labels**: `lifecycle`
+
+**Failure class**: `ConcurrentModificationException` during application shutdown.
+
+**Mechanism**: `KafkaConsumer` is not thread-safe. `@PreDestroy` calls `close()` from the CDI shutdown thread while the consumer thread is inside `poll()`.
+
+**Fix**: Use `wakeup()` (the only thread-safe method), catch `WakeupException` in the consumer loop, and call `close()` from the consumer thread's own `finally` block. Join the consumer thread with a timeout and interrupt as fallback.
+
+**PRs**: #9791 (KafkaSqlRegistryStorage.onDestroy)
+
+---
+
+---
+
+## Pattern 12: Shared Mutable DTO
+**Labels**: `concurrency`
+
+**Failure class**: Tests pass individually but produce wrong results under parallel method execution or test reordering.
+
+**Mechanism**: Mutable DTO objects (e.g., `CreateArtifact`, `CreateRule`) declared as `private static final` and mutated across tests via setters. The `final` keyword prevents reassignment but not mutation. Each test that calls `setArtifactId()` leaves residue for subsequent tests.
+
+**Fix**: Replace the static field with a factory method called in `@BeforeEach` or at the start of each test method.
+
+**Affected files**: `SimpleAuthTest.java`, `AuthTestLocalRoles.java`
+
+---
+
+## Pattern 13: Assertion-Free Test
+**Labels**: `correctness`
+
+**Failure class**: Test always passes. Provides no regression signal.
+
+**Mechanism**: Test methods contain zero assertions and only verify "no exception thrown." A silent behavioral change in the method under test goes undetected.
+
+**Fix**: Add explicit assertions on the method's return value or side effects.
+
+**Affected files**: `MultiRoleValueTest.java`
+
+---
+
+## Pattern 14: Unclosed Test Consumer Leak
+**Labels**: `lifecycle`
+
+**Failure class**: Resource leak; under parallel execution, leaked consumers hold group membership and block rebalancing.
+
+**Mechanism**: KafkaConsumer allocated in `@BeforeAll` but never closed. No `@AfterAll`, no try-with-resources.
+
+**Fix**: `@AfterAll static void tearDown() { if (consumer != null) consumer.close(); }`
+
+**Affected files**: `RegistryEventsTest.java`, `KafkaSqlEventsTest.java`
+
+---
+
+## Pattern 15: Shared Consumer Cross-Test Event Bleed
+**Labels**: `race`, `correctness`
+
+**Failure class**: Test assertions match events from a different test method. Intermittent false passes and false failures.
+
+**Mechanism**: A single KafkaConsumer reused across all test methods in a `@TestInstance(PER_CLASS)` class. Events accumulate across tests. Overlapping field selectors (same eventType, same groupId pattern) cause cross-test matches.
+
+**Fix**: Add unique correlation IDs per test and filter `lookupEvent` by those IDs. Alternatively, create a new consumer per test method with a fresh group ID.
+
+**Affected files**: `RegistryEventsTest.java`
+
+---
+
+## Pattern 16: Silent Cleanup Failure
+**Labels**: `lifecycle`
+
+**Failure class**: Tests fail with stale state from a previous test, but the cleanup failure that caused it is invisible in logs.
+
+**Mechanism**: `@AfterEach` or cleanup code wraps exceptions in `catch (Exception ignored) {}`, hiding failures that leave stale state.
+
+**Fix**: Replace empty catch with `log.warn("Cleanup failed", e)`.
+
+**Affected files**: `ConfluentClientTest.java`, `ReferenceGraphIT.java`, `ArtifactsIT.java`
+
+---
+
+## Pattern 17: Fixed-Sleep Flush Wait
+**Labels**: `timing`, `waste`
+
+**Failure class**: Test passes but wastes CI time. Fragile on slow machines.
+
+**Mechanism**: `Thread.sleep(N)` to wait for an eventually-consistent operation (telemetry flush, cache eviction) instead of Awaitility. The sleep is bounded (not P4's unbounded hang), but it wastes CI time.
+
+**Fix**: `await().atMost(N, SECONDS).untilAsserted(() -> { ... })`
+
+**Affected files**: `UsageTelemetryTest.java` (70s total), `ERCacheTest.java`, `ContractRuleLocalEvaluationTest.java`
+
+---
+
+## Pattern 18: Untyped Exception Expectation
+**Labels**: `correctness`
+
+**Failure class**: Test passes on any exception (including bugs like NPE or ClassCastException), not just the expected one.
+
+**Mechanism**: Tests use `Assertions.fail()` followed by `catch (Exception ignored) {}` instead of `assertThrows(SpecificException.class, ...)`.
+
+**Fix**: `assertThrows(ExpectedException.class, () -> { ... })`
+
+**Affected files**: `JsonSchemaSerdeTest.java` (15 occurrences), `AvroSerdeTest.java`
+
+---
+
+## Pattern 19: Reflective CDI Bypass
+**Labels**: `hygiene`
+
+**Failure class**: Test breaks at runtime (not compile time) when the target field is renamed or retyped.
+
+**Mechanism**: `Field.setAccessible(true)` to inject mocks into CDI-managed fields, bypassing the type system.
+
+**Fix**: Switch to constructor injection or `@InjectMock` (Quarkus) / `@Mock` + `@InjectMocks` (Mockito).
+
+**Affected files**: `OdcsTagProjectorTest.java`, `QualityScoreCalculatorTest.java`, `PromotionServiceTest.java`
+
+---
+
+## Pattern 20: Silent Validation Sink
+**Labels**: `correctness`
+
+**Failure class**: Schema validation appears tested but actually never fails the test.
+
+**Mechanism**: A validation helper catches `ValidationException`, prints it to stdout, and returns normally. The calling test never asserts the result.
+
+**Fix**: Propagate the exception or return a boolean; assert the result in the calling test.
+
+**Affected files**: `JsonSchemaSerdeTest.java`
+
+---
+
+## Pattern 21: Redundant Pre-Wait
+**Labels**: `timing`, `waste`
+
+**Failure class**: Test passes but wastes CI time proportional to the number of artifact operations.
+
+**Mechanism**: Fixed `Thread.sleep()` immediately before a retry/await loop that already handles eventual consistency. The sleep adds latency without improving reliability.
+
+**Estimated CI waste**: ~1s per createArtifact call across all 41 IT classes; 12s in SearchIT alone.
+
+**Fix**: Remove the `Thread.sleep()` call; the subsequent retry loop handles the wait.
+
+**Affected files**: `ApicurioRegistryBaseIT.java` (inherited by 41 classes), `SearchIT.java` (4 instances)
+
+---
+
+## Pattern 22: Orphaned Disabled Test
+**Labels**: `hygiene`
+
+**Failure class**: Dead code that accumulates silently. No path to resolution.
+
+**Mechanism**: Test classes or methods marked `@Disabled` with a textual reason but no link to a GitHub issue. Without a tracking issue, disabled tests become permanently abandoned.
+
+**Fix**: File a GitHub issue for each, add the issue URL: `@Disabled("Reason - see #NNNN")`. Delete if redesign is not planned.
+
+**Affected files**: `LoadIT.java`, `DoNotPreserveIdsImportIT.java`, `GenerateCanonicalHashImportIT.java`, `AvroSerdeIT.java`, `DebugTest.java`
+
+---
+
+## Pattern 23: Unbounded Recursive Retry
+**Labels**: `hygiene`
+
+**Failure class**: `StackOverflowError` instead of a diagnostic failure message.
+
+**Mechanism**: A method catches any Exception and calls itself recursively with no retry counter or depth limit.
+
+**Fix**: Add a `retryCount` parameter; fail with a clear message after N attempts.
+
+**Affected files**: `ITBase.java`
+
+---
+
+## Pattern 24: Sleep-Then-Assert-Stable
+**Labels**: `timing`, `waste`
+
+**Failure class**: Test passes but adds minutes of unconditional sleep per run.
+
+**Mechanism**: `Thread.sleep(30-60s)` followed by assertions that "nothing changed." Used for negative assertions (no upgrade occurred, no downgrade happened). Only checks the condition once at the end of the window.
+
+**Fix**: `await().during(ofSeconds(N)).atMost(maxDuration).untilAsserted(...)` polls continuously and fails fast if the condition breaks during the window.
+
+**Affected files**: `UpgradeOLMITTest.java` (3 occurrences; 2.5 minutes total)
+
+---
+
+## Pattern 25: Benchmark Masquerading as Test
+**Labels**: `waste`
+
+**Failure class**: CI time wasted on non-test code with no assertions.
+
+**Mechanism**: Benchmark methods annotated with `@Test` running millions of iterations, printing results to stdout only.
+
+**Fix**: Exclude from surefire via `@Tag("benchmark")` and a surefire `excludedGroups` configuration, or migrate to JMH.
+
+**Affected files**: `SerDesTracerBenchmark.java`
+
+---
+
+## Pattern 26: Existence-Only Assertion
+**Labels**: `correctness`
+
+**Failure class**: Test verifies connectivity but not correctness. A regression that changes returned data goes undetected.
+
+**Mechanism**: Tests that only use `assertNotNull` without checking the actual content of returned objects.
+
+**Fix**: Add value assertions (e.g., `assertEquals(expectedGroupId, result.getGroupId())`).
+
+**Affected files**: `McpAuthenticationTest.java`
+
+---
+
+---
+
+## Pattern 27: Side Effects Inside Awaitility Lambda
+**Labels**: `correctness`, `timing`
+
+**Failure class**: Test creates duplicate resources or corrupts state on retry. Intermittent 409 Conflict or constraint violations.
+
+**Mechanism**: Awaitility retries the entire lambda on assertion failure. If the lambda contains side effects (create, insert, register), those side effects execute on every retry, not just once.
+
+**Fix**: Separate the mutating operation from the polling assertion. Execute the mutation once before the `await()`, then poll for its effect.
+
+```java
+// BAD: createArtifact runs on every retry
+await().untilAsserted(() -> {
+    createArtifact(groupId, artifactId);
+    assertNotNull(getArtifact(groupId, artifactId));
+});
+
+// GOOD: create once, poll for result
+createArtifact(groupId, artifactId);
+await().untilAsserted(() -> {
+    assertNotNull(getArtifact(groupId, artifactId));
+});
+```
+
+---
+
+## Pattern 28: Awaitility Error Swallowing
+**Labels**: `correctness`
+
+**Failure class**: Test passes when it should fail. Errors inside the polling lambda are silently swallowed.
+
+**Mechanism**: `await().until(() -> condition)` swallows exceptions thrown inside the lambda and treats them as "condition not yet true" (retries). If the exception is a real bug (NPE, ClassCastException), the test waits until timeout and reports "condition not met" instead of the actual error.
+
+**Fix**: Use `untilAsserted()` instead of `until()` when the lambda contains assertions or can throw unexpected exceptions. `untilAsserted` propagates assertion errors on the last attempt.
+
+```java
+// BAD: NPE inside until() is swallowed, test times out
+await().atMost(10, SECONDS).until(() -> getResult().getName().equals("expected"));
+
+// GOOD: NPE propagates on last retry
+await().atMost(10, SECONDS).untilAsserted(() -> {
+    assertEquals("expected", getResult().getName());
+});
+```
+
+---
+
+---
+
+## Pattern 29: Async-Treated-as-Sync
+**Labels**: `timing`, `correctness`
+
+**Failure class**: Test passes individually but fails under parallel execution or CI load. Symptoms: resource collision from a previous test's teardown still in flight, "already exists" errors on resources that should have been deleted.
+
+**Mechanism**: An asynchronous operation (Kubernetes namespace delete, container stop, async HTTP POST) is treated as complete because the API call returned successfully. The caller proceeds to the next step without waiting for the operation to actually finish. Under parallel execution, the next test's setup collides with the previous test's still-in-flight teardown.
+
+**Example**: `ITBase.afterAll()` checked `assertThat(client.namespaces().delete()).isNotNull()` and returned. Kubernetes namespace deletion is asynchronous; the API server removes the namespace object only after all resources inside it (including Ingress hostnames) are garbage-collected. The next Auth test's Ingress creation raced against the stale namespace's deletion.
+
+**Fix**: Poll for the operation's actual completion before returning.
+
+```java
+// BAD: treat API acceptance as completion
+assertThat(client.namespaces().withName(ns).delete()).isNotNull();
+
+// GOOD: wait for actual termination
+client.namespaces().withName(ns).delete();
+await().atMost(60, SECONDS)
+    .until(() -> client.namespaces().withName(ns).get() == null);
+```
+
+**PRs**: #9800 (operator namespace teardown race)
+
+---
+
+## Pattern 30: Third-Party Thread Leak
+**Labels**: `concurrency`, `lifecycle`
+
+**Failure class**: `ConcurrentModificationException` or `KafkaConsumer is not safe for multi-threaded access` errors in test N+1 after test N timed out. Cascading failures across all subsequent tests in the class.
+
+**Mechanism**: A utility library (e.g., `org.rnorth.ducttape.Unreliables`) submits retry loops to a shared daemon thread pool. On timeout, `future.get(timeout, unit)` throws, but the submitted Runnable is never cancelled. The leaked thread continues to access shared mutable state (e.g., a KafkaConsumer field) after the caller has moved on. When the next test reassigns that field, the leaked thread and the new test collide.
+
+**Detection signal**: any use of `Unreliables.retryUntilTrue` or `retryUntilSuccess` with a shared mutable resource (consumer, producer, connection) as the retry target.
+
+**Fix**: Replace the library call with a caller-thread poll loop using an explicit deadline. No background threads, no leaked futures.
+
+```java
+// BAD: Unreliables leaks the retry thread on timeout
+Unreliables.retryUntilTrue(timeout, SECONDS, () -> {
+    ConsumerRecords<?, ?> records = consumer.poll(Duration.ofMillis(500));
+    return records.count() >= expected;
+});
+
+// GOOD: poll on the calling thread with a deadline
+long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(timeout);
+int total = 0;
+while (total < expected && System.currentTimeMillis() < deadline) {
+    ConsumerRecords<?, ?> records = consumer.poll(Duration.ofMillis(500));
+    total += records.count();
+}
+assertTrue(total >= expected, "Expected " + expected + " records, got " + total);
+```
+
+**PRs**: #9800 (Debezium Unreliables thread leak)
+
+---
+
+---
+
+## Pattern 29: Async-Treated-as-Sync
+**Labels**: `timing`, `correctness`
+
+**Failure class**: Test passes individually but fails under parallel execution. Resources collide from a previous test's teardown still in flight.
+
+**Mechanism**: An asynchronous operation (K8s namespace delete, container stop) is treated as complete because the API returned 200. The caller proceeds without waiting for actual completion.
+
+**Fix**: Poll for the operation's actual completion before returning.
+
+```java
+// BAD: treat API acceptance as completion
+assertThat(client.namespaces().withName(ns).delete()).isNotNull();
+
+// GOOD: wait for actual termination
+client.namespaces().withName(ns).delete();
+await().atMost(60, SECONDS).until(() -> client.namespaces().withName(ns).get() == null);
+```
+
+**PRs**: #9800 (operator namespace teardown race)
+
+---
+
+## Pattern 30: Third-Party Thread Leak
+**Labels**: `concurrency`, `lifecycle`
+
+**Failure class**: `ConcurrentModificationException` or thread-safety violations in test N+1 after test N timed out.
+
+**Mechanism**: A library (e.g., `Unreliables`) submits retry loops to a shared thread pool. On timeout, the submitted loop is never cancelled and continues accessing shared mutable state.
+
+**Fix**: Replace with a caller-thread poll loop using an explicit deadline.
+
+**PRs**: #9800 (Debezium Unreliables thread leak)
+
+---
+
+## Pattern 31: Vacuous Predicate on Empty Collection
+**Labels**: `correctness`
+
+**Failure class**: Test always passes regardless of the actual result.
+
+**Mechanism**: `Stream.allMatch()` returns `true` on an empty collection. A test that filters to an empty set and asserts `allMatch(condition)` passes vacuously.
+
+**Fix**: Assert the collection is non-empty before applying the predicate.
+
+**Issues**: #9327 (SearchCommandTest)
+
+---
+
+## Pattern 32: QuarkusTest Overuse
+**Labels**: `waste`
+
+**Failure class**: Test suite is slow. No correctness issue.
+
+**Mechanism**: Tests that only exercise pure logic use `@QuarkusTest`, booting the full runtime. 192 of 270 app tests (71%) use `@QuarkusTest`; 66 distinct profiles cause 66 restarts.
+
+**Fix**: Convert pure-logic tests to plain JUnit. Detection: test uses `@QuarkusTest` but has no CDI injection.
+
+**Source**: epic #9807
+
+---
+
+## Pattern 33: ParameterizedTest Underuse
+**Labels**: `hygiene`
+
+**Failure class**: Test maintenance burden. Copy-paste variants diverge.
+
+**Mechanism**: Multiple test methods with identical structure, varying one argument. Only 2.7% of tests use `@ParameterizedTest`.
+
+**Fix**: Convert to `@ParameterizedTest` with `@MethodSource` or `@EnumSource`.
+
+**Source**: epic #9807
+
+---
+
+## Cross-Cutting: Test Infrastructure Investments
+
+These are not patterns per se but infrastructure decisions that enabled the fixes above:
+
+| Investment | What it enables | PR |
+|---|---|---|
+| JUnit 5 class-level parallelism | Patterns 1, 5, 6, 7 | #9757 |
+| Byteman `-Pbyteman` profile | Pattern 3 | #9789 |
+| mock-oauth2-server | Pattern 10 | #9790 |
+| Awaitility everywhere | Patterns 2, 4, 9 | #8651, #8388 |
+| Surefire `rerunFailingTestsCount` | Pattern 8 (safety net) | #8388 |
+| Per-JVM infrastructure lifecycle | Patterns 5, 8 | #9722 |


### PR DESCRIPTION
## Summary

Contributes a score-based test quality review skill and a 30-pattern test failure catalog, both extracted from real CI fixes applied to this project.

## What this adds

**`/apicurio-test-quality` skill** (`.claude/skills/apicurio-test-quality/SKILL.md`): runs 4 detector agents in parallel against changed test files, each checking a labeled group of patterns. Produces a scored report (0-10 per category, weighted average). Score below 7.0 triggers automatic fix suggestions.

**30-pattern catalog** (`claudedocs/test-fix-pattern-catalog.md`): documents every recurring test failure class encountered in this project, with the root cause mechanism, a fix template with code, and the PR where it was proven. Patterns are labeled: `concurrency`, `timing`, `waste`, `lifecycle`, `correctness`, `hygiene`, `race`.

**Byteman testing guide** (`claudedocs/byteman-testing-guide.md`): how to use Byteman for deterministic race condition reproduction (Pattern 3).

## Where the patterns come from

Most patterns were extracted from Carles' CI overhaul work:
- #9722: fail-fast infrastructure, client timeouts, Strimzi cluster-wide install
- #9757: JUnit 5 class-level parallelism, static field contamination, KafkaFacade ref-counting
- #9798: Debezium cross-class contamination, HttpCompressionTest TOCTOU
- #9800: namespace teardown race, Unreliables thread leak, swallowed deployment errors
- #9795: trust-based CI gating (eliminated label race conditions)

Additional patterns from the concurrency audit (#9775, #9776, #9779) and two validation sweeps across 661 test files.

## How contributors use it

**Claude Code / Codex / Gemini CLI users**: the skill auto-suggests when test files are modified, or invoke manually with `/apicurio-test-quality`.

**Everyone else**: read `claudedocs/test-fix-pattern-catalog.md` for the patterns and fix templates.

## How it works

The skill launches 4 agents in parallel:
1. **Concurrency Safety** (P1, P5, P6, P7, P12): static field contamination, shared infra lifecycle, registration collision
2. **Timing & CI Waste** (P2, P4, P9, P17, P21, P24, P27, P28, P29): TOCTOU assertions, unbounded waits, redundant sleeps, async-as-sync
3. **Lifecycle & Hygiene** (P8, P11, P14, P16, P19, P22, P23, P30): failsafe rerun breakage, consumer leaks, orphaned disabled tests, thread leaks
4. **Correctness & Race Quality** (P3, P10, P13, P15, P18, P20, P25, P26): non-deterministic race tests, assertion-free tests, untyped exceptions

Validated with a clean-room sweep: 62.5% true-positive rate, zero false positives. Retroactive analysis of PR #9800 shows 71% coverage of Carles' 7 fixes.

## Test plan

- [x] Skill registers and auto-suggests (visible in system reminder)
- [x] `/apicurio-test-quality` produces scored report on 3 test files
- [x] Clean-room validation: 34 violations found across 661 files, 0 false positives
- [x] OpenCode symlink works
- [ ] Team feedback on naming, pattern completeness, and score threshold