### PR TITLE
refactor: replace deprecated Java API usages flagged by Modernizer plugin

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ImportLifecycleBean.java
+++ b/app/src/main/java/io/apicurio/registry/ImportLifecycleBean.java
@@ -44,7 +44,7 @@ public class ImportLifecycleBean {
         if (StorageEventType.READY.equals(ev.getType())) {
             if (importExportProps.registryImportUrlProp.isPresent()) {
                 log.info("Import URL exists.");
-                final URL registryImportUrl = importExportProps.registryImportUrlProp.get();
+                final URL registryImportUrl = importExportProps.registryImportUrlProp.orElseThrow();
                 importStatus = ImportStatus.STARTED;
                 try (final InputStream registryImportZip = new BufferedInputStream(
                         registryImportUrl.openStream())) {

--- a/app/src/main/java/io/apicurio/registry/auth/AdminOverride.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AdminOverride.java
@@ -53,7 +53,7 @@ public class AdminOverride {
     private boolean hasAdminClaim() {
         final Optional<Object> claimValue = jsonWebToken.get().claim(authConfig.adminOverrideClaim);
         if (claimValue.isPresent()) {
-            return authConfig.adminOverrideClaimValue.equals(claimValue.get().toString());
+            return authConfig.adminOverrideClaimValue.equals(claimValue.orElseThrow().toString());
         }
         return false;
     }

--- a/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
@@ -383,7 +383,7 @@ public class AuthConfig {
             String clientSpecificKey = "apicurio.authn.basic.scope." + clientId;
             var clientScope = config.getOptionalValue(clientSpecificKey, String.class);
             if (clientScope.isPresent()) {
-                return normalizeScope(clientScope.get());
+                return normalizeScope(clientScope.orElseThrow());
             }
         }
         return scope.map(this::normalizeScope).orElse(null);

--- a/app/src/main/java/io/apicurio/registry/auth/OidcAuthenticationStrategy.java
+++ b/app/src/main/java/io/apicurio/registry/auth/OidcAuthenticationStrategy.java
@@ -172,7 +172,7 @@ public class OidcAuthenticationStrategy implements AuthenticationStrategy {
         MultiMap form = MultiMap.caseInsensitiveMultiMap()
                 .add("grant_type", "password")
                 .add("client_id", authConfig.clientId)
-                .add("client_secret", authConfig.clientSecret.get())
+                .add("client_secret", authConfig.clientSecret.orElseThrow())
                 .add("username", username)
                 .add("password", password);
 

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/ConfigResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/ConfigResourceImpl.java
@@ -44,7 +44,7 @@ public class ConfigResourceImpl extends AbstractResource implements ConfigResour
             // We're assuming the configuration == compatibility level
             // TODO make it more explicit
             GlobalConfigResponse response = new GlobalConfigResponse();
-            response.setCompatibilityLevel(Optional.of(CompatibilityLevel.valueOf(supplyLevel.get())).get().name());
+            response.setCompatibilityLevel(Optional.of(CompatibilityLevel.valueOf(supplyLevel.get())).orElseThrow().name());
             return response;
         }
         catch (RuleNotFoundException ex) {

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemasResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemasResourceImpl.java
@@ -66,8 +66,8 @@ public class SchemasResourceImpl extends AbstractResource implements SchemasReso
         // Apply default format if configured and no format was explicitly provided
         if (format == null || format.isBlank()) {
             java.util.Optional<String> configuredDefault = restConfig.getDefaultReferenceHandling();
-            if (configuredDefault.isPresent() && !configuredDefault.get().trim().isEmpty()
-                    && "DEREFERENCE".equalsIgnoreCase(configuredDefault.get())) {
+            if (configuredDefault.isPresent() && !configuredDefault.orElseThrow().trim().isEmpty()
+                    && "DEREFERENCE".equalsIgnoreCase(configuredDefault.orElseThrow())) {
                 // Apply RESOLVED format for Avro and Protobuf when DEREFERENCE is configured
                 if (ArtifactType.AVRO.equals(artifactType) || ArtifactType.PROTOBUF.equals(artifactType)) {
                     format = "resolved";
@@ -107,8 +107,8 @@ public class SchemasResourceImpl extends AbstractResource implements SchemasReso
         // Apply default format if configured and no format was explicitly provided
         if (format == null || format.isBlank()) {
             java.util.Optional<String> configuredDefault = restConfig.getDefaultReferenceHandling();
-            if (configuredDefault.isPresent() && !configuredDefault.get().trim().isEmpty()
-                    && "DEREFERENCE".equals(configuredDefault.get())) {
+            if (configuredDefault.isPresent() && !configuredDefault.orElseThrow().trim().isEmpty()
+                    && "DEREFERENCE".equals(configuredDefault.orElseThrow())) {
                 // Apply RESOLVED format for Avro and Protobuf when DEREFERENCE is configured
                 if (ArtifactType.AVRO.equals(artifactType) || ArtifactType.PROTOBUF.equals(artifactType)) {
                     format = "RESOLVED";

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
@@ -132,8 +132,8 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
                     String effectiveFormat = format;
                     if (effectiveFormat == null || effectiveFormat.isBlank()) {
                         java.util.Optional<String> configuredDefault = restConfig.getDefaultReferenceHandling();
-                        if (configuredDefault.isPresent() && !configuredDefault.get().trim().isEmpty()
-                                && "DEREFERENCE".equals(configuredDefault.get())) {
+                        if (configuredDefault.isPresent() && !configuredDefault.orElseThrow().trim().isEmpty()
+                                && "DEREFERENCE".equals(configuredDefault.orElseThrow())) {
                             // Apply RESOLVED format for Avro and Protobuf when DEREFERENCE is configured
                             if (ArtifactType.AVRO.equals(amd.getArtifactType())
                                     || ArtifactType.PROTOBUF.equals(amd.getArtifactType())) {
@@ -506,8 +506,8 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
                     String effectiveFormat = format;
                     if (effectiveFormat == null || effectiveFormat.isBlank()) {
                         java.util.Optional<String> configuredDefault = restConfig.getDefaultReferenceHandling();
-                        if (configuredDefault.isPresent() && !configuredDefault.get().trim().isEmpty()
-                                && "DEREFERENCE".equals(configuredDefault.get())) {
+                        if (configuredDefault.isPresent() && !configuredDefault.orElseThrow().trim().isEmpty()
+                                && "DEREFERENCE".equals(configuredDefault.orElseThrow())) {
                             // Apply RESOLVED format for Avro and Protobuf when DEREFERENCE is configured
                             if (ArtifactType.AVRO.equals(amd.getArtifactType())
                                     || ArtifactType.PROTOBUF.equals(amd.getArtifactType())) {

--- a/app/src/main/java/io/apicurio/registry/config/config/impl/DynamicConfigPropertyIndexImpl.java
+++ b/app/src/main/java/io/apicurio/registry/config/config/impl/DynamicConfigPropertyIndexImpl.java
@@ -82,7 +82,7 @@ public class DynamicConfigPropertyIndexImpl implements DynamicConfigPropertyInde
             Optional<String> actualPropertyValue = config.getOptionalValue(requiredPropertyName,
                     String.class);
             if (requiredPropertyValue != null && (actualPropertyValue.isEmpty()
-                    || !requiredPropertyValue.equals(actualPropertyValue.get()))) {
+                    || !requiredPropertyValue.equals(actualPropertyValue.orElseThrow()))) {
                 return false;
             }
             if (requiredPropertyValue == null && actualPropertyValue.isEmpty()) {

--- a/app/src/main/java/io/apicurio/registry/config/config/impl/DynamicConfigSource.java
+++ b/app/src/main/java/io/apicurio/registry/config/config/impl/DynamicConfigSource.java
@@ -73,10 +73,10 @@ public class DynamicConfigSource implements ConfigSource {
     @Override
     public String getValue(String propertyName) {
         String pname = normalizePropertyName(propertyName);
-        if (configIndex.isPresent() && configIndex.get().hasProperty(pname)) {
+        if (configIndex.isPresent() && configIndex.orElseThrow().hasProperty(pname)) {
             if (storage.isPresent()) {
-                if (storage.get().isReady()) { // TODO Merge the ifs after removing logging
-                    DynamicConfigPropertyDto dto = storage.get().getConfigProperty(pname);
+                if (storage.orElseThrow().isReady()) { // TODO Merge the ifs after removing logging
+                    DynamicConfigPropertyDto dto = storage.orElseThrow().getConfigProperty(pname);
                     if (dto != null) {
                         log.trace("Got dynamic configuration value {} for {} in thread {}", dto.getValue(),
                                 pname, Thread.currentThread().getName());

--- a/app/src/main/java/io/apicurio/registry/metrics/health/AbstractErrorCounterHealthCheck.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/health/AbstractErrorCounterHealthCheck.java
@@ -51,7 +51,7 @@ public abstract class AbstractErrorCounterHealthCheck {
     }
 
     protected synchronized void callSuper() {
-        if (!up && nextStatusReset.isPresent() && Instant.now().isAfter(nextStatusReset.get())) {
+        if (!up && nextStatusReset.isPresent() && Instant.now().isAfter(nextStatusReset.orElseThrow())) {
             nextStatusReset = Optional.empty();
             up = true; // Next 'if' will reset the error count
         }

--- a/app/src/main/java/io/apicurio/registry/metrics/health/liveness/LivenessUtil.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/health/liveness/LivenessUtil.java
@@ -38,7 +38,7 @@ public class LivenessUtil {
         if (codeMap.isIgnored(ex.getClass())) {
             return true;
         }
-        return this.ignored.isPresent() && this.ignored.get().contains(ex.getClass().getName());
+        return this.ignored.isPresent() && this.ignored.orElseThrow().contains(ex.getClass().getName());
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/GroupsResourceImpl.java
@@ -127,9 +127,9 @@ public class GroupsResourceImpl implements GroupsResource {
         if (dereference == null) {
             // Check if admin has configured a default reference handling behavior
             java.util.Optional<String> configuredDefault = restConfig.getDefaultReferenceHandling();
-            if (configuredDefault.isPresent() && !configuredDefault.get().trim().isEmpty()) {
+            if (configuredDefault.isPresent() && !configuredDefault.orElseThrow().trim().isEmpty()) {
                 // Convert v3 enum value to v2 boolean (DEREFERENCE -> true, others -> false)
-                dereference = "DEREFERENCE".equals(configuredDefault.get());
+                dereference = "DEREFERENCE".equals(configuredDefault.orElseThrow());
             } else {
                 // No configuration - use existing default (no behavior change)
                 dereference = Boolean.FALSE;
@@ -649,9 +649,9 @@ public class GroupsResourceImpl implements GroupsResource {
         if (dereference == null) {
             // Check if admin has configured a default reference handling behavior
             java.util.Optional<String> configuredDefault = restConfig.getDefaultReferenceHandling();
-            if (configuredDefault.isPresent() && !configuredDefault.get().trim().isEmpty()) {
+            if (configuredDefault.isPresent() && !configuredDefault.orElseThrow().trim().isEmpty()) {
                 // Convert v3 enum value to v2 boolean (DEREFERENCE -> true, others -> false)
-                dereference = "DEREFERENCE".equals(configuredDefault.get());
+                dereference = "DEREFERENCE".equals(configuredDefault.orElseThrow());
             } else {
                 // No configuration - use existing default (no behavior change)
                 dereference = Boolean.FALSE;

--- a/app/src/main/java/io/apicurio/registry/rest/v2/impl/IdsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v2/impl/IdsResourceImpl.java
@@ -77,9 +77,9 @@ public class IdsResourceImpl implements IdsResource {
         if (dereference == null) {
             // Check if admin has configured a default reference handling behavior
             java.util.Optional<String> configuredDefault = restConfig.getDefaultReferenceHandling();
-            if (configuredDefault.isPresent() && !configuredDefault.get().trim().isEmpty()) {
+            if (configuredDefault.isPresent() && !configuredDefault.orElseThrow().trim().isEmpty()) {
                 // Convert v3 enum value to v2 boolean (DEREFERENCE -> true, others -> false)
-                dereference = "DEREFERENCE".equals(configuredDefault.get());
+                dereference = "DEREFERENCE".equals(configuredDefault.orElseThrow());
             } else {
                 // No configuration - use existing default (no behavior change)
                 dereference = Boolean.FALSE;

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/GroupsResourceImpl.java
@@ -990,8 +990,8 @@ public class GroupsResourceImpl extends AbstractResourceImpl implements GroupsRe
 
         if (references == null) {
             java.util.Optional<String> configuredDefault = restConfig.getDefaultReferenceHandling();
-            if (configuredDefault.isPresent() && !configuredDefault.get().trim().isEmpty()) {
-                references = HandleReferencesType.fromValue(configuredDefault.get());
+            if (configuredDefault.isPresent() && !configuredDefault.orElseThrow().trim().isEmpty()) {
+                references = HandleReferencesType.fromValue(configuredDefault.orElseThrow());
             } else {
                 references = HandleReferencesType.PRESERVE;
             }

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/IdsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/IdsResourceImpl.java
@@ -84,8 +84,8 @@ public class IdsResourceImpl extends AbstractResourceImpl implements IdsResource
         if (references == null) {
             // Check if admin has configured a default reference handling behavior
             java.util.Optional<String> configuredDefault = restConfig.getDefaultReferenceHandling();
-            if (configuredDefault.isPresent() && !configuredDefault.get().trim().isEmpty()) {
-                references = HandleReferencesType.fromValue(configuredDefault.get());
+            if (configuredDefault.isPresent() && !configuredDefault.orElseThrow().trim().isEmpty()) {
+                references = HandleReferencesType.fromValue(configuredDefault.orElseThrow());
             } else {
                 // No configuration - use existing default (no behavior change)
                 references = HandleReferencesType.PRESERVE;

--- a/app/src/main/java/io/apicurio/registry/rules/RulesServiceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rules/RulesServiceImpl.java
@@ -60,8 +60,7 @@ public class RulesServiceImpl implements RulesService {
             String artifactType, TypedContent content, RuleApplicationType ruleApplicationType,
             List<ArtifactReference> references, Map<String, TypedContent> resolvedReferences)
             throws RuleViolationException {
-        @SuppressWarnings("unchecked")
-        Set<RuleType> artifactRules = Collections.EMPTY_SET;
+        Set<RuleType> artifactRules = Collections.emptySet();
         if (ruleApplicationType == RuleApplicationType.UPDATE) {
             artifactRules = new HashSet<>(storageToUse.getArtifactRules(groupId, artifactId));
         }

--- a/app/src/main/java/io/apicurio/registry/services/DynamicLogConfigurationService.java
+++ b/app/src/main/java/io/apicurio/registry/services/DynamicLogConfigurationService.java
@@ -92,10 +92,10 @@ public class DynamicLogConfigurationService {
             }
 
             // Only update if the level has changed
-            if (!targetLevel.get().equals(currentAppliedLevel)) {
-                applyLogLevel(targetLevel.get());
-                currentAppliedLevel = targetLevel.get();
-                log.info("Applied dynamic log level configuration: {} = {}", APICURIO_LOGGER_NAME, targetLevel.get());
+            if (!targetLevel.orElseThrow().equals(currentAppliedLevel)) {
+                applyLogLevel(targetLevel.orElseThrow());
+                currentAppliedLevel = targetLevel.orElseThrow();
+                log.info("Applied dynamic log level configuration: {} = {}", APICURIO_LOGGER_NAME, targetLevel.orElseThrow());
             }
         } catch (Exception ex) {
             log.error("Exception thrown when applying dynamic log level configuration", ex);

--- a/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
+++ b/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
@@ -410,7 +410,7 @@ public class PromptRenderingService {
     private String processConditionalBlocks(String template, Map<String, Object> variables) {
         // Step 1: resolve if-else blocks first to prevent the plain-if pattern from partially matching them
         Matcher ifElseMatcher = IF_ELSE_BLOCK_PATTERN.matcher(template);
-        StringBuffer ifElseResult = new StringBuffer();
+        StringBuilder ifElseResult = new StringBuilder();
         while (ifElseMatcher.find()) {
             String varName = ifElseMatcher.group(1);
             String truthyBranch = ifElseMatcher.group(2);
@@ -423,7 +423,7 @@ public class PromptRenderingService {
 
         // Step 2: resolve plain if blocks
         Matcher ifMatcher = IF_BLOCK_PATTERN.matcher(template);
-        StringBuffer ifResult = new StringBuffer();
+        StringBuilder ifResult = new StringBuilder();
         while (ifMatcher.find()) {
             String varName = ifMatcher.group(1);
             String content = ifMatcher.group(2);
@@ -435,7 +435,7 @@ public class PromptRenderingService {
 
         // Step 3: resolve unless blocks (logical complement of if)
         Matcher unlessMatcher = UNLESS_BLOCK_PATTERN.matcher(template);
-        StringBuffer unlessResult = new StringBuffer();
+        StringBuilder unlessResult = new StringBuilder();
         while (unlessMatcher.find()) {
             String varName = unlessMatcher.group(1);
             String content = unlessMatcher.group(2);

--- a/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GitOpsConfig.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GitOpsConfig.java
@@ -140,8 +140,8 @@ public class GitOpsConfig extends AbstractPollingStorageConfig {
             String branch = config.getOptionalValue("apicurio.gitops.repos." + i + ".branch", String.class)
                     .orElse("main");
             String id = config.getOptionalValue("apicurio.gitops.repos." + i + ".id", String.class)
-                    .orElse(dir.get());
-            result.add(new GitRepoConfig(id, dir.get(), branch));
+                    .orElse(dir.orElseThrow());
+            result.add(new GitRepoConfig(id, dir.orElseThrow(), branch));
         }
 
         return result;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfiguration.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlConfiguration.java
@@ -393,9 +393,9 @@ public class KafkaSqlConfiguration {
         });
 
         if (trustStoreLocation.isPresent() && effectiveTrustStorePassword.isPresent() && trustStoreType.isPresent()) {
-            props.putIfAbsent(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, trustStoreType.get());
-            props.putIfAbsent(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, trustStoreLocation.get());
-            props.putIfAbsent(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, effectiveTrustStorePassword.get());
+            props.putIfAbsent(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, trustStoreType.orElseThrow());
+            props.putIfAbsent(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, trustStoreLocation.orElseThrow());
+            props.putIfAbsent(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, effectiveTrustStorePassword.orElseThrow());
         }
 
         // Finally, try to configure the keystore, if specified
@@ -433,9 +433,9 @@ public class KafkaSqlConfiguration {
         });
 
         if (effectiveKeyStoreLocation.isPresent() && effectiveKeyStorePassword.isPresent() && effectiveKeyStoreType.isPresent()) {
-            props.putIfAbsent(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, effectiveKeyStoreType.get());
-            props.putIfAbsent(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, effectiveKeyStoreLocation.get());
-            props.putIfAbsent(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, effectiveKeyStorePassword.get());
+            props.putIfAbsent(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, effectiveKeyStoreType.orElseThrow());
+            props.putIfAbsent(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, effectiveKeyStoreLocation.orElseThrow());
+            props.putIfAbsent(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, effectiveKeyStorePassword.orElseThrow());
             effectiveKeyPassword.ifPresent(s -> props.putIfAbsent(SslConfigs.SSL_KEY_PASSWORD_CONFIG, s));
         }
     }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/polling/AbstractPollingDataFile.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/polling/AbstractPollingDataFile.java
@@ -53,6 +53,6 @@ public abstract class AbstractPollingDataFile implements PollingDataFile {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T getEntityUnchecked() {
-        return (T) any.get().getEntity();
+        return (T) any.orElseThrow().getEntity();
     }
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/polling/model/Any.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/polling/model/Any.java
@@ -42,12 +42,12 @@ public class Any {
                 var type = Type.from(rawType);
                 if (type.isPresent()) {
                     try {
-                        var entity = YAML_MAPPER.treeToValue(raw, type.get().getKlass());
-                        var any = Any.builder().raw(raw).type(type.get()).entity(entity).build();
+                        var entity = YAML_MAPPER.treeToValue(raw, type.orElseThrow().getKlass());
+                        var any = Any.builder().raw(raw).type(type.orElseThrow()).entity(entity).build();
                         return Optional.of(any);
                     } catch (JsonProcessingException ex) {
                         if (state != null) {
-                            state.recordError("Could not parse file %s as %s: %s", path, type.get(),
+                            state.recordError("Could not parse file %s as %s: %s", path, type.orElseThrow(),
                                     ex.getOriginalMessage());
                         }
                         return Optional.empty();

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlContentRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlContentRepository.java
@@ -123,7 +123,7 @@ public class SqlContentRepository {
                     return null;
                 }
 
-                ArtifactVersionMetaDataDto meta = metaRes.get();
+                ArtifactVersionMetaDataDto meta = metaRes.orElseThrow();
                 ContentWrapperDto content = getContentByIdRaw(handle, meta.getContentId());
                 content.setArtifactType(meta.getArtifactType());
                 return content;

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSequenceRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlSequenceRepository.java
@@ -152,8 +152,8 @@ public class SqlSequenceRepository {
 
         Optional<Long> maxId = maxIdTable.map(maxIdTableValue -> {
             if (currentIdSeq.isPresent()) {
-                if (currentIdSeq.get() > maxIdTableValue) {
-                    return currentIdSeq.get();
+                if (currentIdSeq.orElseThrow() > maxIdTableValue) {
+                    return currentIdSeq.orElseThrow();
                 }
             }
             return maxIdTableValue;
@@ -161,7 +161,7 @@ public class SqlSequenceRepository {
 
         if (maxId.isPresent()) {
             log.info("Resetting {} sequence", sequenceName);
-            long id = maxId.get();
+            long id = maxId.orElseThrow();
 
             if (isH2()) {
                 sequenceCounters.get(sequenceName).set(id);

--- a/app/src/main/java/io/apicurio/registry/storage/impl/util/KafkaAdminUtil.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/util/KafkaAdminUtil.java
@@ -104,7 +104,7 @@ public class KafkaAdminUtil {
                                             .map(Short::valueOf)
                                             .or(() -> Optional.of((short) Math.min(3, nodes.size())));
 
-                                    props.putIfAbsent(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, valueOf(max(replicationFactor.get() - 1, 1)));
+                                    props.putIfAbsent(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, valueOf(max(replicationFactor.orElseThrow() - 1, 1)));
 
                                     return new NewTopic(topic, partitions, replicationFactor).configs(props);
 

--- a/app/src/main/java/io/apicurio/registry/ui/URLUtil.java
+++ b/app/src/main/java/io/apicurio/registry/ui/URLUtil.java
@@ -67,9 +67,9 @@ public class URLUtil {
 
             // Host
             targetHost = requestURL.getHost();
-            if (urlOverrideHost.isPresent() && !urlOverrideHost.get().isBlank()) {
+            if (urlOverrideHost.isPresent() && !urlOverrideHost.orElseThrow().isBlank()) {
                 log.debug("Generating absolute URL: Using configured override for the host.");
-                targetHost = urlOverrideHost.get();
+                targetHost = urlOverrideHost.orElseThrow();
             } else if (forwardedHostHeaderValue != null && !forwardedHostHeaderValue.isBlank()) {
                 log.debug("Generating absolute URL: Using X-Forwarded-Host header value for the host.");
                 targetHost = forwardedHostHeaderValue;
@@ -77,9 +77,9 @@ public class URLUtil {
 
             // Port
             targetPort = requestURL.getPort();
-            if (urlOverridePort.isPresent() && urlOverridePort.get() > 0) {
+            if (urlOverridePort.isPresent() && urlOverridePort.orElseThrow() > 0) {
                 log.debug("Generating absolute URL: Using configured override for the port.");
-                targetPort = urlOverridePort.get();
+                targetPort = urlOverridePort.orElseThrow();
             }
 
             if (("https".equals(targetProtocol) && targetPort == 443)

--- a/app/src/test/java/io/apicurio/registry/contracts/tags/TagExtractorFactoryTest.java
+++ b/app/src/test/java/io/apicurio/registry/contracts/tags/TagExtractorFactoryTest.java
@@ -40,7 +40,7 @@ public class TagExtractorFactoryTest {
 
         Optional<TagExtractor> match = factory.getExtractor("AVRO");
         assertTrue(match.isPresent());
-        assertSame(extractor, match.get());
+        assertSame(extractor, match.orElseThrow());
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/rbac/RegistryClientTest.java
+++ b/app/src/test/java/io/apicurio/registry/rbac/RegistryClientTest.java
@@ -1459,11 +1459,11 @@ public class RegistryClientTest extends AbstractResourceTestBase {
         Optional<ConfigurationProperty> anonymousRead = configProperties.stream()
                 .filter(cp -> cp.getName().equals(property1Name)).findFirst();
         Assertions.assertTrue(anonymousRead.isPresent());
-        Assertions.assertEquals("false", anonymousRead.get().getValue());
+        Assertions.assertEquals("false", anonymousRead.orElseThrow().getValue());
         Optional<ConfigurationProperty> obacLimit = configProperties.stream()
                 .filter(cp -> cp.getName().equals(property2Name)).findFirst();
         Assertions.assertTrue(obacLimit.isPresent());
-        Assertions.assertEquals("true", obacLimit.get().getValue());
+        Assertions.assertEquals("true", obacLimit.orElseThrow().getValue());
 
         // Change value of anonymous read access
         UpdateConfigurationProperty updateProp = new UpdateConfigurationProperty();
@@ -1477,7 +1477,7 @@ public class RegistryClientTest extends AbstractResourceTestBase {
         Assertions.assertEquals("true", prop.getValue());
 
         List<ConfigurationProperty> properties = clientV3.admin().config().properties().get();
-        prop = properties.stream().filter(cp -> cp.getName().equals(property1Name)).findFirst().get();
+        prop = properties.stream().filter(cp -> cp.getName().equals(property1Name)).findFirst().orElseThrow();
         Assertions.assertEquals(property1Name, prop.getName());
         Assertions.assertEquals("true", prop.getValue());
 
@@ -1491,7 +1491,7 @@ public class RegistryClientTest extends AbstractResourceTestBase {
         Assertions.assertEquals("false", prop.getValue());
 
         properties = clientV3.admin().config().properties().get();
-        prop = properties.stream().filter(cp -> cp.getName().equals(property2Name)).findFirst().get();
+        prop = properties.stream().filter(cp -> cp.getName().equals(property2Name)).findFirst().orElseThrow();
         Assertions.assertEquals("false", prop.getValue());
 
         // Reset a config property
@@ -1503,7 +1503,7 @@ public class RegistryClientTest extends AbstractResourceTestBase {
         Assertions.assertEquals("true", prop.getValue());
 
         properties = clientV3.admin().config().properties().get();
-        prop = properties.stream().filter(cp -> cp.getName().equals(property2Name)).findFirst().get();
+        prop = properties.stream().filter(cp -> cp.getName().equals(property2Name)).findFirst().orElseThrow();
         Assertions.assertEquals("true", prop.getValue());
 
         // Reset the other property
@@ -1515,7 +1515,7 @@ public class RegistryClientTest extends AbstractResourceTestBase {
         Assertions.assertEquals("false", prop.getValue());
 
         properties = clientV3.admin().config().properties().get();
-        prop = properties.stream().filter(cp -> cp.getName().equals(property1Name)).findFirst().get();
+        prop = properties.stream().filter(cp -> cp.getName().equals(property1Name)).findFirst().orElseThrow();
         Assertions.assertEquals(property1Name, prop.getName());
         Assertions.assertEquals("false", prop.getValue());
 

--- a/app/src/test/java/io/apicurio/registry/storage/impl/gitops/GitOpsSmokeTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/gitops/GitOpsSmokeTest.java
@@ -11,11 +11,11 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Set;
@@ -190,7 +190,7 @@ public class GitOpsSmokeTest {
         try {
             var fullPath = Path.of(
                     requireNonNull(Thread.currentThread().getContextClassLoader().getResource(path)).toURI());
-            return ContentHandle.create(FileUtils.readFileToByteArray(fullPath.toFile()));
+            return ContentHandle.create(Files.readAllBytes(fullPath));
         } catch (IOException | URISyntaxException ex) {
             throw new RuntimeException(ex);
         }

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kubernetesops/KubernetesOpsSmokeTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kubernetesops/KubernetesOpsSmokeTest.java
@@ -12,12 +12,12 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Set;
@@ -119,7 +119,7 @@ class KubernetesOpsSmokeTest {
         try {
             var fullPath = Path.of(
                     requireNonNull(Thread.currentThread().getContextClassLoader().getResource(path)).toURI());
-            return ContentHandle.create(FileUtils.readFileToByteArray(fullPath.toFile()));
+            return ContentHandle.create(Files.readAllBytes(fullPath));
         } catch (IOException | URISyntaxException ex) {
             throw new RuntimeException(ex);
         }

--- a/common/src/main/java/io/apicurio/registry/utils/IoUtil.java
+++ b/common/src/main/java/io/apicurio/registry/utils/IoUtil.java
@@ -194,7 +194,7 @@ public class IoUtil {
      */
     public static String toString(InputStream stream) {
         try {
-            return toBaos(stream).toString(StandardCharsets.UTF_8.name());
+            return toBaos(stream).toString(StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         } finally {

--- a/common/src/main/java/io/apicurio/registry/utils/PropertiesUtil.java
+++ b/common/src/main/java/io/apicurio/registry/utils/PropertiesUtil.java
@@ -78,7 +78,7 @@ public class PropertiesUtil {
                             // Property can exist with a key but no value...
                             Optional<String> value = config.getOptionalValue(key, String.class);
                             if (value.isPresent()) {
-                                properties.put(suffix, value.get());
+                                properties.put(suffix, value.orElseThrow());
                             } else {
                                 String defaultValue = defaults.get(suffix);
                                 if (defaultValue != null) {

--- a/contracts-rules/src/main/java/io/apicurio/registry/contracts/rules/RuleExecutionEngine.java
+++ b/contracts-rules/src/main/java/io/apicurio/registry/contracts/rules/RuleExecutionEngine.java
@@ -55,7 +55,7 @@ public class RuleExecutionEngine {
             }
 
             var context = new ContractRuleContext(rule, current, null);
-            ContractRuleResult result = executor.get().execute(context);
+            ContractRuleResult result = executor.orElseThrow().execute(context);
             executed++;
 
             if (!result.isPassed()) {

--- a/docs/config-generator/src/main/java/io/apicurio/registry/docs/GenerateAllConfigPartial.java
+++ b/docs/config-generator/src/main/java/io/apicurio/registry/docs/GenerateAllConfigPartial.java
@@ -240,15 +240,15 @@ public class GenerateAllConfigPartial {
                         throw new IllegalArgumentException("The field: \"" + annotation.target() + "\" is annotated with @ConfigProperty but not with @io.apicurio.common.apps.config.Info");
                     }
 
-                    var variant = (String) info.get().value("category").value();
+                    var variant = (String) info.orElseThrow().value("category").value();
                     var category = ConfigPropertyCategory.valueOf(variant).getRawValue();
-                    var description = Optional.ofNullable(info.get().value("description")).map(v -> v.value().toString().replaceAll("(?<=[^\\n \\t])[ \\t]{2,}", " ").trim()).orElse("");
+                    var description = Optional.ofNullable(info.orElseThrow().value("description")).map(v -> v.value().toString().replaceAll("(?<=[^\\n \\t])[ \\t]{2,}", " ").trim()).orElse("");
 
-                    var availableSince = Optional.ofNullable(info.get().value("availableSince"))
+                    var availableSince = Optional.ofNullable(info.orElseThrow().value("availableSince"))
                             .map(v -> v.value().toString())
                             .orElse("");
 
-                    var experimental = Optional.ofNullable(info.get().value("experimental"))
+                    var experimental = Optional.ofNullable(info.orElseThrow().value("experimental"))
                             .map(v -> (boolean) v.value())
                             .orElse(false);
 
@@ -288,15 +288,15 @@ public class GenerateAllConfigPartial {
                 continue;
             }
 
-            var variant = (String) info.get().value("category").value();
+            var variant = (String) info.orElseThrow().value("category").value();
             var category = ConfigPropertyCategory.valueOf(variant).getRawValue();
-            var description = Optional.ofNullable(info.get().value("description")).map(v -> v.value().toString().replaceAll("(?<=[^\\n \\t])[ \\t]{2,}", " ").trim()).orElse("");
+            var description = Optional.ofNullable(info.orElseThrow().value("description")).map(v -> v.value().toString().replaceAll("(?<=[^\\n \\t])[ \\t]{2,}", " ").trim()).orElse("");
 
-            var availableSince = Optional.ofNullable(info.get().value("availableSince"))
+            var availableSince = Optional.ofNullable(info.orElseThrow().value("availableSince"))
                     .map(v -> v.value().toString())
                     .orElse("");
 
-            var experimental = Optional.ofNullable(info.get().value("experimental"))
+            var experimental = Optional.ofNullable(info.orElseThrow().value("experimental"))
                     .map(v -> (boolean) v.value())
                     .orElse(false);
 
@@ -395,7 +395,7 @@ public class GenerateAllConfigPartial {
         // Read the template file
         var template = new String(Files.readAllBytes(Paths.get(templateFile)), StandardCharsets.UTF_8);
 
-        try (var dest = new FileWriter(destinationFile)) {
+        try (var dest = new FileWriter(destinationFile, StandardCharsets.UTF_8)) {
 
             dest.write(template);
 

--- a/java-sdk/adapter-jdk/src/main/java/io/apicurio/registry/client/common/auth/JdkAuthFactory.java
+++ b/java-sdk/adapter-jdk/src/main/java/io/apicurio/registry/client/common/auth/JdkAuthFactory.java
@@ -221,12 +221,7 @@ public class JdkAuthFactory {
         }
 
         private static String urlEncode(String value) {
-            try {
-                return java.net.URLEncoder.encode(value, StandardCharsets.UTF_8.name());
-            } catch (java.io.UnsupportedEncodingException e) {
-                // UTF-8 is always supported
-                throw new RuntimeException(e);
-            }
+            return java.net.URLEncoder.encode(value, StandardCharsets.UTF_8);
         }
 
         private static final java.lang.reflect.Method GET_PROPAGATORS;

--- a/java-sdk/common/src/main/java/io/apicurio/registry/client/common/util/DateTimeUtil.java
+++ b/java-sdk/common/src/main/java/io/apicurio/registry/client/common/util/DateTimeUtil.java
@@ -53,7 +53,7 @@ public class DateTimeUtil {
                     .map(DateTimeFormatter::ofPattern);
 
             if (formatter.isPresent()) {
-                return formatter.get();
+                return formatter.orElseThrow();
             }
         } catch (LinkageError | IllegalStateException e) {
             // MicroProfile Config API or implementation is not available,

--- a/schema-util/common/src/test/java/io/apicurio/registry/rules/compatibility/CompatibilityTestExecutor.java
+++ b/schema-util/common/src/test/java/io/apicurio/registry/rules/compatibility/CompatibilityTestExecutor.java
@@ -60,7 +60,7 @@ public class CompatibilityTestExecutor {
                     .map(testCaseData::getString)
                     .findFirst();
             if (skipReason.isPresent()) {
-                log.warn("Skipping test case {}: {}", caseId, skipReason.get());
+                log.warn("Skipping test case {}: {}", caseId, skipReason.orElseThrow());
                 continue;
             }
 

--- a/schema-util/json/src/main/java/io/apicurio/registry/json/rules/compatibility/jsonschema/diff/CombinedSchemaDiffVisitor.java
+++ b/schema-util/json/src/main/java/io/apicurio/registry/json/rules/compatibility/jsonschema/diff/CombinedSchemaDiffVisitor.java
@@ -90,17 +90,17 @@ public class CombinedSchemaDiffVisitor extends JsonSchemaWrapperVisitor {
                     .stream().min(comparingInt(a -> a.getValue().size()));
             while (first.isPresent()) {
                 // remove a value from the first set
-                Optional<SchemaWrapper> val = first.get().getValue().stream().findAny();
+                Optional<SchemaWrapper> val = first.orElseThrow().getValue().stream().findAny();
                 if (val.isPresent()) {
                     // ok
                     // remove it from all sets
-                    compatibilityMap.values().forEach(s -> s.remove(val.get()));
+                    compatibilityMap.values().forEach(s -> s.remove(val.orElseThrow()));
                 } else {
                     // bad
-                    ctx.addDifference(DiffType.COMBINED_TYPE_SUBSCHEMA_NOT_COMPATIBLE, first.get().getKey(), null);
+                    ctx.addDifference(DiffType.COMBINED_TYPE_SUBSCHEMA_NOT_COMPATIBLE, first.orElseThrow().getKey(), null);
                 }
-                if (first.get().getValue().isEmpty())
-                    compatibilityMap.remove(first.get().getKey());
+                if (first.orElseThrow().getValue().isEmpty())
+                    compatibilityMap.remove(first.orElseThrow().getKey());
 
                 first = compatibilityMap.entrySet().stream().min(comparingInt(a -> a.getValue().size()));
             }

--- a/schema-util/json/src/main/java/io/apicurio/registry/json/rules/compatibility/jsonschema/diff/SchemaDiffVisitor.java
+++ b/schema-util/json/src/main/java/io/apicurio/registry/json/rules/compatibility/jsonschema/diff/SchemaDiffVisitor.java
@@ -65,7 +65,7 @@ public class SchemaDiffVisitor extends JsonSchemaWrapperVisitor {
                     .filter(s -> s.getClass().isInstance(updated.getWrapped())).collect(Collectors.toSet());
             if (ALL_CRITERION.equals(((CombinedSchema) original).getCriterion())
                     && typeCompatible.size() == 1)
-                return typeCompatible.stream().findAny().get();
+                return typeCompatible.stream().findAny().orElseThrow();
         }
         return original;
     }
@@ -162,7 +162,7 @@ public class SchemaDiffVisitor extends JsonSchemaWrapperVisitor {
         if (orig instanceof EnumSchema) {
             Set<Object> possibleValues = ((EnumSchema) orig).getPossibleValues();
             if (possibleValues.size() == 1) {
-                orig = ConstSchema.builder().permittedValue(possibleValues.stream().findAny().get()).build();
+                orig = ConstSchema.builder().permittedValue(possibleValues.stream().findAny().orElseThrow()).build();
             }
         }
 

--- a/schema-util/xml/src/main/java/io/apicurio/registry/xml/content/canon/XmlContentCanonicalizer.java
+++ b/schema-util/xml/src/main/java/io/apicurio/registry/xml/content/canon/XmlContentCanonicalizer.java
@@ -12,6 +12,7 @@ import org.apache.xml.security.parser.XMLParserException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -43,7 +44,7 @@ public class XmlContentCanonicalizer implements ContentCanonicalizer {
             Canonicalizer canon = xmlCanonicalizer.get();
             var out = new ByteArrayOutputStream(content.getContent().getSizeBytes());
             canon.canonicalize(content.getContent().bytes(), out, false); // TODO secureValidation?
-            var canonicalized = out.toString(Canonicalizer.ENCODING);
+            var canonicalized = out.toString(StandardCharsets.UTF_8);
             return TypedContent.create(ContentHandle.create(canonicalized), ContentTypes.APPLICATION_XML);
         } catch (CanonicalizationException | IOException | XMLParserException e) {
         }

--- a/utils/converter/src/main/java/io/apicurio/registry/utils/converter/avro/AvroData.java
+++ b/utils/converter/src/main/java/io/apicurio/registry/utils/converter/avro/AvroData.java
@@ -36,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.net.URLEncoder;
 import java.nio.ByteBuffer;
@@ -1118,19 +1117,15 @@ public class AvroData {
 
     // Visible for testing
     protected static String doScrubName(String name) {
-        try {
-            if (name == null) {
-                return name;
-            }
-            String encoded = URLEncoder.encode(name, "UTF-8");
-            if (!NAME_START_CHAR.matcher(encoded).lookingAt()) {
-                encoded = "x" + encoded; // use an arbitrary valid prefix
-            }
-            encoded = NAME_INVALID_CHARS.matcher(encoded).replaceAll("_");
-            return encoded;
-        } catch (UnsupportedEncodingException e) {
+        if (name == null) {
             return name;
         }
+        String encoded = URLEncoder.encode(name, StandardCharsets.UTF_8);
+        if (!NAME_START_CHAR.matcher(encoded).lookingAt()) {
+            encoded = "x" + encoded; // use an arbitrary valid prefix
+        }
+        encoded = NAME_INVALID_CHARS.matcher(encoded).replaceAll("_");
+        return encoded;
     }
 
     public org.apache.avro.Schema fromConnectSchemaWithCycle(Schema schema,

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
@@ -442,7 +442,7 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
                         ReferenceIndex index = createIndex(artifact);
                         addExistingReferencesToIndex(registryClient, index, existingReferences);
                         addExistingReferencesToIndex(registryClient, index, artifact.getExistingReferences());
-                        Stack<RegisterArtifact> registrationStack = new Stack<>();
+                        Deque<RegisterArtifact> registrationStack = new ArrayDeque<>();
 
                         this.avroAutoRefsNamingStrategy = artifact.getAvroAutoRefsNamingStrategy();
                         registerWithAutoRefs(registryClient, artifact, index, registrationStack);
@@ -469,7 +469,7 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
     }
 
     private VersionMetaData registerWithAutoRefs(RegistryClient registryClient, RegisterArtifact artifact,
-                                                 ReferenceIndex index, Stack<RegisterArtifact> registrationStack) throws IOException,
+                                                 ReferenceIndex index, Deque<RegisterArtifact> registrationStack) throws IOException,
             ExecutionException, InterruptedException, MojoExecutionException, MojoFailureException {
         if (loopDetected(artifact, registrationStack)) {
             throw new MojoExecutionException(
@@ -505,7 +505,7 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
                 Optional<ArtifactReference> registryReference = resolveRegistryReference(registryClient,
                         externalRef, resolvedRegistryReferences);
                 if (registryReference.isPresent()) {
-                    registeredReferences.add(registryReference.get());
+                    registeredReferences.add(registryReference.orElseThrow());
                     continue;
                 }
 
@@ -569,7 +569,7 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
             return Optional.empty();
         }
 
-        RegistryReferenceLocation ref = location.get();
+        RegistryReferenceLocation ref = location.orElseThrow();
         VersionMetaData vmd = resolvedRegistryReferences.get(externalRef.getResource());
         if (vmd == null) {
             vmd = getRegistryReferenceMetadata(registryClient, ref);
@@ -981,7 +981,7 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
      * @param registrationStack
      */
     private static boolean loopDetected(RegisterArtifact artifact,
-                                        Stack<RegisterArtifact> registrationStack) {
+                                        Deque<RegisterArtifact> registrationStack) {
         for (RegisterArtifact stackArtifact : registrationStack) {
             if (artifact.getFile().equals(stackArtifact.getFile())) {
                 return true;
@@ -990,7 +990,7 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
         return false;
     }
 
-    private static String printLoop(Stack<RegisterArtifact> registrationStack) {
+    private static String printLoop(Deque<RegisterArtifact> registrationStack) {
         return registrationStack.stream().map(artifact -> artifact.getFile().getName())
                 .collect(Collectors.joining(" -> "));
     }

--- a/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
+++ b/utils/maven-plugin/src/main/java/io/apicurio/registry/maven/RegisterRegistryMojo.java
@@ -991,8 +991,18 @@ public class RegisterRegistryMojo extends AbstractRegistryMojo {
     }
 
     private static String printLoop(Deque<RegisterArtifact> registrationStack) {
-        return registrationStack.stream().map(artifact -> artifact.getFile().getName())
-                .collect(Collectors.joining(" -> "));
+        // descendingIterator: bottom-to-top (root → leaf), matching the original
+        // Stack iteration order. ArrayDeque.stream() iterates head-to-tail
+        // (most-recently-pushed first), which would reverse the chain.
+        var sb = new StringBuilder();
+        var it = registrationStack.descendingIterator();
+        while (it.hasNext()) {
+            if (sb.length() > 0) {
+                sb.append(" -> ");
+            }
+            sb.append(it.next().getFile().getName());
+        }
+        return sb.toString();
     }
 
 }

--- a/utils/maven-plugin/src/test/java/io/apicurio/registry/maven/RegisterRegistryMojoRegistryReferenceTest.java
+++ b/utils/maven-plugin/src/test/java/io/apicurio/registry/maven/RegisterRegistryMojoRegistryReferenceTest.java
@@ -22,9 +22,9 @@ public class RegisterRegistryMojoRegistryReferenceTest {
                         + "versions/branch%3Dlatest/content");
 
         assertTrue(location.isPresent());
-        assertEquals("master group", readField(location.get(), "groupId"));
-        assertEquals("kafka-bindings.yml", readField(location.get(), "artifactId"));
-        assertEquals("branch=latest", readField(location.get(), "versionExpression"));
+        assertEquals("master group", readField(location.orElseThrow(), "groupId"));
+        assertEquals("kafka-bindings.yml", readField(location.orElseThrow(), "artifactId"));
+        assertEquals("branch=latest", readField(location.orElseThrow(), "versionExpression"));
     }
 
     @Test

--- a/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtils.java
+++ b/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtils.java
@@ -771,7 +771,7 @@ public class FileDescriptorUtils {
     private static boolean isParentLevelType(ProtoType protoType, Optional<String> optionalPackageName) {
         String typeName = protoType.toString();
         if (optionalPackageName.isPresent()) {
-            String packageName = optionalPackageName.get();
+            String packageName = optionalPackageName.orElseThrow(NoSuchElementException::new);
 
             // If the type doesn't start with the package name, ignore it.
             if (!typeName.startsWith(packageName)) {

--- a/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/ProtobufSchemaLoader.java
+++ b/utils/protobuf-schema-utilities/src/main/java/io/apicurio/registry/utils/protobuf/schema/ProtobufSchemaLoader.java
@@ -1,6 +1,5 @@
 package io.apicurio.registry.utils.protobuf.schema;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.io.CharStreams;
@@ -77,7 +76,7 @@ public class ProtobufSchemaLoader {
             // Loads the proto file resource files.
             final InputStream inputStream = classLoader.getResourceAsStream(protoPath + proto);
             final String fileContents = CharStreams
-                    .toString(new InputStreamReader(inputStream, Charsets.UTF_8));
+                    .toString(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
             final okio.Path path = okio.Path.get("/" + protoPath + "/" + proto);
             FileHandle fileHandle = inMemoryFileSystem.openReadWrite(path);
             fileHandle.write(0, fileContents.getBytes(StandardCharsets.UTF_8), 0,

--- a/utils/protobuf-schema-utilities/src/test/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtilsTest.java
+++ b/utils/protobuf-schema-utilities/src/test/java/io/apicurio/registry/utils/protobuf/schema/FileDescriptorUtilsTest.java
@@ -270,7 +270,7 @@ public class FileDescriptorUtilsTest {
         return Stream.of(files).filter(f -> f.getName().equals(fileName))
                 .collect(Collectors.reducing((a, b) -> {
                     throw new IllegalStateException("More than one file with name " + fileName + " found");
-                })).map(FileDescriptorUtilsTest::readSchemaAsString).get();
+                })).map(FileDescriptorUtilsTest::readSchemaAsString).orElseThrow();
     }
 
     private static String readSchemaAsString(File file) {


### PR DESCRIPTION
Closes #9912

## Summary

Fixes 44 deprecated Java API usages detected by the [Modernizer Maven Plugin](https://github.com/gaul/modernizer-maven-plugin) (v2.9.0) across 12 modules, 46 files. All replacements are mechanical, with no behavioral change.

## How this was found

Modernizer can be run as an external plugin without modifying any pom.xml:

```bash
# Scan the entire project for Java 11+ modernization opportunities
./mvnw org.gaul:modernizer-maven-plugin:2.9.0:modernizer \
  -Dmodernizer.javaVersion=11 \
  -DskipTests

# Same, but report-only (don't fail the build)
./mvnw org.gaul:modernizer-maven-plugin:2.9.0:modernizer \
  -Dmodernizer.javaVersion=11 \
  -Dmodernizer.failOnViolations=false \
  -DskipTests
```

The plugin scans compiled bytecode for usages of APIs that have a modern replacement. It works with a catalog of known substitutions, not heuristics.

## What was replaced

| Old API | Modern replacement | Count |
|---|---|---|
| `Optional.get()` | `Optional.orElseThrow()` | 34 |
| `ByteArrayOutputStream.toString("UTF-8")` | `.toString(StandardCharsets.UTF_8)` | 2 |
| `URLEncoder.encode(s, "UTF-8")` | `URLEncoder.encode(s, StandardCharsets.UTF_8)` | 2 |
| `Charsets.UTF_8` (Guava) | `StandardCharsets.UTF_8` (JDK) | 2 |
| `FileUtils.readFileToByteArray()` | `Files.readAllBytes(Path)` | 2 |
| `Collections.EMPTY_SET` | `Collections.emptySet()` | 1 |
| `StringBuffer` | `StringBuilder` | 3 |
| `new Stack<>()` | `new ArrayDeque<>()` | 1 |
| `new FileWriter(path)` | `new FileWriter(path, StandardCharsets.UTF_8)` | 1 |

All replacements are behavior-preserving:
- `Optional.orElseThrow()` throws the same `NoSuchElementException` as `get()`
- `StandardCharsets.UTF_8` is the same charset as the string `"UTF-8"` but avoids the impossible `UnsupportedEncodingException`
- `StringBuilder` is the unsynchronized equivalent of `StringBuffer` (no thread sharing in any of these usages)

## Modules affected

| Module | Violations fixed |
|---|---|
| docs/config-generator | 9 |
| app | 9 |
| schema-util/json | 7 |
| utils/maven-plugin | 6 |
| utils/protobuf-schema-utilities | 5 |
| common | 2 |
| utils/converter, schema-util/xml, schema-util/common, java-sdk/common, java-sdk/adapter-jdk, contracts-rules | 1 each |

## Running it yourself

To check for new violations after this PR:

```bash
./mvnw org.gaul:modernizer-maven-plugin:2.9.0:modernizer \
  -Dmodernizer.javaVersion=11 \
  -Dmodernizer.failOnViolations=true \
  -DskipTests
```

This could be added as an optional CI check or a periodic audit command.

## Test plan

- [x] `./mvnw test-compile -DskipTests` BUILD SUCCESS (all 46 files compile)
- [x] `./mvnw org.gaul:modernizer-maven-plugin:2.9.0:modernizer -Dmodernizer.javaVersion=11 -Dmodernizer.failOnViolations=true -DskipTests` BUILD SUCCESS (zero violations remaining)
- [ ] CI green