### PR TITLE
fix(rest): sanitize HTTP 500 error responses across all exception map…

### DIFF
--- a/app/src/main/java/io/apicurio/registry/services/http/CCompatExceptionMapperService.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/CCompatExceptionMapperService.java
@@ -97,6 +97,10 @@ public class CCompatExceptionMapperService {
             code = codeMap.getCode(t.getClass());
         }
 
+        if (code <= 0) {
+            code = HTTP_INTERNAL_ERROR;
+        }
+
         if (code == HTTP_INTERNAL_ERROR) {
             // If the error is not something we should ignore, then we report it to the liveness object
             // and log it. Otherwise we only log it if debug logging is enabled.

--- a/app/src/main/java/io/apicurio/registry/services/http/CCompatExceptionMapperService.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/CCompatExceptionMapperService.java
@@ -30,6 +30,9 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.slf4j.Logger;
 
+import io.apicurio.common.apps.config.Info;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -37,6 +40,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_API;
 import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 
@@ -78,6 +82,10 @@ public class CCompatExceptionMapperService {
     @Inject
     HttpStatusCodeMap codeMap;
 
+    @ConfigProperty(name = "apicurio.api.errors.include-stack-in-response", defaultValue = "false")
+    @Info(category = CATEGORY_API, description = "Include stack trace in errors responses", availableSince = "2.1.4.Final")
+    boolean includeStackTrace;
+
     public Response mapException(Throwable t) {
         int code = 0;
         Response response = null;
@@ -102,14 +110,14 @@ public class CCompatExceptionMapperService {
         if (response != null) {
             builder = Response.fromResponse(response);
         } else {
-            Error error = toError(t);
+            Error error = toError(t, code);
             builder = Response.status(code).entity(error);
         }
 
         return builder.type(MediaType.APPLICATION_JSON).build();
     }
 
-    private Error toError(Throwable t) {
+    private Error toError(Throwable t, int code) {
         Error error;
 
         if (t instanceof RuleViolationException) {
@@ -121,11 +129,14 @@ public class CCompatExceptionMapperService {
         }
 
         error.setErrorCode(CONFLUENT_CODE_MAP.getOrDefault(t.getClass(), 0));
-        error.setMessage(toConfluentMessage(t));
+        error.setMessage(toConfluentMessage(t, code));
         return error;
     }
 
-    private String toConfluentMessage(Throwable t) {
+    private String toConfluentMessage(Throwable t, int code) {
+        if (code >= 500 && !includeStackTrace) {
+            return "An unexpected error occurred.";
+        }
         if (t instanceof ArtifactNotFoundException anfe) {
             String artifactId = anfe.getArtifactId();
             if (artifactId != null) {

--- a/app/src/main/java/io/apicurio/registry/services/http/CoreRegistryExceptionMapperService.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/CoreRegistryExceptionMapperService.java
@@ -56,6 +56,10 @@ public class CoreRegistryExceptionMapperService {
             code = codeMap.getCode(t.getClass());
         }
 
+        if (code <= 0) {
+            code = HTTP_INTERNAL_ERROR;
+        }
+
         if (code == HTTP_INTERNAL_ERROR) {
             // If the error is not something we should ignore, then we report it to the liveness object
             // and log it. Otherwise we only log it if debug logging is enabled.

--- a/app/src/main/java/io/apicurio/registry/services/http/CoreRegistryExceptionMapperService.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/CoreRegistryExceptionMapperService.java
@@ -87,16 +87,25 @@ public class CoreRegistryExceptionMapperService {
             ((RuleViolationProblemDetails) details).setCauses(toRestCauses(rve.getCauses()));
         } else {
             details = new ProblemDetails();
-            details.setTitle(t.getLocalizedMessage());
-            if (includeStackTrace) {
-                details.setDetail(getStackTrace(t));
+            if (code >= 500 && !includeStackTrace) {
+                details.setTitle("Internal Server Error");
+                details.setDetail("An unexpected error occurred.");
             } else {
-                details.setDetail(getRootMessage(t));
+                details.setTitle(t.getLocalizedMessage());
+                if (includeStackTrace) {
+                    details.setDetail(getStackTrace(t));
+                } else {
+                    details.setDetail(getRootMessage(t));
+                }
             }
         }
 
         details.setStatus(code);
-        details.setName(t.getClass().getSimpleName());
+        if (code >= 500 && !includeStackTrace) {
+            details.setName("InternalError");
+        } else {
+            details.setName(t.getClass().getSimpleName());
+        }
         return details;
     }
 

--- a/app/src/main/java/io/apicurio/registry/services/http/CoreV2RegistryExceptionMapperService.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/CoreV2RegistryExceptionMapperService.java
@@ -83,8 +83,13 @@ public class CoreV2RegistryExceptionMapperService {
     private Object toAuthError(Throwable t, int code) {
         AuthError error = new AuthError();
         error.setStatus(code);
-        error.setTitle(t.getLocalizedMessage());
-        error.setName(t.getClass().getSimpleName());
+        if (code >= 500 && !includeStackTrace) {
+            error.setTitle("Internal Server Error");
+            error.setName("InternalError");
+        } else {
+            error.setTitle(t.getLocalizedMessage());
+            error.setName(t.getClass().getSimpleName());
+        }
         return error;
     }
 
@@ -100,13 +105,19 @@ public class CoreV2RegistryExceptionMapperService {
         }
 
         error.setErrorCode(code);
-        error.setMessage(t.getLocalizedMessage());
-        if (includeStackTrace) {
-            error.setDetail(getStackTrace(t));
+        if (code >= 500 && !includeStackTrace) {
+            error.setMessage("Internal Server Error");
+            error.setDetail("An unexpected error occurred.");
+            error.setName("InternalError");
         } else {
-            error.setDetail(getRootMessage(t));
+            error.setMessage(t.getLocalizedMessage());
+            if (includeStackTrace) {
+                error.setDetail(getStackTrace(t));
+            } else {
+                error.setDetail(getRootMessage(t));
+            }
+            error.setName(t.getClass().getSimpleName());
         }
-        error.setName(t.getClass().getSimpleName());
         return error;
     }
 

--- a/app/src/main/java/io/apicurio/registry/services/http/CoreV2RegistryExceptionMapperService.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/CoreV2RegistryExceptionMapperService.java
@@ -60,6 +60,10 @@ public class CoreV2RegistryExceptionMapperService {
             code = codeMap.getCode(t.getClass());
         }
 
+        if (code <= 0) {
+            code = HTTP_INTERNAL_ERROR;
+        }
+
         if (code == HTTP_INTERNAL_ERROR) {
             // If the error is not something we should ignore, then we report it to the liveness object
             // and log it. Otherwise we only log it if debug logging is enabled.

--- a/app/src/main/java/io/apicurio/registry/services/http/IcebergExceptionMapperService.java
+++ b/app/src/main/java/io/apicurio/registry/services/http/IcebergExceptionMapperService.java
@@ -17,6 +17,11 @@ import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import io.apicurio.common.apps.config.Info;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_API;
+
 /**
  * Exception mapper service for Iceberg REST API errors.
  * Maps storage exceptions to Iceberg-formatted error responses.
@@ -26,6 +31,10 @@ public class IcebergExceptionMapperService {
 
     @Inject
     IcebergMetricsService metricsService;
+
+    @ConfigProperty(name = "apicurio.api.errors.include-stack-in-response", defaultValue = "false")
+    @Info(category = CATEGORY_API, description = "Include stack trace in errors responses", availableSince = "2.1.4.Final")
+    boolean includeStackTrace;
 
     public Response mapException(Throwable t) {
         if (t instanceof NotFoundException) {
@@ -79,8 +88,8 @@ public class IcebergExceptionMapperService {
         }
 
         // Default to internal server error
-        return buildErrorResponse(500, "InternalServerError",
-                t.getMessage() != null ? t.getMessage() : "An unexpected error occurred");
+        String message = (includeStackTrace && t.getMessage() != null) ? t.getMessage() : "An unexpected error occurred";
+        return buildErrorResponse(500, "InternalServerError", message);
     }
 
     private Response buildErrorResponse(int code, String type, String message) {

--- a/app/src/test/java/io/apicurio/registry/services/http/ExceptionMapperTest.java
+++ b/app/src/test/java/io/apicurio/registry/services/http/ExceptionMapperTest.java
@@ -1,0 +1,98 @@
+package io.apicurio.registry.services.http;
+
+import io.apicurio.registry.rest.v2.beans.Error;
+import io.apicurio.registry.rest.v3.beans.ProblemDetails;
+import io.apicurio.registry.metrics.health.liveness.ResponseErrorLivenessCheck;
+import io.apicurio.registry.metrics.health.liveness.LivenessUtil;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+
+public class ExceptionMapperTest {
+
+    private CCompatExceptionMapperService ccompatMapper;
+    private CoreRegistryExceptionMapperService coreMapper;
+    private CoreV2RegistryExceptionMapperService coreV2Mapper;
+
+    private HttpStatusCodeMap codeMap;
+    private ResponseErrorLivenessCheck liveness;
+    private LivenessUtil livenessUtil;
+    private Logger log;
+
+    @BeforeEach
+    public void setup() {
+        codeMap = Mockito.mock(HttpStatusCodeMap.class);
+        liveness = Mockito.mock(ResponseErrorLivenessCheck.class);
+        livenessUtil = Mockito.mock(LivenessUtil.class);
+        log = Mockito.mock(Logger.class);
+
+        // Standard setup: unmapped exception should return HTTP_INTERNAL_ERROR from codeMap
+        Mockito.when(codeMap.getCode(Mockito.any())).thenReturn(HTTP_INTERNAL_ERROR);
+
+        ccompatMapper = new CCompatExceptionMapperService();
+        ccompatMapper.codeMap = codeMap;
+        ccompatMapper.liveness = liveness;
+        ccompatMapper.livenessUtil = livenessUtil;
+        ccompatMapper.log = log;
+        ccompatMapper.includeStackTrace = false;
+
+        coreMapper = new CoreRegistryExceptionMapperService();
+        coreMapper.codeMap = codeMap;
+        coreMapper.liveness = liveness;
+        coreMapper.livenessUtil = livenessUtil;
+        coreMapper.log = log;
+        coreMapper.includeStackTrace = false;
+
+        coreV2Mapper = new CoreV2RegistryExceptionMapperService();
+        coreV2Mapper.codeMap = codeMap;
+        coreV2Mapper.liveness = liveness;
+        coreV2Mapper.livenessUtil = livenessUtil;
+        coreV2Mapper.log = log;
+        coreV2Mapper.includeStackTrace = false;
+    }
+
+    @Test
+    public void testCCompatMapperSanitization() {
+        // Test with unmapped exception (which results in HTTP_INTERNAL_ERROR)
+        RuntimeException unmappedException = new RuntimeException("Sensitive database syntax error info");
+        Response response = ccompatMapper.mapException(unmappedException);
+
+        Assertions.assertEquals(500, response.getStatus());
+        Error error = (Error) response.getEntity();
+        Assertions.assertNotNull(error);
+        Assertions.assertEquals("An unexpected error occurred.", error.getMessage());
+    }
+
+    @Test
+    public void testCCompatMapperNormalization() {
+        // Test code normalization where code <= 0 (e.g. code is 0 because map returned 0 or uninitialized)
+        Mockito.when(codeMap.getCode(Mockito.any())).thenReturn(0);
+
+        RuntimeException exception = new RuntimeException("Another sensitive DB message");
+        Response response = ccompatMapper.mapException(exception);
+
+        // Verifies status code normalized to 500
+        Assertions.assertEquals(500, response.getStatus());
+        Error error = (Error) response.getEntity();
+        Assertions.assertNotNull(error);
+        Assertions.assertEquals("An unexpected error occurred.", error.getMessage());
+    }
+
+    @Test
+    public void testCoreMapperSanitization() {
+        RuntimeException unmappedException = new RuntimeException("Sensitive DB columns");
+        Response response = coreMapper.mapException(unmappedException);
+
+        Assertions.assertEquals(500, response.getStatus());
+        ProblemDetails details = (ProblemDetails) response.getEntity();
+        Assertions.assertNotNull(details);
+        Assertions.assertEquals("Internal Server Error", details.getTitle());
+        Assertions.assertEquals("An unexpected error occurred.", details.getDetail());
+        Assertions.assertEquals("InternalError", details.getName());
+    }
+}


### PR DESCRIPTION
## What / Why

This PR sanitizes client-facing error responses for unmapped/internal server-side exceptions (HTTP 500 status codes) to ensure that we do not expose internal Java class names, stack traces, database schema, or query syntax information to the client.

### Problem
Previously, when the REST API encountered an uncaught runtime exception (such as a database constraint violation or SQL syntax error), the exception mappers unconditionally returned the raw exception's simple class name (e.g., `JdbcSQLSyntaxErrorException`) and mapped the root cause message via `ExceptionUtils.getRootCauseMessage(t)` in the `detail` or `message` fields. 

This behavior leaks sensitive details about our database tables, constraints, and backend architecture, violating the REST API security guidelines defined in `AGENTS.md`:
* *"Never expose stack traces or internal errors to API clients."*
* *"API error responses never expose internal state (usernames, stack traces, class names)."*

### Solution
We injected `apicurio.api.errors.include-stack-in-response` (the `includeStackTrace` flag) into all four core JAX-RS exception mappers:
1. `CoreRegistryExceptionMapperService.java`
2. `CoreV2RegistryExceptionMapperService.java`
3. `CCompatExceptionMapperService.java`
4. `IcebergExceptionMapperService.java`

For any HTTP 500/internal error:
* If `includeStackTrace` is `false` (default in production/standard environments), the response `name`, `title`, and `detail`/`message` are replaced with generic and sanitized values (e.g., `"InternalError"`, `"Internal Server Error"`, and `"An unexpected error occurred."`).
* If `includeStackTrace` is `true` (enabled for local development/debugging), the mappers fall back to exposing the localized message/stack trace details to facilitate troubleshooting.

---
##Issue
Closes : #9825 

## Verifications & Checklists

### Build & Style
- [x] Verified compilation: `./mvnw test-compile -pl app -am -DskipTests` completed successfully.
- [x] Verified Checkstyle check: `./mvnw checkstyle:check -pl app` passed with 0 violations.

### DCO Sign-off
- [x] All commits signed off using `git commit -s`.
