### PR TITLE
docs: add /apicurio-test-quality gate to Contributor Checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,8 +106,9 @@ Full contribution guidelines are in [CONTRIBUTING.md](CONTRIBUTING.md).
 - [ ] Every new code path has tests. Missing tests = automatic rejection.
 - [ ] Test assertions check **specific values** ("counter is 3"), not just existence ("counter is not null").
 - [ ] Security tests cover: authorized access, unauthorized access (403), edge cases (null tokens, expired sessions).
-- [ ] Tests for CDI annotations (`@Retry`, `@CircuitBreaker`, `@Timeout`) use `@QuarkusTest` with injected beans — plain JUnit with `new` bypasses interceptors.
+- [ ] Tests for CDI annotations (`@Retry`, `@CircuitBreaker`, `@Timeout`) use `@QuarkusTest` with injected beans; plain JUnit with `new` bypasses interceptors.
 - [ ] If CI fails on a test unrelated to your change, report it as a separate issue with the flaky test class, error message, and CI run link.
+- [ ] When the diff touches `**/src/test/**`, run `/apicurio-test-quality` (scores test code against 30 documented failure patterns P1-P30; score below 7.0 blocks submission).
 
 ### Submission
 - [ ] `./mvnw test-compile -pl <module> -am -DskipTests` compiles cleanly (use `test-compile`, not `compile`, when touching test files).


### PR DESCRIPTION
## Summary

- Add `/apicurio-test-quality` as a mandatory gate in the Tests section of the Contributor Checklist
- When a PR touches any file under `**/src/test/**`, the test quality skill must score the changes against the project's 30 documented failure patterns (P1-P30)
- A score below 7.0 blocks submission

## Context

The 30-pattern catalog was extracted from 30+ PRs and a 661-file codebase sweep. It catches concurrency hazards, timing flakes, CI waste, lifecycle bugs, and race test quality issues that reviewers commonly miss. Making it a checklist item ensures it runs consistently.

## Test plan

- [ ] CLAUDE.md renders correctly on GitHub
- [ ] AGENTS.md (symlink) reflects the same change