### PR TITLE
chore(deps): remove monthly schedule for Kiota TypeScript updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -370,10 +370,7 @@
       "matchPackageNames": [
         "@microsoft/kiota-*"
       ],
-      "enabled": true,
-      "schedule": [
-        "* 0 15 * *"
-      ]
+      "enabled": true
     },
     {
       "groupName": "Dependencies: UI Tests",


### PR DESCRIPTION
## Summary

- Remove the `"schedule": ["* 0 15 * *"]` restriction from the Kiota TypeScript Renovate rule
- Kiota updates will now follow the default Renovate cadence (every run) instead of once a month on the 15th

## Why

The monthly schedule delayed a security fix (credential leak on cross-origin redirect, fixed in preview.102, released June 17) by weeks. PR #9827 had to be opened manually because Renovate hadn't proposed the update yet.

Other UI dependencies already update on every Renovate run; Kiota should follow the same cadence.

## Test plan

- [ ] Renovate picks up Kiota updates on next run
- [ ] No unintended side effects on other dependency groups