### PR TITLE
feat(auth): add MockOAuth2TestResource for lightweight test OIDC

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -169,7 +169,7 @@ Guidelines:
   carry no roles by default. Tests relying on realm-defined clients or role assignments must
   stay on `KeycloakTestContainerManager`.
 
-`AuthTestAuthenticatedReadAccess` is a working example of a test using the lightweight provider.
+`AuthenticatedReadAccessAuthTest` is a working example of a test using the lightweight provider.
 
 ## Running with Postgres (docker-compose)
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -143,6 +143,34 @@ are in a separate module and need to be explicitly enabled:
 See the [integration tests module](integration-tests/) for test groups, deployment
 modes, and detailed usage instructions.
 
+### Auth Test Resources
+
+Tests that exercise authentication need an OIDC provider. Two implementations live in
+`utils/tests` (`io.apicurio.registry.utils.tests`) and can be selected per test profile:
+
+| Test resource                  | Backing                                                                        | Startup | Use when                                                                                        |
+|--------------------------------|--------------------------------------------------------------------------------|---------|-------------------------------------------------------------------------------------------------|
+| `KeycloakTestContainerManager` | Keycloak testcontainer (Docker)                                                 | ~30s+   | The test depends on *realm state*: pre-created clients, realm roles, role mappings, or TLS       |
+| `MockOAuth2TestResource`       | [mock-oauth2-server](https://github.com/navikt/mock-oauth2-server) (in-JVM)     | <1s     | The test only needs *valid OIDC tokens*: discovery, token issuance, and JWKS validation suffice  |
+
+Guidelines:
+
+- **Prefer `MockOAuth2TestResource` for new tests** - it requires no Docker daemon and starts
+  in milliseconds instead of tens of seconds.
+- Enable it through the ready-made `MockOAuth2AuthTestProfile`, or annotate directly with
+  `@QuarkusTestResource(MockOAuth2TestResource.class)` and add any needed
+  `apicurio.auth.*` policy overrides in a profile's `getConfigOverrides()`.
+- Customization is available via init args: `issuer.id` (default `default`) and
+  `token.expiry` in seconds (default `3600`), e.g.
+  `new TestResourceEntry(MockOAuth2TestResource.class, Map.of("token.expiry", "60"))`.
+- Tests can declare a `MockOAuth2Server server` field (or call `getServer()`) to issue custom
+  tokens with explicit claims, e.g. role claims such as `sr-admin`.
+- The mock server accepts *any* client id/secret at its token endpoint, but issued tokens
+  carry no roles by default. Tests relying on realm-defined clients or role assignments must
+  stay on `KeycloakTestContainerManager`.
+
+`AuthTestAuthenticatedReadAccess` is a working example of a test using the lightweight provider.
+
 ## Running with Postgres (docker-compose)
 
 Run Apicurio Registry with Postgres:

--- a/app/src/test/java/io/apicurio/registry/auth/AuthTestAuthenticatedReadAccess.java
+++ b/app/src/test/java/io/apicurio/registry/auth/AuthTestAuthenticatedReadAccess.java
@@ -8,33 +8,45 @@ import io.apicurio.registry.rest.client.models.CreateArtifact;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
 import io.apicurio.registry.utils.tests.ApicurioTestTags;
-import io.apicurio.registry.utils.tests.AuthTestProfileAuthenticatedReadAccess;
-import io.apicurio.registry.utils.tests.KeycloakTestContainerManager;
+import io.apicurio.registry.utils.tests.MockOAuth2AuthTestProfile;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.vertx.core.Vertx;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@TestProfile(AuthTestProfileAuthenticatedReadAccess.class)
+@TestProfile(MockOAuth2AuthTestProfile.class)
 @Tag(ApicurioTestTags.SLOW)
 public class AuthTestAuthenticatedReadAccess extends AbstractResourceTestBase {
+
+    /**
+     * Client ids are arbitrary for the mock OIDC server - any credentials are accepted,
+     * but issued tokens carry no roles unless claims are added explicitly.
+     */
+    private static final String ADMIN_CLIENT_ID = "admin-client";
+    private static final String NO_ROLE_CLIENT_ID = "no-role-client";
 
     @ConfigProperty(name = "quarkus.oidc.token-path")
     String authServerUrl;
 
     final String groupId = getClass().getSimpleName() + "Group";
 
+    @BeforeEach
+    protected void beforeEach() throws Exception {
+        setupRestAssured();
+    }
+
     @Override
     protected RegistryClient createRestClientV3(Vertx vertx) {
         return RegistryClientFactory.create(RegistryClientOptions.create()
                 .registryUrl(registryV3ApiUrl)
                 .vertx(vertx)
-                .oauth2(authServerUrl, KeycloakTestContainerManager.ADMIN_CLIENT_ID, "test1"));
+                .oauth2(authServerUrl, ADMIN_CLIENT_ID, "test1"));
     }
 
     @Test
@@ -43,7 +55,7 @@ public class AuthTestAuthenticatedReadAccess extends AbstractResourceTestBase {
         RegistryClient client = RegistryClientFactory.create(RegistryClientOptions.create()
                 .registryUrl(registryV3ApiUrl)
                 .vertx(vertx)
-                .oauth2(authServerUrl, KeycloakTestContainerManager.NO_ROLE_CLIENT_ID, "test1"));
+                .oauth2(authServerUrl, NO_ROLE_CLIENT_ID, "test1"));
         var results = client.search().artifacts().get(config -> config.queryParameters.groupId = groupId);
         Assertions.assertTrue(results.getCount() >= 0);
 

--- a/app/src/test/java/io/apicurio/registry/auth/AuthenticatedReadAccessAuthTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/AuthenticatedReadAccessAuthTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 @QuarkusTest
 @TestProfile(MockOAuth2AuthTestProfile.class)
 @Tag(ApicurioTestTags.SLOW)
-public class AuthTestAuthenticatedReadAccess extends AbstractResourceTestBase {
+public class AuthenticatedReadAccessAuthTest extends AbstractResourceTestBase {
 
     /**
      * Client ids are arbitrary for the mock OIDC server - any credentials are accepted,

--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,7 @@
     <embedded-postgres.version>2.2.2</embedded-postgres.version>
     <strimzi.version>0.105.0</strimzi.version>
     <wiremock.version>3.13.2</wiremock.version>
+    <mock-oauth2-server.version>2.2.1</mock-oauth2-server.version>
     <strimzi-test-container.version>0.116.0</strimzi-test-container.version>
 
     <!-- Iceberg -->
@@ -1007,6 +1008,11 @@
         <groupId>org.wiremock</groupId>
         <artifactId>wiremock</artifactId>
         <version>${wiremock.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>no.nav.security</groupId>
+        <artifactId>mock-oauth2-server</artifactId>
+        <version>${mock-oauth2-server.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.truth.extensions</groupId>

--- a/utils/tests/pom.xml
+++ b/utils/tests/pom.xml
@@ -74,6 +74,11 @@
     </dependency>
 
     <dependency>
+      <groupId>no.nav.security</groupId>
+      <artifactId>mock-oauth2-server</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-mssqlserver</artifactId>
     </dependency>

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/MockOAuth2AuthTestProfile.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/MockOAuth2AuthTestProfile.java
@@ -1,0 +1,36 @@
+package io.apicurio.registry.utils.tests;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Lightweight alternative to {@link AuthTestProfile}: same registry auth configuration,
+ * but backed by {@link MockOAuth2TestResource} (in-JVM mock-oauth2-server) instead of a
+ * Keycloak testcontainer. Use for tests that only need valid OIDC bearer tokens without
+ * realm state (pre-created clients, role mappings, etc.). Tests that exercise realm
+ * roles or client definitions should still use {@link AuthTestProfile}.
+ */
+public class MockOAuth2AuthTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> props = new HashMap<>();
+        props.put("apicurio.rest.deletion.group.enabled", "true");
+        props.put("apicurio.rest.deletion.artifact.enabled", "true");
+        props.put("apicurio.rest.deletion.artifact-version.enabled", "true");
+        props.put("apicurio.auth.authenticated-read-access.enabled", "true");
+        props.put("apicurio.auth.role-based-authorization", "true");
+        props.put("apicurio.auth.owner-only-authorization", "true");
+        props.put("apicurio.auth.admin-override.enabled", "true");
+        props.put("apicurio.authn.basic-client-credentials.enabled", "true");
+        return props;
+    }
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        return List.of(new TestResourceEntry(MockOAuth2TestResource.class));
+    }
+}

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/MockOAuth2TestResource.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/MockOAuth2TestResource.java
@@ -1,0 +1,145 @@
+package io.apicurio.registry.utils.tests;
+
+import com.nimbusds.jwt.SignedJWT;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import no.nav.security.mock.oauth2.MockOAuth2Server;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Lightweight OIDC provider for tests, backed by <a href="https://github.com/navikt/mock-oauth2-server">
+ * NAV's mock-oauth2-server</a>. Runs in-JVM (no container), making it much faster than
+ * {@link KeycloakTestContainerManager} for tests that only need valid JWTs against a real
+ * OIDC endpoint flow (discovery, token issuance, JWKS validation).
+ *
+ * <p>Use it through {@link MockOAuth2AuthTestProfile}, or annotate a test class directly:
+ * <pre>
+ * &#64;QuarkusTestResource(MockOAuth2TestResource.class)
+ * </pre>
+ *
+ * <p>Supported init args (via {@code TestResourceEntry} args):
+ * <ul>
+ *   <li>{@code issuer.id} - OIDC issuer identifier appended to the base URL
+ *       (default: {@value #DEFAULT_ISSUER_ID})</li>
+ *   <li>{@code token.expiry} - lifetime in seconds of tokens issued through
+ *       {@link #issueToken(String, Map)} (default: 3600)</li>
+ * </ul>
+ *
+ * @see KeycloakTestContainerManager for full-realm auth testing
+ */
+public class MockOAuth2TestResource implements QuarkusTestResourceLifecycleManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MockOAuth2TestResource.class);
+
+    public static final String DEFAULT_ISSUER_ID = "default";
+    public static final String DEFAULT_CLIENT_ID = "test-client";
+    public static final String DEFAULT_CLIENT_SECRET = "test-secret";
+
+    private MockOAuth2Server server;
+    private String issuerId = DEFAULT_ISSUER_ID;
+    private long tokenExpirySeconds = 3600;
+
+    @Override
+    public void init(Map<String, String> initArgs) {
+        if (initArgs != null && !initArgs.isEmpty()) {
+            String issuerArg = initArgs.get("issuer.id");
+            if (issuerArg != null && !issuerArg.isBlank()) {
+                issuerId = issuerArg;
+            }
+            String expiryArg = initArgs.get("token.expiry");
+            if (expiryArg != null && !expiryArg.isBlank()) {
+                tokenExpirySeconds = Long.parseLong(expiryArg.trim());
+            }
+        }
+        LOGGER.info("Initialized MockOAuth2TestResource [issuerId={}, tokenExpirySeconds={}]", issuerId, tokenExpirySeconds);
+    }
+
+    @Override
+    public Map<String, String> start() {
+        server = new MockOAuth2Server();
+        server.start();
+        LOGGER.info("Mock OAuth2 server started on port {}", server.url(issuerId).port());
+
+        Map<String, String> props = new HashMap<>();
+        props.put("quarkus.oidc.auth-server-url", authServerUrl());
+        props.put("quarkus.oidc.token-path", tokenEndpointUrl());
+        props.put("quarkus.oidc.client-id", DEFAULT_CLIENT_ID);
+        props.put("quarkus.oidc.credentials.secret", DEFAULT_CLIENT_SECRET);
+        props.put("quarkus.oidc.tenant-enabled", "true");
+
+        LOGGER.info("Registry OIDC properties: {}", props);
+        return props;
+    }
+
+    @Override
+    public synchronized void stop() {
+        if (server != null) {
+            server.shutdown();
+            LOGGER.info("Mock OAuth2 server was shut down");
+            server = null;
+        }
+    }
+
+    /**
+     * Injects the running {@link MockOAuth2Server} into any field of that type on the test
+     * instance, so tests can issue custom tokens (e.g. with specific claims).
+     */
+    @Override
+    public void inject(Object testInstance) {
+        Class<?> clazz = testInstance.getClass();
+        while (clazz != null) {
+            for (Field field : clazz.getDeclaredFields()) {
+                if (field.getType().equals(MockOAuth2Server.class)) {
+                    try {
+                        field.setAccessible(true);
+                        field.set(testInstance, getServer());
+                    } catch (IllegalAccessException e) {
+                        throw new RuntimeException("Failed to inject MockOAuth2Server into " + field, e);
+                    }
+                }
+            }
+            clazz = clazz.getSuperclass();
+        }
+    }
+
+    /**
+     * Issues a signed JWT for the configured issuer with the given subject and extra claims,
+     * honoring the {@code token.expiry} init arg. Use for custom token scenarios; regular
+     * tests can simply authenticate against {@link #tokenEndpointUrl()} with any client credentials.
+     */
+    public SignedJWT issueToken(String subject, Map<String, Object> claims) {
+        return getServer().issueToken(issuerId, subject, DEFAULT_CLIENT_ID, claims, tokenExpirySeconds);
+    }
+
+    public synchronized MockOAuth2Server getServer() {
+        if (server == null) {
+            throw new IllegalStateException("MockOAuth2Server is not running - was start() called?");
+        }
+        return server;
+    }
+
+    /** The OIDC issuer base URL, e.g. {@code http://localhost:{port}/{issuerId}}. */
+    public String authServerUrl() {
+        String url = getServer().url(issuerId).toString();
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+
+    /** The OAuth2 token endpoint, usable with SDK clients ({@code RegistryClientOptions.oauth2(...)}). */
+    public String tokenEndpointUrl() {
+        return getServer().tokenEndpointUrl(issuerId).toString();
+    }
+
+    /** The OpenID Connect discovery document URL. */
+    public String wellKnownUrl() {
+        return getServer().wellKnownUrl(issuerId).toString();
+    }
+
+    /** The JWKS endpoint used by Quarkus OIDC to verify token signatures. */
+    public String jwksUrl() {
+        return getServer().jwksUrl(issuerId).toString();
+    }
+}


### PR DESCRIPTION
Closes #9796

Added `MockOAuth2TestResource` implementing `QuarkusTestResourceLifecycleManager` that wraps `mock-oauth2-server`, providing an in-JVM, lightweight OIDC provider for tests that only require token issuance, discovery, and signature validation without full Keycloak testcontainers.
### What's Changed
- Added `MockOAuth2TestResource` in `utils/tests` backed by in-JVM `mock-oauth2-server`.
- Added `MockOAuth2AuthTestProfile` with standard test auth config.
- Supports server injection via `inject()` for custom token issuance and init args (`issuer.id`, `token.expiry`).
- Migrated `AuthTestAuthenticatedReadAccess` as a proof of concept.
- Documented usage guidelines and comparison table in `DEVELOPING.md`.
### Test Coverage & Migration:
Migrated `AuthTestAuthenticatedReadAccess.java` as a proof of concept:
- `testReadOperationWithNoRole()`: verifies that authenticated clients without roles can perform read operations (returns 200 OK) while write operations are rejected (returns 403 Forbidden).
- Overrode `beforeEach()` to streamline execution without requiring admin global rule cleanup.
