### PR TITLE
feat(auth): add MockOAuth2TestResource for lightweight test OIDC

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -49,7 +49,7 @@ The project uses a three-tier build system to allow developers to build only wha
 
 | Tier        | Flag      | What's included                                         | Use case                           |
 |-------------|-----------|--------------------------------------------------------|------------------------------------|
-| **Local**   | `-Dlocal` | Core server, Java SDK, schema utilities, serializers — skips javadoc, source JARs, checkstyle, assembly | Quick local development iteration |
+| **Local**   | `-Dlocal` | Core server, Java SDK, schema utilities, serializers â€” skips javadoc, source JARs, checkstyle, assembly | Quick local development iteration |
 | **Default** | *(none)*  | Local + CLI, docs, distribution                         | Normal development                 |
 | **Full**    | `-Dfull`  | Default + MCP server, Go SDK, operator, extra utilities | CI builds, releases                |
 
@@ -142,6 +142,13 @@ are in a separate module and need to be explicitly enabled:
 
 See the [integration tests module](integration-tests/) for test groups, deployment
 modes, and detailed usage instructions.
+
+### Authentication Test Resources
+
+When writing or migrating tests that require authentication:
+
+- **`MockOAuth2TestResource` (recommended for most auth tests):** Lightweight, embedded mock OIDC server based on `mock-oauth2-server` (starts in milliseconds, no Docker required). Use this for tests verifying bearer tokens, JWT roles/claims, or client credentials grant (e.g., annotate with `@TestProfile(MockOAuth2AuthTestProfile.class)` or `@QuarkusTestResource(MockOAuth2TestResource.class)`).
+- **`KeycloakTestContainerManager`:** Full Keycloak instance running via Testcontainers (requires Docker). Use only when tests specifically require real Keycloak realm configurations, Keycloak Admin REST API operations, or custom TLS certificate testing with Keycloak.
 
 ## Running with Postgres (docker-compose)
 

--- a/app/src/test/java/io/apicurio/registry/auth/ProxyAndOidcDualAuthTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/ProxyAndOidcDualAuthTest.java
@@ -1,10 +1,26 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.apicurio.registry.auth;
 
 import io.apicurio.registry.AbstractResourceTestBase;
 import io.apicurio.registry.types.ArtifactType;
 import io.apicurio.registry.types.ContentTypes;
-import io.apicurio.registry.utils.tests.AuthTestProfile;
-import io.apicurio.registry.utils.tests.KeycloakTestContainerManager;
+import io.apicurio.registry.utils.tests.MockOAuth2AuthTestProfile;
+import io.apicurio.registry.utils.tests.MockOAuth2TestResource;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
@@ -16,15 +32,11 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
- * Tests for dual proxy-header + OIDC authentication mode. When both mechanisms are enabled,
- * proxy headers are tried first. If absent, the request falls back to OIDC authentication.
- *
- * <p>This test shares {@link AuthTestProfile} with other auth tests to avoid an extra Quarkus
- * augmentation. The profile enables both proxy-header and OIDC; existing OIDC-only tests are
- * unaffected because the proxy-header mechanism returns null when no proxy headers are present.</p>
+ * Tests for dual proxy-header + OIDC authentication mode using lightweight {@link MockOAuth2TestResource}.
+ * When both mechanisms are enabled, proxy headers are tried first. If absent, the request falls back to OIDC.
  */
 @QuarkusTest
-@TestProfile(AuthTestProfile.class)
+@TestProfile(MockOAuth2AuthTestProfile.class)
 public class ProxyAndOidcDualAuthTest extends AbstractResourceTestBase {
 
     private static final String ARTIFACT_CONTENT = "{\"name\":\"redhat\"}";
@@ -46,7 +58,7 @@ public class ProxyAndOidcDualAuthTest extends AbstractResourceTestBase {
     }
 
     /**
-     * Obtains a Bearer token from Keycloak using client credentials grant.
+     * Obtains a Bearer token from mock-oauth2-server using client credentials grant.
      */
     private String obtainOidcToken(String clientId, String clientSecret) {
         return given()
@@ -103,7 +115,7 @@ public class ProxyAndOidcDualAuthTest extends AbstractResourceTestBase {
     public void testNoProxyHeaders_OidcFallback() {
         String groupId = TestUtils.generateGroupId();
         String artifactId = TestUtils.generateArtifactId();
-        String token = obtainOidcToken(KeycloakTestContainerManager.ADMIN_CLIENT_ID, "test1");
+        String token = obtainOidcToken(MockOAuth2TestResource.ADMIN_CLIENT_ID, "test1");
 
         given()
                 .header("Authorization", "Bearer " + token)
@@ -116,7 +128,7 @@ public class ProxyAndOidcDualAuthTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200)
                 .body("version.owner",
-                        equalTo(KeycloakTestContainerManager.ADMIN_CLIENT_ID));
+                        equalTo(MockOAuth2TestResource.ADMIN_CLIENT_ID));
 
         // Clean up
         given()
@@ -147,7 +159,7 @@ public class ProxyAndOidcDualAuthTest extends AbstractResourceTestBase {
      */
     @Test
     public void testBothPresent_ProxyWins() {
-        String token = obtainOidcToken(KeycloakTestContainerManager.ADMIN_CLIENT_ID, "test1");
+        String token = obtainOidcToken(MockOAuth2TestResource.ADMIN_CLIENT_ID, "test1");
 
         given()
                 .header(HEADER_USERNAME, PROXY_USERNAME)
@@ -163,8 +175,7 @@ public class ProxyAndOidcDualAuthTest extends AbstractResourceTestBase {
 
     /**
      * Verify that OIDC client credentials authentication still works as a fallback when proxy
-     * headers are absent — confirming that the full OIDC client credentials flow (not just Bearer
-     * token pass-through) functions correctly in dual mode.
+     * headers are absent — confirming that the full OIDC client credentials flow functions correctly.
      */
     @Test
     public void testOidcClientCredentials_WithBasicAuth() {
@@ -173,7 +184,7 @@ public class ProxyAndOidcDualAuthTest extends AbstractResourceTestBase {
 
         given()
                 .auth().preemptive().basic(
-                        KeycloakTestContainerManager.DEVELOPER_CLIENT_ID, "test1")
+                        MockOAuth2TestResource.DEVELOPER_CLIENT_ID, "test1")
                 .contentType(ContentType.JSON)
                 .body(TestUtils.clientCreateArtifact(artifactId, ArtifactType.JSON,
                         ARTIFACT_CONTENT, ContentTypes.APPLICATION_JSON))
@@ -183,12 +194,12 @@ public class ProxyAndOidcDualAuthTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200)
                 .body("version.owner",
-                        equalTo(KeycloakTestContainerManager.DEVELOPER_CLIENT_ID));
+                        equalTo(MockOAuth2TestResource.DEVELOPER_CLIENT_ID));
 
         // Clean up
         given()
                 .auth().preemptive().basic(
-                        KeycloakTestContainerManager.DEVELOPER_CLIENT_ID, "test1")
+                        MockOAuth2TestResource.DEVELOPER_CLIENT_ID, "test1")
                 .when()
                 .pathParam("groupId", groupId)
                 .delete("/registry/v3/groups/{groupId}/artifacts/" + artifactId)

--- a/utils/tests/pom.xml
+++ b/utils/tests/pom.xml
@@ -101,6 +101,12 @@
     <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-testing-testcontainers</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.squareup.okhttp3</groupId>
+          <artifactId>okhttp</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -111,6 +117,12 @@
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>no.nav.security</groupId>
+      <artifactId>mock-oauth2-server</artifactId>
+      <version>6.0.2</version>
     </dependency>
 
     <dependency>

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/InjectMockOAuth2Server.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/InjectMockOAuth2Server.java
@@ -1,0 +1,15 @@
+package io.apicurio.registry.utils.tests;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used to inject the {@link no.nav.security.mock.oauth2.MockOAuth2Server}
+ * instance from {@link MockOAuth2TestResource} into test class fields.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface InjectMockOAuth2Server {
+}

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/MockOAuth2AuthTestProfile.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/MockOAuth2AuthTestProfile.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.utils.tests;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Quarkus test profile that activates {@link MockOAuth2TestResource} for lightweight,
+ * fast OIDC authentication testing without Docker or Keycloak.
+ */
+public class MockOAuth2AuthTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> props = new HashMap<>();
+        props.put("apicurio.rest.deletion.group.enabled", "true");
+        props.put("apicurio.rest.deletion.artifact.enabled", "true");
+        props.put("apicurio.rest.deletion.artifact-version.enabled", "true");
+        props.put("apicurio.authn.proxy-header.enabled", "true");
+        props.put("apicurio.authn.mechanism.priority", "proxy-header,oidc");
+        return props;
+    }
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        if (!Boolean.parseBoolean(System.getProperty("cluster.tests"))) {
+            return List.of(new TestResourceEntry(MockOAuth2TestResource.class));
+        } else {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/MockOAuth2TestResource.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/MockOAuth2TestResource.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.utils.tests;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import no.nav.security.mock.oauth2.MockOAuth2Server;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import no.nav.security.mock.oauth2.OAuth2Config;
+import no.nav.security.mock.oauth2.token.OAuth2TokenCallback;
+import no.nav.security.mock.oauth2.token.OAuth2TokenProvider;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Test resource manager wrapping {@link MockOAuth2Server}, providing a lightweight, embeddable
+ * OIDC provider for tests that need auth but don't need a full Keycloak instance.
+ *
+ * <p>Starts in milliseconds with no Docker dependency, unlike
+ * {@link KeycloakTestContainerManager}. Use this for tests that only need bearer token
+ * validation or role-based access checks (roles are JWT claims, not Keycloak-specific). Stay on
+ * {@link KeycloakTestContainerManager} for anything needing real Keycloak realm configuration,
+ * TLS with Keycloak's certificates, or the Keycloak Admin API.
+ *
+ * <p>Supports init args for customization:
+ * <ul>
+ *   <li>{@code issuer.id} - the mock server's issuer identifier (default: "default")</li>
+ *   <li>{@code token.expiry} - default token expiry in seconds, exposed to tests via
+ *       {@link #getDefaultTokenExpirySeconds()} for convenience when issuing custom tokens
+ *       (default: 3600)</li>
+ * </ul>
+ */
+public class MockOAuth2TestResource implements QuarkusTestResourceLifecycleManager {
+
+    static final Logger LOGGER = LoggerFactory.getLogger(MockOAuth2TestResource.class);
+
+    public static final String DEFAULT_ISSUER_ID = "default";
+    public static final String DEFAULT_CLIENT_ID = "test-client";
+    public static final String DEFAULT_CLIENT_SECRET = "test-secret";
+    public static final String ADMIN_CLIENT_ID = "admin-client";
+    public static final String DEVELOPER_CLIENT_ID = "developer-client";
+    public static final String READONLY_CLIENT_ID = "readonly-client";
+    private static final long DEFAULT_TOKEN_EXPIRY_SECONDS = 3600;
+
+    // Mirrors the realm-role-to-client mapping in utils/tests/src/main/resources/realm.json
+    // (the Keycloak-based fixture) so mock-issued tokens carry the same "groups" claim
+    // Apicurio's role-based authorization expects.
+    private static final Map<String, List<String>> CLIENT_ID_TO_ROLES = Map.of(
+            ADMIN_CLIENT_ID, List.of("sr-admin"),
+            DEVELOPER_CLIENT_ID, List.of("sr-developer"),
+            READONLY_CLIENT_ID, List.of("sr-readonly")
+    );
+
+    private MockOAuth2Server server;
+    private String issuerId = DEFAULT_ISSUER_ID;
+    private long defaultTokenExpirySeconds = DEFAULT_TOKEN_EXPIRY_SECONDS;
+
+    @Override
+    public void init(Map<String, String> initArgs) {
+        if (initArgs == null) {
+            return;
+        }
+
+        String issuerIdArg = initArgs.get("issuer.id");
+        if (issuerIdArg != null && !issuerIdArg.isBlank()) {
+            issuerId = issuerIdArg;
+        }
+
+        String tokenExpiryArg = initArgs.get("token.expiry");
+        if (tokenExpiryArg != null && !tokenExpiryArg.isBlank()) {
+            try {
+                defaultTokenExpirySeconds = Long.parseLong(tokenExpiryArg);
+            } catch (NumberFormatException e) {
+                LOGGER.warn("Invalid token.expiry value '{}', falling back to default of {}s",
+                        tokenExpiryArg, DEFAULT_TOKEN_EXPIRY_SECONDS);
+            }
+        }
+    }
+
+    @Override
+    public Map<String, String> start() {
+        OAuth2TokenCallback roleClaimCallback =
+                new RoleClaimTokenCallback(issuerId, CLIENT_ID_TO_ROLES, defaultTokenExpirySeconds);
+        server = new MockOAuth2Server(new OAuth2Config(
+                false, null, null, false,
+                new OAuth2TokenProvider(),
+                Set.of(roleClaimCallback)
+        ));
+
+        LOGGER.info("Starting mock-oauth2-server...");
+        try {
+            server.start();
+        } catch (Exception e) {
+            LOGGER.error("Failed to start mock-oauth2-server", e);
+            throw new RuntimeException("Failed to start mock-oauth2-server", e);
+        }
+        LOGGER.info("mock-oauth2-server started at {}", server.baseUrl());
+
+        String issuerUrl = server.issuerUrl(issuerId).toString();
+        String tokenUrl = server.tokenEndpointUrl(issuerId).toString();
+
+        Map<String, String> props = new HashMap<>();
+        props.put("quarkus.oidc.auth-server-url", issuerUrl);
+        props.put("quarkus.oidc.token-path", tokenUrl);
+        props.put("quarkus.oidc.client-id", DEFAULT_CLIENT_ID);
+        props.put("quarkus.oidc.credentials.secret", DEFAULT_CLIENT_SECRET);
+        props.put("quarkus.oidc.tenant-enabled", "true");
+        props.put("apicurio.auth.role-based-authorization", "true");
+        props.put("apicurio.auth.owner-only-authorization", "true");
+        props.put("apicurio.auth.admin-override.enabled", "true");
+        props.put("apicurio.authn.basic-client-credentials.enabled", "true");
+
+        LOGGER.info("mock-oauth2-server properties: {}", props);
+        return props;
+    }
+
+    @Override
+    public void inject(TestInjector testInjector) {
+        testInjector.injectIntoFields(server,
+                new TestInjector.AnnotatedAndMatchesType(InjectMockOAuth2Server.class, MockOAuth2Server.class));
+    }
+
+    @Override
+    public synchronized void stop() {
+        if (server != null) {
+            server.shutdown();
+            LOGGER.info("mock-oauth2-server was shut down");
+            server = null;
+        }
+    }
+
+    public long getDefaultTokenExpirySeconds() {
+        return defaultTokenExpirySeconds;
+    }
+}

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/RoleClaimTokenCallback.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/RoleClaimTokenCallback.java
@@ -1,0 +1,84 @@
+package io.apicurio.registry.utils.tests;
+
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import no.nav.security.mock.oauth2.token.OAuth2TokenCallback;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Token callback that attaches a {@code groups} claim to issued tokens based on the
+ * requesting client_id, so Apicurio's role-based authorization (which reads roles from
+ * the token's {@code groups} claim by default) has something to authorize against.
+ *
+ * <p>Mirrors the realm-role-to-client mapping baked into utils/tests/src/main/resources/
+ * realm.json for the real Keycloak-based tests (admin-client -> sr-admin, developer-client
+ * -> sr-developer, readonly-client -> sr-readonly).
+ */
+public class RoleClaimTokenCallback implements OAuth2TokenCallback {
+
+    private final String issuerId;
+    private final Map<String, List<String>> clientIdToRoles;
+    private final long tokenExpirySeconds;
+
+    public RoleClaimTokenCallback(String issuerId, Map<String, List<String>> clientIdToRoles,
+            long tokenExpirySeconds) {
+        this.issuerId = issuerId;
+        this.clientIdToRoles = clientIdToRoles;
+        this.tokenExpirySeconds = tokenExpirySeconds;
+    }
+
+    private String resolveClientId(TokenRequest tokenRequest) {
+        // Case 1: client_id sent as a form parameter (public client / unauthenticated request)
+        ClientID clientId = tokenRequest.getClientID();
+        if (clientId != null) {
+            return clientId.getValue();
+        }
+        // Case 2: client_id sent via client authentication (e.g. HTTP Basic auth for
+        // client-credentials grant with client_secret_basic)
+        ClientAuthentication clientAuth = tokenRequest.getClientAuthentication();
+        if (clientAuth != null && clientAuth.getClientID() != null) {
+            return clientAuth.getClientID().getValue();
+        }
+        return null;
+    }
+
+    @Override
+    public String issuerId() {
+        return issuerId;
+    }
+
+    @Override
+    public String subject(TokenRequest tokenRequest) {
+        String clientId = resolveClientId(tokenRequest);
+        return clientId != null ? clientId : "unknown-client";
+    }
+
+    @Override
+    public String typeHeader(TokenRequest tokenRequest) {
+        return "JWT";
+    }
+
+    @Override
+    public List<String> audience(TokenRequest tokenRequest) {
+        return List.of();
+    }
+
+    @Override
+    public Map<String, Object> addClaims(TokenRequest tokenRequest) {
+        String clientId = resolveClientId(tokenRequest);
+        Map<String, Object> claims = new HashMap<>();
+        if (clientId != null && clientIdToRoles.containsKey(clientId)) {
+            claims.put("groups", clientIdToRoles.get(clientId));
+        }
+        return claims;
+    }
+
+    @Override
+    public long tokenExpiry() {
+        return tokenExpirySeconds;
+    }
+}

--- a/utils/tests/src/test/java/io/apicurio/registry/utils/tests/MockOAuth2TestResourceTest.java
+++ b/utils/tests/src/test/java/io/apicurio/registry/utils/tests/MockOAuth2TestResourceTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.registry.utils.tests;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import no.nav.security.mock.oauth2.MockOAuth2Server;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.function.Predicate;
+
+public class MockOAuth2TestResourceTest {
+
+    private MockOAuth2TestResource resource;
+
+    @BeforeEach
+    public void setUp() {
+        resource = new MockOAuth2TestResource();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (resource != null) {
+            resource.stop();
+        }
+    }
+
+    @Test
+    public void testStartAndStopDefaultConfig() {
+        Map<String, String> props = resource.start();
+
+        Assertions.assertNotNull(props);
+        Assertions.assertTrue(props.containsKey("quarkus.oidc.auth-server-url"));
+        Assertions.assertTrue(props.get("quarkus.oidc.auth-server-url").contains("/default"));
+        Assertions.assertTrue(props.containsKey("quarkus.oidc.token-path"));
+        Assertions.assertTrue(props.get("quarkus.oidc.token-path").contains("/default/token"));
+        Assertions.assertEquals(MockOAuth2TestResource.DEFAULT_CLIENT_ID, props.get("quarkus.oidc.client-id"));
+        Assertions.assertEquals(MockOAuth2TestResource.DEFAULT_CLIENT_SECRET, props.get("quarkus.oidc.credentials.secret"));
+        Assertions.assertEquals("true", props.get("quarkus.oidc.tenant-enabled"));
+        Assertions.assertEquals("true", props.get("apicurio.authn.basic-client-credentials.enabled"));
+        Assertions.assertEquals("true", props.get("apicurio.auth.role-based-authorization"));
+        Assertions.assertEquals(3600L, resource.getDefaultTokenExpirySeconds());
+
+        resource.stop();
+    }
+
+    @Test
+    public void testCustomInitArgs() {
+        resource.init(Map.of(
+                "issuer.id", "my-custom-issuer",
+                "token.expiry", "7200"
+        ));
+
+        Map<String, String> props = resource.start();
+
+        Assertions.assertNotNull(props);
+        Assertions.assertTrue(props.get("quarkus.oidc.auth-server-url").contains("/my-custom-issuer"));
+        Assertions.assertTrue(props.get("quarkus.oidc.token-path").contains("/my-custom-issuer/token"));
+        Assertions.assertEquals(7200L, resource.getDefaultTokenExpirySeconds());
+
+        resource.stop();
+    }
+
+    @Test
+    public void testInvalidTokenExpiryFallsBackToDefault() {
+        resource.init(Map.of("token.expiry", "invalid-number"));
+        Assertions.assertEquals(3600L, resource.getDefaultTokenExpirySeconds());
+    }
+
+    @Test
+    public void testFieldInjection() {
+        resource.start();
+
+        TestClass target = new TestClass();
+        resource.inject(new QuarkusTestResourceLifecycleManager.TestInjector() {
+            @Override
+            public void injectIntoFields(Object instance, Predicate<Field> predicate) {
+                for (Field field : target.getClass().getDeclaredFields()) {
+                    if (predicate.test(field)) {
+                        field.setAccessible(true);
+                        try {
+                            field.set(target, instance);
+                        } catch (IllegalAccessException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }
+            }
+        });
+
+        Assertions.assertNotNull(target.mockServer);
+        Assertions.assertTrue(target.mockServer instanceof MockOAuth2Server);
+    }
+
+    private static class TestClass {
+        @InjectMockOAuth2Server
+        MockOAuth2Server mockServer;
+    }
+}


### PR DESCRIPTION
Closes #9796

## Summary

Wraps mock-oauth2-server as a `QuarkusTestResourceLifecycleManager`, providing a Docker-free alternative to `KeycloakTestContainerManager` for auth tests. Includes:

- **MockOAuth2TestResource** with init args (`issuer.id`, `token.expiry`) and server  injection via `@InjectMockOAuth2Server`
- **MockOAuth2AuthTestProfile** for test wiring
- **RoleClaimTokenCallback** attaching per-client `groups` claims (mirrors the  `sr-admin`/`sr-developer`/`sr-readonly` mapping in `realm.json`) so Apicurio's  role-based authorization works against mock-issued tokens, handling both form-param  and HTTP Basic Auth client identification
- **ProxyAndOidcDualAuthTest** migrated from `KeycloakTestContainerManager` as proof of  concept, covering proxy-header auth, OIDC fallback, and Basic-Auth client-credentials  across three distinct client roles — all 5 test cases pass locally
- `DEVELOPING.md` updated with guidance on when to use this resource vs Keycloak

**Note on overlapping PR:** #9844 is also open against this issue. I'm assigned to #9797 (via /assign-me), and on that issue Paolo asked me to prioritize #9796 first since #9797 depends on it. I tried /assign-me on #9796 too but hit the 3-open-issue contributor limit, so I went ahead with a PR. Flagging for maintainer visibility rather than checking the "no overlapping PRs" box below, since that would not be accurate.

## Checklist
- [x] Linked issue has maintainer approval
- [ ] No overlapping open PRs for the same issue — see note above
- [ ] Checked the [Tried & Rejected list](https://github.com/Apicurio/apicurio-registry/discussions/8364)
- [x] Tests added for new code paths
- [x] Tested locally: `./mvnw test -pl app -am -Dlocal` (`ProxyAndOidcDualAuthTest`: 5/5 passing)
- [ ] `./mvnw checkstyle:check -pl <module>` passes
- [x] All commits have DCO sign-off (`git commit -s`)