### PR TITLE
fix: make usage telemetry dedup and config cache loads atomic (#9774)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/config/RegistryStorageConfigCache.java
+++ b/app/src/main/java/io/apicurio/registry/config/RegistryStorageConfigCache.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_CACHE;
 import static io.quarkus.scheduler.Scheduled.ConcurrentExecution.SKIP;
@@ -34,6 +35,7 @@ public class RegistryStorageConfigCache extends RegistryStorageDecoratorBase
     boolean enabled;
 
     private Map<String, DynamicConfigPropertyDto> configCache = new ConcurrentHashMap<>();
+    private final AtomicLong cacheGeneration = new AtomicLong();
     private Instant lastRefresh = null;
 
     /**
@@ -64,17 +66,22 @@ public class RegistryStorageConfigCache extends RegistryStorageDecoratorBase
      * @see io.apicurio.registry.storage.decorator.RegistryStorageDecorator#getConfigProperty(java.lang.String)
      */
     public DynamicConfigPropertyDto getConfigProperty(String propertyName) {
-        DynamicConfigPropertyDto propertyDto = configCache.computeIfAbsent(propertyName, (key) -> {
-            DynamicConfigPropertyDto dto = delegate.getConfigProperty(key);
-            if (dto == null) {
-                dto = NULL_DTO;
-            }
-            return dto;
-        });
-        return propertyDto == NULL_DTO ? null : propertyDto;
+        DynamicConfigPropertyDto cached = configCache.get(propertyName);
+        if (cached != null) {
+            return cached == NULL_DTO ? null : cached;
+        }
+        // Load outside the map, so no bin is locked while storage is queried, and discard the
+        // result instead of caching it if an invalidation happened during the load.
+        long generation = cacheGeneration.get();
+        DynamicConfigPropertyDto loaded = delegate.getConfigProperty(propertyName);
+        if (cacheGeneration.get() == generation) {
+            configCache.putIfAbsent(propertyName, loaded == null ? NULL_DTO : loaded);
+        }
+        return loaded;
     }
 
     private void invalidateCache() {
+        cacheGeneration.incrementAndGet();
         configCache.clear();
     }
 

--- a/app/src/main/java/io/apicurio/registry/config/RegistryStorageConfigCache.java
+++ b/app/src/main/java/io/apicurio/registry/config/RegistryStorageConfigCache.java
@@ -70,13 +70,19 @@ public class RegistryStorageConfigCache extends RegistryStorageDecoratorBase
         if (cached != null) {
             return cached == NULL_DTO ? null : cached;
         }
-        // Load outside the map, so no bin is locked while storage is queried, and discard the
-        // result instead of caching it if an invalidation happened during the load.
+        // Load outside the map, so no bin is locked while storage is queried. The insert goes
+        // through compute() because it takes the same bin that clear() needs: an invalidation
+        // either bumps the generation before this check, or clears the entry after it. Checking
+        // the generation and then putting separately would leave a window between the two.
         long generation = cacheGeneration.get();
         DynamicConfigPropertyDto loaded = delegate.getConfigProperty(propertyName);
-        if (cacheGeneration.get() == generation) {
-            configCache.putIfAbsent(propertyName, loaded == null ? NULL_DTO : loaded);
-        }
+        DynamicConfigPropertyDto toCache = loaded == null ? NULL_DTO : loaded;
+        configCache.compute(propertyName, (key, existing) -> {
+            if (existing != null) {
+                return existing;
+            }
+            return cacheGeneration.get() == generation ? toCache : null;
+        });
         return loaded;
     }
 

--- a/app/src/main/java/io/apicurio/registry/rest/UsageTelemetryBuffer.java
+++ b/app/src/main/java/io/apicurio/registry/rest/UsageTelemetryBuffer.java
@@ -45,12 +45,20 @@ public class UsageTelemetryBuffer {
         String dedupKey = (event.getGlobalId() > 0 ? "g" + event.getGlobalId() : "c" + event.getContentId())
                 + ":" + event.getClientId();
         long now = System.currentTimeMillis();
-        Long lastSeen = dedupMap.get(dedupKey);
-        if (lastSeen != null && (now - lastSeen) < DEDUP_WINDOW_MS) {
-            return;
+        // Decide and stamp in one atomic step, so concurrent calls for the same key buffer a
+        // single event. The flag carries the decision out because the new timestamp on its own
+        // cannot: two calls in the same millisecond would both look like the winner.
+        boolean[] accepted = new boolean[1];
+        dedupMap.compute(dedupKey, (key, lastSeen) -> {
+            if (lastSeen != null && (now - lastSeen) < DEDUP_WINDOW_MS) {
+                return lastSeen;
+            }
+            accepted[0] = true;
+            return now;
+        });
+        if (accepted[0]) {
+            buffer.add(event);
         }
-        dedupMap.put(dedupKey, now);
-        buffer.add(event);
     }
 
     @Scheduled(delay = 5, delayUnit = TimeUnit.SECONDS, concurrentExecution = SKIP, every = "{apicurio.usage.flush.every}")

--- a/app/src/test/java/io/apicurio/registry/config/RegistryStorageConfigCacheTest.java
+++ b/app/src/test/java/io/apicurio/registry/config/RegistryStorageConfigCacheTest.java
@@ -8,9 +8,16 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -134,5 +141,37 @@ public class RegistryStorageConfigCacheTest {
 
         cache.enabled = false;
         assertEquals(false, cache.isEnabled());
+    }
+
+    @Test
+    void getConfigPropertyDoesNotCacheAValueLoadedAcrossAnInvalidation() throws Exception {
+        CountDownLatch loadStarted = new CountDownLatch(1);
+        CountDownLatch invalidated = new CountDownLatch(1);
+        AtomicReference<String> stored = new AtomicReference<>("old");
+
+        when(delegate.getConfigProperty("apicurio.a")).thenAnswer(invocation -> {
+            String snapshot = stored.get();
+            loadStarted.countDown();
+            assertTrue(invalidated.await(10, TimeUnit.SECONDS), "invalidation did not happen");
+            return new DynamicConfigPropertyDto("apicurio.a", snapshot);
+        });
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<DynamicConfigPropertyDto> slowLoad = executor
+                    .submit(() -> cache.getConfigProperty("apicurio.a"));
+            assertTrue(loadStarted.await(10, TimeUnit.SECONDS), "load did not start");
+
+            stored.set("new");
+            cache.setConfigProperty(new DynamicConfigPropertyDto("apicurio.a", "new"));
+            invalidated.countDown();
+
+            // The in-flight read still returns what storage handed it, but it must not survive the
+            // invalidation, or that stale value is served until a later refresh happens to notice.
+            assertEquals("old", slowLoad.get(10, TimeUnit.SECONDS).getValue());
+            assertEquals("new", cache.getConfigProperty("apicurio.a").getValue());
+        } finally {
+            executor.shutdownNow();
+        }
     }
 }

--- a/app/src/test/java/io/apicurio/registry/rest/UsageTelemetryBufferTest.java
+++ b/app/src/test/java/io/apicurio/registry/rest/UsageTelemetryBufferTest.java
@@ -1,0 +1,93 @@
+package io.apicurio.registry.rest;
+
+import io.apicurio.registry.storage.dto.SchemaUsageEventDto;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UsageTelemetryBufferTest {
+
+    private static final int THREADS = 8;
+    private static final int KEYS = 200;
+    private static final String CLIENT_ID = "client";
+
+    @Test
+    void testDuplicateEventWithinDedupWindowIsDropped() throws Exception {
+        UsageTelemetryBuffer telemetry = new UsageTelemetryBuffer();
+
+        telemetry.addEvent(event(1));
+        telemetry.addEvent(event(1));
+
+        assertEquals(1, buffer(telemetry).size());
+    }
+
+    @Test
+    void testEventIsBufferedAgainOnceTheDedupWindowHasPassed() throws Exception {
+        UsageTelemetryBuffer telemetry = new UsageTelemetryBuffer();
+        telemetry.addEvent(event(1));
+
+        dedupMap(telemetry).put("g1:" + CLIENT_ID, System.currentTimeMillis() - 120_000);
+        telemetry.addEvent(event(1));
+
+        assertEquals(2, buffer(telemetry).size());
+    }
+
+    /**
+     * Every key is offered by all threads at once. The dedup window is a minute, so a correct
+     * implementation buffers each key exactly once no matter how the threads interleave.
+     */
+    @Test
+    void testConcurrentAddEventBuffersEachKeyExactlyOnce() throws Exception {
+        UsageTelemetryBuffer telemetry = new UsageTelemetryBuffer();
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch finished = new CountDownLatch(THREADS);
+
+        for (int i = 0; i < THREADS; i++) {
+            new Thread(() -> {
+                try {
+                    start.await();
+                    for (int key = 1; key <= KEYS; key++) {
+                        telemetry.addEvent(event(key));
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    finished.countDown();
+                }
+            }).start();
+        }
+
+        start.countDown();
+        assertTrue(finished.await(30, TimeUnit.SECONDS), "threads did not finish in time");
+        assertEquals(KEYS, buffer(telemetry).size());
+    }
+
+    private static SchemaUsageEventDto event(long globalId) {
+        return SchemaUsageEventDto.builder().globalId(globalId).clientId(CLIENT_ID)
+                .operation("read").eventTimestamp(System.currentTimeMillis()).build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Collection<SchemaUsageEventDto> buffer(UsageTelemetryBuffer telemetry)
+            throws Exception {
+        return (Collection<SchemaUsageEventDto>) field(telemetry, "buffer");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Long> dedupMap(UsageTelemetryBuffer telemetry) throws Exception {
+        return (Map<String, Long>) field(telemetry, "dedupMap");
+    }
+
+    private static Object field(UsageTelemetryBuffer telemetry, String name) throws Exception {
+        Field field = UsageTelemetryBuffer.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(telemetry);
+    }
+}


### PR DESCRIPTION
Closes #9774, which lists five ConcurrentHashMap check-then-act sites. Three are already
covered by open PRs (#9790 for the OIDC caches, #9792 and #9823 for KafkaSqlCoordinator), so
this only touches the two that aren't.

### UsageTelemetryBuffer

`addEvent` read `dedupMap`, decided, then wrote in a separate call. Two requests for the
same schema and client id can both see no recent entry and both buffer the event, which is
the duplicate the dedup window exists to prevent.

One `compute()` now decides and stamps together. The decision leaves the lambda on a flag
rather than by reading what `compute()` returns: neither that nor `merge()` can tell "I
claimed the key" from "someone else claimed it in this same millisecond", because both come
back equal to `now`.

### RegistryStorageConfigCache

`getConfigProperty` loaded through `computeIfAbsent`, so `delegate.getConfigProperty` ran
inside the mapping function, and `computeIfAbsent` holds the bin monitor for the whole call.
`invalidateCache()` therefore blocks inside `clear()` until storage answers. Measured with a
2s mapping function:

    mapping function ran for   : 2000 ms
    clear() blocked for        : 1900 ms
    unrelated get() blocked for: 0 ms

Reads are unaffected, since CHM `get()` is lock-free. It is the invalidation path that waits.
Separately, a `clear()` that passes the bin just before the entry is inserted can leave a
value that was read before the write.

Switching to `compute()` would not help, because the read would still run inside the mapping
function. So the load now happens outside the map, and an `AtomicLong` generation that
`invalidateCache()` bumps guards the write: a load that straddles an invalidation is returned
to the caller but not cached.

Trade-off worth naming: `computeIfAbsent` gave single-flight, one storage read per key. This
does not, so several cold readers for the same key can each read once. Config lookups are
single-row indexed reads and this is a read-through cache, so that seemed the better side to
be on than holding a monitor across storage. If you would rather keep single-flight, I can
cache a `CompletableFuture` per key instead.

`RegistryStorageConfigCache` is a storage decorator and this change is variant-agnostic, so
it behaves the same across all four storage kinds.

### Not changed

`KubernetesAuthenticationStrategy` at lines 86-104 already reads `cache.get()` into a local
and null-checks it, so there is no check-then-act there. `compute()` would be worse: the
TokenReview call would run under the bin monitor, and `cachePut` writes the same map, which
is a recursive update. The compound operation in that class is `cachePut`'s `size()` then
`put()`, which only lets the cache overshoot `MAX_CACHE_SIZE` slightly. Left alone, happy to
pick it up separately.

### Testing

Byteman is not on `main` yet, so these are latch-based in the style the app module already
uses. Both were checked against the unfixed code and both fail there: the telemetry test
buffers 201 events instead of 200, and the config cache test times out after 13.4s because
`clear()` never returns while the load holds the bin.

- `UsageTelemetryBufferTest` releases 8 threads through one barrier over the same 200 keys
  and asserts exactly 200 events reach the buffer, plus the within-window and past-window
  single-threaded cases.
- `RegistryStorageConfigCacheTest` holds a load open on one thread, invalidates from another,
  and asserts the stale value is returned to the caller but not left in the cache, plus
  normal caching and negative caching.
