### PR TITLE
fix(app): remove global lock from RegistryConfigSource's hot path

### DIFF
--- a/app/src/main/java/io/apicurio/registry/services/RegistryConfigSource.java
+++ b/app/src/main/java/io/apicurio/registry/services/RegistryConfigSource.java
@@ -13,26 +13,46 @@ import java.util.Set;
  * <p>
  */
 public class RegistryConfigSource implements ConfigSource {
-    private Map<String, String> properties;
+    // Computed once, eagerly, from environment variables - which are fixed for the lifetime of
+    // the JVM - so this can be a plain final field instead of a lazily-initialized one guarded by
+    // a lock. The previous implementation synchronized on `this` inside getProperties(), but
+    // every single config lookup that reaches this ConfigSource (getValue(), getPropertyNames())
+    // goes through getProperties(), including code paths that re-read config dynamically
+    // per-request rather than once at injection time - under concurrent load this made the lock
+    // a global serialization point, confirmed via thread dumps showing multiple threads BLOCKED
+    // waiting on this monitor.
+    private final Map<String, String> properties;
 
-    @Override
-    public synchronized Map<String, String> getProperties() {
-        if (properties == null) {
-            properties = new HashMap<>();
-            String prefix = System.getenv("REGISTRY_PROPERTIES_PREFIX");
-            if (prefix != null) {
-                String profile = LaunchMode.current().getProfileKey();
-                String profilePrefix = "%" + profile + ".";
-                Map<String, String> envMap = System.getenv();
-                for (Map.Entry<String, String> entry : envMap.entrySet()) {
-                    String key = entry.getKey();
-                    if (key.startsWith(prefix)) {
-                        String newKey = profilePrefix + key.replace("_", ".").toLowerCase();
-                        properties.put(newKey, entry.getValue());
-                    }
+    public RegistryConfigSource() {
+        this(computeProperties());
+    }
+
+    // Package-private, for tests to supply fixed properties directly instead of relying on
+    // System.getenv() (which real env vars aren't practical to control from a unit test).
+    RegistryConfigSource(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+    private static Map<String, String> computeProperties() {
+        Map<String, String> properties = new HashMap<>();
+        String prefix = System.getenv("REGISTRY_PROPERTIES_PREFIX");
+        if (prefix != null) {
+            String profile = LaunchMode.current().getProfileKey();
+            String profilePrefix = "%" + profile + ".";
+            Map<String, String> envMap = System.getenv();
+            for (Map.Entry<String, String> entry : envMap.entrySet()) {
+                String key = entry.getKey();
+                if (key.startsWith(prefix)) {
+                    String newKey = profilePrefix + key.replace("_", ".").toLowerCase();
+                    properties.put(newKey, entry.getValue());
                 }
             }
         }
+        return properties;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
         return properties;
     }
 

--- a/app/src/test/java/io/apicurio/registry/services/RegistryConfigSourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/services/RegistryConfigSourceTest.java
@@ -1,10 +1,8 @@
 package io.apicurio.registry.services;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -12,16 +10,9 @@ import java.util.Set;
 /**
  * Unit tests for RegistryConfigSource.
  * Tests the ConfigSource SPI contract: getPropertyNames() must return property keys,
- * and must be safe to call before getProperties().
+ * and must be safe to call on a source with no properties.
  */
 public class RegistryConfigSourceTest {
-
-    private RegistryConfigSource configSource;
-
-    @BeforeEach
-    public void setUp() {
-        configSource = new RegistryConfigSource();
-    }
 
     /**
      * Test that getPropertyNames() returns property keys (not values).
@@ -29,13 +20,13 @@ public class RegistryConfigSourceTest {
      * a Set of property names (keys), not the property values.
      */
     @Test
-    public void testGetPropertyNamesReturnsKeys() throws Exception {
+    public void testGetPropertyNamesReturnsKeys() {
         Map<String, String> properties = new HashMap<>();
         properties.put("%prod.my.key1", "value1");
         properties.put("%prod.my.key2", "value2");
         properties.put("%prod.another.setting", "another_value");
-        
-        setPropertiesViaReflection(properties);
+
+        RegistryConfigSource configSource = new RegistryConfigSource(properties);
 
         Set<String> propertyNames = configSource.getPropertyNames();
 
@@ -55,33 +46,30 @@ public class RegistryConfigSourceTest {
     }
 
     /**
-     * Test that getPropertyNames() is safe to call before getProperties().
-     * This verifies that getPropertyNames() does not throw NullPointerException
-     * when the internal properties field is null (before lazy initialization).
-     * The method must handle the lazy initialization safely.
+     * Test that getPropertyNames() is safe to call on a source with an empty property map (no
+     * REGISTRY_PROPERTIES_PREFIX-matching env vars found).
      */
     @Test
-    public void testGetPropertyNamesBeforeGetProperties() throws Exception {
-        setPropertiesViaReflection(null);
+    public void testGetPropertyNamesWithNoProperties() {
+        RegistryConfigSource configSource = new RegistryConfigSource(new HashMap<>());
 
-        Set<String> propertyNames = Assertions.assertDoesNotThrow(() -> {
-            return configSource.getPropertyNames();
-        }, "getPropertyNames() should not throw NPE when called before getProperties()");
+        Set<String> propertyNames = Assertions.assertDoesNotThrow(configSource::getPropertyNames,
+                "getPropertyNames() should not throw when there are no properties");
 
-        Assertions.assertNotNull(propertyNames,
-                "getPropertyNames() should return a Set, not null");
-        Assertions.assertTrue(propertyNames instanceof Set,
-                "getPropertyNames() should return a Set instance");
+        Assertions.assertNotNull(propertyNames, "getPropertyNames() should return a Set, not null");
+        Assertions.assertTrue(propertyNames.isEmpty(), "getPropertyNames() should be empty");
     }
 
     /**
-     * Helper method to inject properties via reflection.
-     * This allows unit tests to control the properties without relying on
-     * System.getenv() which is difficult to mock.
+     * The public, no-arg constructor computes properties from real environment variables - this
+     * just verifies it doesn't throw and always returns a non-null, usable ConfigSource, since
+     * REGISTRY_PROPERTIES_PREFIX won't normally be set in a test environment.
      */
-    private void setPropertiesViaReflection(Map<String, String> props) throws Exception {
-        Field propertiesField = RegistryConfigSource.class.getDeclaredField("properties");
-        propertiesField.setAccessible(true);
-        propertiesField.set(configSource, props);
+    @Test
+    public void testDefaultConstructorComputesFromEnvironment() {
+        RegistryConfigSource configSource = new RegistryConfigSource();
+
+        Assertions.assertNotNull(configSource.getProperties());
+        Assertions.assertNotNull(configSource.getPropertyNames());
     }
 }


### PR DESCRIPTION
## What

`RegistryConfigSource.getProperties()` was `synchronized` on `this`, but the lock was only ever
needed for the one-time lazy initialization of the `properties` map - every subsequent call (which
is every single config lookup that reaches this `ConfigSource`, via `getValue()` and
`getPropertyNames()`) still acquired the same monitor just to return an already-computed,
effectively-immutable `Map`.

## Why

Under concurrent load, this became a global serialization point for any code path that reads
MicroProfile Config values dynamically per-request (several places in the codebase use
`Instance<T>` injection specifically so config can be re-read at call time rather than fixed once
at injection). Confirmed via a live thread dump under concurrent load: multiple `executor-thread`
instances `BLOCKED` waiting to acquire this monitor:

```
"executor-thread-N" ... BLOCKED
  at io.apicurio.registry.services.RegistryConfigSource.getProperties(RegistryConfigSource.java:20)
  - waiting to lock <0x...> (a io.apicurio.registry.services.RegistryConfigSource)
  at io.apicurio.registry.services.RegistryConfigSource.getValue(RegistryConfigSource.java:46)
  at io.smallrye.config.SmallRyeConfigSources$ConfigValueConfigSourceWrapper.getConfigValue(...)
```

Found while investigating throughput characteristics in the `perf-tests` module (#9839).

## How

The properties are derived entirely from environment variables, which are fixed for the lifetime
of the JVM, so they're now computed once eagerly (in the public no-arg constructor, still used to
satisfy the `ConfigSource` SPI's no-arg-constructor requirement - see
`META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource`) into a plain `final` field,
removing the need for any lock on the read path.

`RegistryConfigSourceTest` previously used reflection to inject values into (and null out) the old
mutable/nullable field to exercise the lazy-init path, which no longer exists. Added a
package-private constructor for tests to supply fixed properties directly instead, and updated the
tests accordingly (still covers the same SPI-contract behavior: `getPropertyNames()` returns keys
not values, and is safe to call with no properties present).

## Testing

- `./mvnw test -pl app -Dtest=RegistryConfigSourceTest` - 3/3 passing
- `./mvnw checkstyle:check -pl app` - no new violations (verified by diffing against a baseline run
  with pre-existing, unrelated generated-code violations only)

Closes nothing on its own but is referenced by #9852, which has the full investigation/rationale.