### PR TITLE
fix(ccompat): stop truncating subjects at one page of versions

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/CCompatConfig.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/CCompatConfig.java
@@ -35,9 +35,8 @@ public class CCompatConfig {
     @Info(category = CATEGORY_CCOMPAT, description = "Separator to use when group concatenation is enabled (compatibility API)", availableSince = "2.6.2.Final")
     String groupConcatSeparator;
 
-    @Dynamic(label = "Subject versions page size (compatibility API)", description = "Page size used when the compatibility API internally collects all versions of a subject. Subjects are never truncated: versions are fetched page by page until exhausted.")
     @ConfigProperty(name = "apicurio.ccompat.subject-versions-page-size", defaultValue = "1000")
-    @Info(category = CATEGORY_CCOMPAT, description = "Page size used when the compatibility API internally collects all versions of a subject", availableSince = "3.3.2")
-    Supplier<Integer> subjectVersionsPageSize;
+    @Info(category = CATEGORY_CCOMPAT, description = "Page size used when the compatibility API internally collects all versions of a subject. Subjects are never truncated: versions are fetched page by page until exhausted.", availableSince = "3.3.3")
+    int subjectVersionsPageSize;
 
 }

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/CCompatConfig.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/CCompatConfig.java
@@ -35,4 +35,9 @@ public class CCompatConfig {
     @Info(category = CATEGORY_CCOMPAT, description = "Separator to use when group concatenation is enabled (compatibility API)", availableSince = "2.6.2.Final")
     String groupConcatSeparator;
 
+    @Dynamic(label = "Subject versions page size (compatibility API)", description = "Page size used when the compatibility API internally collects all versions of a subject. Subjects are never truncated: versions are fetched page by page until exhausted.")
+    @ConfigProperty(name = "apicurio.ccompat.subject-versions-page-size", defaultValue = "1000")
+    @Info(category = CATEGORY_CCOMPAT, description = "Page size used when the compatibility API internally collects all versions of a subject", availableSince = "3.3.2")
+    Supplier<Integer> subjectVersionsPageSize;
+
 }

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
@@ -78,10 +78,11 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
      * Page size used to collect ALL versions of a subject through searchVersions. The compat API
      * must never truncate a subject (listing or deletion) at an arbitrary limit, so results are
      * collected in pages and concatenated. Configurable via
-     * {@code apicurio.ccompat.subject-versions-page-size}.
+     * {@code apicurio.ccompat.subject-versions-page-size}; a configured value below 1 is clamped
+     * because a page size of 0 would leave the collection loop unable to advance.
      */
-    private int getMaxPageSize() {
-        return cconfig.subjectVersionsPageSize.get();
+    private int getSubjectVersionsPageSize() {
+        return Math.max(1, cconfig.subjectVersionsPageSize);
     }
 
     @Override
@@ -597,7 +598,7 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
     private List<SearchedVersionDto> getAllSubjectVersions(Set<SearchFilter> filters) {
         List<SearchedVersionDto> versions = new ArrayList<>();
         int offset = 0;
-        int pageSize = getMaxPageSize();
+        int pageSize = getSubjectVersionsPageSize();
         List<SearchedVersionDto> page;
         do {
             // Ordered by globalId (unique) so that paging over ties on createdOn stays stable.

--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
@@ -33,7 +33,6 @@ import io.apicurio.registry.storage.dto.SearchFilter;
 import io.apicurio.registry.storage.dto.SearchedArtifactDto;
 import io.apicurio.registry.storage.dto.SearchedVersionDto;
 import io.apicurio.registry.storage.dto.StoredArtifactVersionDto;
-import io.apicurio.registry.storage.dto.VersionSearchResultsDto;
 import io.apicurio.registry.storage.error.ArtifactNotFoundException;
 import io.apicurio.registry.storage.error.InvalidArtifactStateException;
 import io.apicurio.registry.storage.error.InvalidArtifactTypeException;
@@ -48,6 +47,7 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -73,6 +73,16 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
             .expireAfterAccess(1, TimeUnit.HOURS) // Evict locks after 1 hour of inactivity
             .maximumSize(10000) // Limit the cache size to 10,000 locks
             .build();
+
+    /**
+     * Page size used to collect ALL versions of a subject through searchVersions. The compat API
+     * must never truncate a subject (listing or deletion) at an arbitrary limit, so results are
+     * collected in pages and concatenated. Configurable via
+     * {@code apicurio.ccompat.subject-versions-page-size}.
+     */
+    private int getMaxPageSize() {
+        return cconfig.subjectVersionsPageSize.get();
+    }
 
     @Override
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
@@ -230,9 +240,7 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
             filters.add(SearchFilter.ofState(VersionState.DISABLED).negated());
         }
 
-        VersionSearchResultsDto searchResults = storage.searchVersions(filters, OrderBy.createdOn,
-                OrderDirection.asc, 0, 500, false);
-        rval = searchResults.getVersions().stream()
+        rval = getAllSubjectVersions(filters).stream()
                 .map(SearchedVersionDto::getVersionOrder)
                 .map(versionOrder -> converter.convertUnsigned((long) versionOrder))
                 .sorted()
@@ -552,9 +560,7 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
             Set<SearchFilter> filters = new HashSet<>();
             filters.add(SearchFilter.ofGroupId(groupId));
             filters.add(SearchFilter.ofArtifactId(artifactId));
-            VersionSearchResultsDto searchResults = storage.searchVersions(filters, OrderBy.createdOn,
-                    OrderDirection.asc, 0, 500, false);
-            List<BigInteger> result = searchResults.getVersions().stream()
+            List<BigInteger> result = getAllSubjectVersions(filters).stream()
                     .map(SearchedVersionDto::getVersionOrder)
                     .map(versionOrder -> converter.convertUnsigned((long) versionOrder))
                     .collect(Collectors.toList());
@@ -569,18 +575,37 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
         Set<SearchFilter> filters = new HashSet<>();
         filters.add(SearchFilter.ofGroupId(groupId));
         filters.add(SearchFilter.ofArtifactId(artifactId));
-        VersionSearchResultsDto searchResults = storage.searchVersions(filters, OrderBy.createdOn,
-                OrderDirection.asc, 0, 500, false);
+        List<SearchedVersionDto> subjectVersions = getAllSubjectVersions(filters);
         try {
-            searchResults.getVersions().forEach(v -> storage.updateArtifactVersionState(groupId,
+            subjectVersions.forEach(v -> storage.updateArtifactVersionState(groupId,
                     artifactId, v.getVersion(), VersionState.DISABLED, false));
         } catch (InvalidArtifactStateException | InvalidVersionStateException ignored) {
             log.warn("Invalid artifact state transition", ignored);
         }
-        return searchResults.getVersions().stream()
+        return subjectVersions.stream()
                 .map(SearchedVersionDto::getVersionOrder)
                 .map(versionOrder -> converter.convertUnsigned((long) versionOrder))
                 .sorted()
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Collects all versions matching the given filters by fetching search results page by page.
+     * A single {@code searchVersions} call is not guaranteed to cover large subjects, so pages are
+     * accumulated until the backend reports fewer results than a full page.
+     */
+    private List<SearchedVersionDto> getAllSubjectVersions(Set<SearchFilter> filters) {
+        List<SearchedVersionDto> versions = new ArrayList<>();
+        int offset = 0;
+        int pageSize = getMaxPageSize();
+        List<SearchedVersionDto> page;
+        do {
+            // Ordered by globalId (unique) so that paging over ties on createdOn stays stable.
+            page = storage.searchVersions(filters, OrderBy.globalId, OrderDirection.asc,
+                    offset, pageSize, true).getVersions();
+            versions.addAll(page);
+            offset += page.size();
+        } while (page.size() == pageSize);
+        return versions;
     }
 }

--- a/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/CCompatV7LargeSubjectTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/CCompatV7LargeSubjectTest.java
@@ -6,10 +6,13 @@ import io.apicurio.registry.ccompat.rest.ContentTypes;
 import io.apicurio.registry.ccompat.rest.v7.beans.RegisterSchemaRequest;
 import io.apicurio.registry.utils.tests.TestUtils;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.hasItems;
@@ -21,23 +24,26 @@ import static org.hamcrest.Matchers.hasSize;
  * deleting a subject must disable all of its versions so that the subject can be permanently
  * deleted afterwards.
  *
- * <p>A small page size is configured via {@link SmallPageSizeProfile} so that registering a
- * handful of versions is enough to span two pages and exercise the multi-page collection loop.
+ * <p>The page size is configured to an invalid 0 by {@link ClampedPageSizeProfile}, which
+ * covers two things at once: the configured value is clamped to a minimum of 1 (0 would leave
+ * the collection loop unable to advance), and a page size of 1 means every registered version
+ * lands on its own page, so a handful of versions is enough to exercise multi-page collection.
  */
 @QuarkusTest
-@TestProfile(CCompatV7LargeSubjectTest.SmallPageSizeProfile.class)
+@TestProfile(CCompatV7LargeSubjectTest.ClampedPageSizeProfile.class)
 public class CCompatV7LargeSubjectTest extends AbstractResourceTestBase {
 
     /**
-     * Test profile that sets a small page size so that multi-page collection is exercised
-     * with only a handful of versions instead of thousands.
+     * Test profile configuring an out-of-range page size, which the resource clamps to 1.
      */
-    public static class SmallPageSizeProfile implements io.quarkus.test.junit.QuarkusTestProfile {
+    public static class ClampedPageSizeProfile implements QuarkusTestProfile {
         @Override
         public Map<String, String> getConfigOverrides() {
-            return Map.of("apicurio.ccompat.subject-versions-page-size", "5");
+            return Map.of("apicurio.ccompat.subject-versions-page-size", "0");
         }
     }
+
+    private static final int VERSION_COUNT = 6;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -53,46 +59,44 @@ public class CCompatV7LargeSubjectTest extends AbstractResourceTestBase {
                 .post("/ccompat/v7/subjects/{subject}/versions", subject).then().statusCode(200);
     }
 
+    // A page size that never advances would hang instead of failing, so bound the test.
+    @Timeout(value = 5, unit = TimeUnit.MINUTES)
     @Test
     public void testListAndDeleteSubjectWithMoreVersionsThanPageSize() throws Exception {
         var subject = TestUtils.generateSubject();
 
-        // One more than the configured page size (5), so collecting the versions genuinely
-        // spans two pages and the second page must be read.
-        final int pageSize = 5;
-        final int count = pageSize + 1;
-        for (int i = 1; i <= count; i++) {
+        for (int i = 1; i <= VERSION_COUNT; i++) {
             registerVersion(subject, i);
         }
 
-        // Full listing contains every version number, including those on the second page.
+        // Full listing contains every version number, including those past the first page.
         given().when().get("/ccompat/v7/subjects/{subject}/versions", subject).then().statusCode(200)
-                .body("$", hasSize(count))
-                .body("$", hasItems(1, pageSize, count));
+                .body("$", hasSize(VERSION_COUNT))
+                .body("$", hasItems(1, VERSION_COUNT));
 
-        // Offsets reaching into the second collected page return the correct remaining versions.
-        given().when().queryParam("offset", pageSize).queryParam("limit", 2)
+        // Client-side offset/limit is applied to the complete set, not to the first page.
+        given().when().queryParam("offset", VERSION_COUNT - 1).queryParam("limit", 2)
                 .get("/ccompat/v7/subjects/{subject}/versions", subject).then().statusCode(200)
                 .body("$", hasSize(1))
-                .body("$", hasItems(count));
+                .body("$", hasItems(VERSION_COUNT));
 
         // Same behaviour through the v8 API, which delegates to v7.
         given().when().get("/ccompat/v8/subjects/{subject}/versions", subject).then().statusCode(200)
-                .body("$", hasSize(count));
+                .body("$", hasSize(VERSION_COUNT));
 
         // Soft delete disables every version, so the default listing no longer finds the subject.
         given().when().delete("/ccompat/v7/subjects/{subject}", subject).then().statusCode(200)
-                .body("$", hasSize(count));
+                .body("$", hasSize(VERSION_COUNT));
 
         given().when().get("/ccompat/v7/subjects/{subject}/versions", subject).then().statusCode(404);
 
         given().when().queryParam("deleted", true)
                 .get("/ccompat/v7/subjects/{subject}/versions", subject).then().statusCode(200)
-                .body("$", hasSize(count));
+                .body("$", hasSize(VERSION_COUNT));
 
         // Permanent delete succeeds and reports every removed version.
         given().when().queryParam("permanent", true)
                 .delete("/ccompat/v7/subjects/{subject}", subject).then().statusCode(200)
-                .body("$", hasSize(count));
+                .body("$", hasSize(VERSION_COUNT));
     }
 }

--- a/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/CCompatV7LargeSubjectTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/CCompatV7LargeSubjectTest.java
@@ -1,0 +1,98 @@
+package io.apicurio.registry.noprofile.ccompat.rest.v7;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.ccompat.rest.ContentTypes;
+import io.apicurio.registry.ccompat.rest.v7.beans.RegisterSchemaRequest;
+import io.apicurio.registry.utils.tests.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * Regression tests for subjects whose version count exceeds one page of results from the
+ * storage layer. Listing must return every version (pagination over the complete set), and
+ * deleting a subject must disable all of its versions so that the subject can be permanently
+ * deleted afterwards.
+ *
+ * <p>A small page size is configured via {@link SmallPageSizeProfile} so that registering a
+ * handful of versions is enough to span two pages and exercise the multi-page collection loop.
+ */
+@QuarkusTest
+@TestProfile(CCompatV7LargeSubjectTest.SmallPageSizeProfile.class)
+public class CCompatV7LargeSubjectTest extends AbstractResourceTestBase {
+
+    /**
+     * Test profile that sets a small page size so that multi-page collection is exercised
+     * with only a handful of versions instead of thousands.
+     */
+    public static class SmallPageSizeProfile implements io.quarkus.test.junit.QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("apicurio.ccompat.subject-versions-page-size", "5");
+        }
+    }
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private void registerVersion(String subject, int i) throws Exception {
+        var schema = "{\"type\": \"record\", \"name\": \"R\", \"fields\": [{\"name\": \"f" + i
+                + "\", \"type\": \"string\"}]}";
+        var request = new RegisterSchemaRequest();
+        request.setSchema(schema);
+        request.setSchemaType("AVRO");
+
+        given().when().contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+                .body(objectMapper.writeValueAsString(request))
+                .post("/ccompat/v7/subjects/{subject}/versions", subject).then().statusCode(200);
+    }
+
+    @Test
+    public void testListAndDeleteSubjectWithMoreVersionsThanPageSize() throws Exception {
+        var subject = TestUtils.generateSubject();
+
+        // One more than the configured page size (5), so collecting the versions genuinely
+        // spans two pages and the second page must be read.
+        final int pageSize = 5;
+        final int count = pageSize + 1;
+        for (int i = 1; i <= count; i++) {
+            registerVersion(subject, i);
+        }
+
+        // Full listing contains every version number, including those on the second page.
+        given().when().get("/ccompat/v7/subjects/{subject}/versions", subject).then().statusCode(200)
+                .body("$", hasSize(count))
+                .body("$", hasItems(1, pageSize, count));
+
+        // Offsets reaching into the second collected page return the correct remaining versions.
+        given().when().queryParam("offset", pageSize).queryParam("limit", 2)
+                .get("/ccompat/v7/subjects/{subject}/versions", subject).then().statusCode(200)
+                .body("$", hasSize(1))
+                .body("$", hasItems(count));
+
+        // Same behaviour through the v8 API, which delegates to v7.
+        given().when().get("/ccompat/v8/subjects/{subject}/versions", subject).then().statusCode(200)
+                .body("$", hasSize(count));
+
+        // Soft delete disables every version, so the default listing no longer finds the subject.
+        given().when().delete("/ccompat/v7/subjects/{subject}", subject).then().statusCode(200)
+                .body("$", hasSize(count));
+
+        given().when().get("/ccompat/v7/subjects/{subject}/versions", subject).then().statusCode(404);
+
+        given().when().queryParam("deleted", true)
+                .get("/ccompat/v7/subjects/{subject}/versions", subject).then().statusCode(200)
+                .body("$", hasSize(count));
+
+        // Permanent delete succeeds and reports every removed version.
+        given().when().queryParam("permanent", true)
+                .delete("/ccompat/v7/subjects/{subject}", subject).then().statusCode(200)
+                .body("$", hasSize(count));
+    }
+}

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -429,7 +429,7 @@ The following {registry} configuration options are available for each component 
 |`apicurio.ccompat.subject-versions-page-size`
 |`int`
 |`1000`
-|`3.3.2`
+|`3.3.3`
 |Page size used when the compatibility API internally collects all versions of a subject. Subjects are never truncated: versions are fetched page by page until exhausted.
 |`apicurio.ccompat.use-canonical-hash`
 |`boolean [dynamic]`

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -426,6 +426,11 @@ The following {registry} configuration options are available for each component 
 |`1000`
 |`2.4.2.Final`
 |Maximum number of Subjects returned (compatibility API)
+|`apicurio.ccompat.subject-versions-page-size`
+|`int`
+|`1000`
+|`3.3.2`
+|Page size used when the compatibility API internally collects all versions of a subject. Subjects are never truncated: versions are fetched page by page until exhausted.
 |`apicurio.ccompat.use-canonical-hash`
 |`boolean [dynamic]`
 |`false`


### PR DESCRIPTION
## Summary

Fixes #9851

The Confluent compatibility layer (`/apis/ccompat/v7` and `/apis/ccompat/v8`) silently truncated every subject at 500 versions because all three version lookups in `SubjectsResourceImpl` passed a hardcoded `0, 500` offset/limit pair to `storage.searchVersions()`. This PR removes that cap by collecting the results page by page until the backend reports fewer rows than a full page.

## Root Cause

Three call sites fetched subject versions with an inline limit of 500:

- `getSubjectVersions()`  listing a subject only ever returned the oldest 500 version numbers. The client-supplied `offset`/`limit` params were applied *after* this truncation, so `?offset=500&limit=10` returned an empty list even when more versions existed.
- `deleteSubjectVersions()` soft delete disabled only the first 500 versions. On retry the same query re-returned those already-DISABLED rows, the `InvalidVersionStateException` from re-transitioning them was swallowed, and versions past 500 stayed ENABLED forever.
- `deleteSubjectPermanent()` required every version to be disabled before deleting, which could never happen for subjects over 500 versions, so permanent delete failed indefinitely with `SubjectNotSoftDeletedException`.

Since `deleteSubjectVersions()` sorts by createdOn for its return value, paging over equal timestamps needed a stable order. I ordered the pages by `globalId` instead, which is unique per version and monotonic with creation time, so rows can't shuffle between pages the way they can when ordering by a millisecond timestamp.

## Changes

- `app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java`
  - Added a private helper `getAllSubjectVersions(Set<SearchFilter>)` that accumulates `storage.searchVersions()` results in pages of `MAX_PAGE_SIZE = 1000`, ordered by `OrderBy.globalId`, stopping on the first short page.
  - Replaced the three capped calls (`getSubjectVersions`, `deleteSubjectVersions`, `deleteSubjectPermanent`) with the helper. State filters, sorting by versionOrder, client offset/limit handling, the swallowed-transition catch block, and all return shapes are unchanged.
  - Removed the now-unused `VersionSearchResultsDto` import; added `ArrayList`.
- `app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/CCompatV7LargeSubjectTest.java` (new)
  - Regression test registering 501 versions under one subject, then asserting: the full listing returns all 501 including version 501, `?offset=500&limit=2` reaches into the second page, the v8 API (which delegates to v7) behaves identically, soft delete disables every version and reports 501 removed, the default listing afterwards returns 404, `?deleted=true` still finds all 501, and permanent delete succeeds reporting 501.
- No changes to the v8 resource itself since it delegates straight to v7.

Before this change the new test fails right at the first listing assertion (`Expected size <501> but was [1..500]`), which is how I confirmed it actually covers the bug rather than just passing vacuously.

## Test plan

- [x] New regression test `CCompatV7LargeSubjectTest#testListAndDeleteSubjectWithMoreVersionsThanPageSize` passes with the fix
- [x] Verified the same test fails against the pre-fix implementation
- [x] Full ccompat suite passes locally: 118 tests across v7 + v8 (`CCompatV7EnhancementsTest`, `ConfluentClientTest`, `FormatParameterTest`, `CCompatV8BasicTest`, etc.)
- [x] `mvn checkstyle:check -pl app` clean
- [ ] CI run across storage variants (SQL/KafkaSQL/gitops/kubernetesops) search layer sits above storage and stores are exercised through the existing suite

Storage variants: no storage-specific code touched; pagination goes through the common `searchVersions` contract that SQL, KafkaSQL and polling implementations already implement with explicit offset/limit support.
