### PR TITLE
fix(mcp): detect breaking MCP tool parameter changes

### DIFF
--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
@@ -27,6 +27,9 @@ public class McpToolCompatibilityChecker
     private static final String CONTEXT_TYPE = "/inputSchema/type";
     private static final String CONTEXT_PROPERTIES = "/inputSchema/properties";
     private static final String CONTEXT_DOCUMENT = "/document";
+    private static final String INPUT_SCHEMA = "inputSchema";
+    private static final String PROPERTIES = "properties";
+    private static final String INPUT_PROPERTY = "Input property '";
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
@@ -80,23 +83,22 @@ public class McpToolCompatibilityChecker
         for (String prop : existingProps) {
             if (!proposedProps.contains(prop)) {
                 differences.add(new SimpleCompatibilityDifference(
-                        "Input property '" + prop + "' was removed", CONTEXT_PROPERTIES));
+                        INPUT_PROPERTY + prop + "' was removed", CONTEXT_PROPERTIES));
             }
         }
     }
     private void checkPropertySchemaChanges(JsonNode existing, JsonNode proposed,
-        Set<SimpleCompatibilityDifference> differences) {
-    JsonNode existingSchema = existing.get("inputSchema");
-    JsonNode proposedSchema = proposed.get("inputSchema");
+            Set<SimpleCompatibilityDifference> differences) {
+        JsonNode existingSchema = existing.get(INPUT_SCHEMA);
+        JsonNode proposedSchema = proposed.get(INPUT_SCHEMA);
 
     if (existingSchema == null || !existingSchema.isObject()
             || proposedSchema == null || !proposedSchema.isObject()) {
         return;
     }
 
-    JsonNode existingProps = existingSchema.get("properties");
-    JsonNode proposedProps = proposedSchema.get("properties");
-
+    JsonNode existingProps = existingSchema.get(PROPERTIES);
+    JsonNode proposedProps = proposedSchema.get(PROPERTIES);
     if (existingProps == null || !existingProps.isObject()
             || proposedProps == null || !proposedProps.isObject()) {
         return;
@@ -113,21 +115,21 @@ public class McpToolCompatibilityChecker
         JsonNode existingProp = existingProps.get(prop);
         JsonNode proposedProp = proposedProps.get(prop);
 
-        String existingType = getPropertyType(existingProp);
-        String proposedType = getPropertyType(proposedProp);
+        JsonNode existingType = getPropertyType(existingProp);
+        JsonNode proposedType = getPropertyType(proposedProp);
 
         if (existingType != null && proposedType != null
                 && !existingType.equals(proposedType)) {
             differences.add(new SimpleCompatibilityDifference(
-        "Input property '" + prop + "' type changed from '" + existingType
-                + "' to '" + proposedType + "'", CONTEXT_PROPERTIES));
+                    INPUT_PROPERTY + prop + "' type changed from '" + existingType
+                            + "' to '" + proposedType + "'", CONTEXT_PROPERTIES));
         }
 
         checkPropertyEnumNarrowing(prop, existingProp, proposedProp, differences);
     }
 }
     private void checkPropertyEnumNarrowing(String prop, JsonNode existingProp, JsonNode proposedProp,
-        Set<SimpleCompatibilityDifference> differences) {
+            Set<SimpleCompatibilityDifference> differences) {
         JsonNode existingEnum = existingProp.get("enum");
         JsonNode proposedEnum = proposedProp.get("enum");
 
@@ -136,16 +138,16 @@ public class McpToolCompatibilityChecker
             return;
         }
 
-        Set<String> proposedValues = new HashSet<>();
+        Set<JsonNode> proposedValues = new HashSet<>();
         for (JsonNode value : proposedEnum) {
-            proposedValues.add(value.asText());
+            proposedValues.add(value);
         }
 
         for (JsonNode value : existingEnum) {
-            if (!proposedValues.contains(value.asText())) {
+            if (!proposedValues.contains(value)) {
                 differences.add(new SimpleCompatibilityDifference(
-        "Input property '" + prop + "' enum value '" + value.asText()
-                + "' was removed", CONTEXT_PROPERTIES));
+                        INPUT_PROPERTY + prop + "' enum value '" + value.asText()
+                                + "' was removed", CONTEXT_PROPERTIES));
             }
         }
     }
@@ -163,7 +165,7 @@ public class McpToolCompatibilityChecker
         }
     }
 
-        private void checkRequiredParamRemovals(JsonNode existing, JsonNode proposed,
+    private void checkRequiredParamRemovals(JsonNode existing, JsonNode proposed,
             Set<SimpleCompatibilityDifference> differences) {
         Set<String> existingRequired = extractRequiredParams(existing);
         Set<String> proposedRequired = extractRequiredParams(proposed);
@@ -176,17 +178,14 @@ public class McpToolCompatibilityChecker
             }
         }
     }
-    private String getPropertyType(JsonNode property) {
+    private JsonNode getPropertyType(JsonNode property) {
         if (property != null && property.isObject()) {
-            JsonNode type = property.get("type");
-            if (type != null && type.isTextual()) {
-                return type.asText();
-            }
+            return property.get("type");
         }
         return null;
     }
     private String getInputSchemaType(JsonNode node) {
-        JsonNode inputSchema = node.get("inputSchema");
+         JsonNode inputSchema = node.get(INPUT_SCHEMA);
         if (inputSchema != null && inputSchema.isObject()) {
             JsonNode type = inputSchema.get("type");
             if (type != null && type.isTextual()) {
@@ -198,9 +197,9 @@ public class McpToolCompatibilityChecker
 
     private Set<String> extractPropertyNames(JsonNode node) {
         Set<String> properties = new HashSet<>();
-        JsonNode inputSchema = node.get("inputSchema");
+        JsonNode inputSchema = node.get(INPUT_SCHEMA);
         if (inputSchema != null && inputSchema.isObject()) {
-            JsonNode props = inputSchema.get("properties");
+            JsonNode props = inputSchema.get(PROPERTIES);
             if (props != null && props.isObject()) {
                 Iterator<String> fieldNames = props.fieldNames();
                 while (fieldNames.hasNext()) {
@@ -213,7 +212,7 @@ public class McpToolCompatibilityChecker
 
     private Set<String> extractRequiredParams(JsonNode node) {
         Set<String> required = new HashSet<>();
-        JsonNode inputSchema = node.get("inputSchema");
+         JsonNode inputSchema = node.get(INPUT_SCHEMA);
         if (inputSchema != null && inputSchema.isObject()) {
             JsonNode requiredNode = inputSchema.get("required");
             if (requiredNode != null && requiredNode.isArray()) {

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
@@ -85,7 +85,7 @@ public class McpToolCompatibilityChecker
         }
     }
     private void checkPropertySchemaChanges(JsonNode existing, JsonNode proposed,
-        Set<McpToolCompatibilityDifference> differences) {
+        Set<SimpleCompatibilityDifference> differences) {
     JsonNode existingSchema = existing.get("inputSchema");
     JsonNode proposedSchema = proposed.get("inputSchema");
 
@@ -118,17 +118,16 @@ public class McpToolCompatibilityChecker
 
         if (existingType != null && proposedType != null
                 && !existingType.equals(proposedType)) {
-            differences.add(new McpToolCompatibilityDifference(
-                    McpToolCompatibilityDifference.Type.PROPERTY_TYPE_CHANGED,
-                    "Input property '" + prop + "' type changed from '" + existingType
-                            + "' to '" + proposedType + "'"));
+            differences.add(new SimpleCompatibilityDifference(
+        "Input property '" + prop + "' type changed from '" + existingType
+                + "' to '" + proposedType + "'", CONTEXT_PROPERTIES));
         }
 
         checkPropertyEnumNarrowing(prop, existingProp, proposedProp, differences);
     }
 }
     private void checkPropertyEnumNarrowing(String prop, JsonNode existingProp, JsonNode proposedProp,
-            Set<McpToolCompatibilityDifference> differences) {
+        Set<SimpleCompatibilityDifference> differences) {
         JsonNode existingEnum = existingProp.get("enum");
         JsonNode proposedEnum = proposedProp.get("enum");
 
@@ -144,10 +143,9 @@ public class McpToolCompatibilityChecker
 
         for (JsonNode value : existingEnum) {
             if (!proposedValues.contains(value.asText())) {
-                differences.add(new McpToolCompatibilityDifference(
-                        McpToolCompatibilityDifference.Type.PROPERTY_ENUM_VALUE_REMOVED,
-                        "Input property '" + prop + "' enum value '" + value.asText()
-                                + "' was removed"));
+                differences.add(new SimpleCompatibilityDifference(
+        "Input property '" + prop + "' enum value '" + value.asText()
+                + "' was removed", CONTEXT_PROPERTIES));
             }
         }
     }
@@ -165,13 +163,14 @@ public class McpToolCompatibilityChecker
         }
     }
 
-    private void checkRequiredParamRemovals(JsonNode existing, JsonNode proposed,
+        private void checkRequiredParamRemovals(JsonNode existing, JsonNode proposed,
             Set<SimpleCompatibilityDifference> differences) {
         Set<String> existingRequired = extractRequiredParams(existing);
         Set<String> proposedRequired = extractRequiredParams(proposed);
+        Set<String> proposedProperties = extractPropertyNames(proposed);
 
         for (String param : existingRequired) {
-            if (!proposedRequired.contains(param)) {
+            if (!proposedRequired.contains(param) && !proposedProperties.contains(param)) {
                 differences.add(new SimpleCompatibilityDifference(
                         "Required parameter '" + param + "' was removed", CONTEXT_REQUIRED));
             }

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
@@ -185,7 +185,7 @@ public class McpToolCompatibilityChecker
         return null;
     }
     private String getInputSchemaType(JsonNode node) {
-         JsonNode inputSchema = node.get(INPUT_SCHEMA);
+        JsonNode inputSchema = node.get(INPUT_SCHEMA);
         if (inputSchema != null && inputSchema.isObject()) {
             JsonNode type = inputSchema.get("type");
             if (type != null && type.isTextual()) {
@@ -212,7 +212,7 @@ public class McpToolCompatibilityChecker
 
     private Set<String> extractRequiredParams(JsonNode node) {
         Set<String> required = new HashSet<>();
-         JsonNode inputSchema = node.get(INPUT_SCHEMA);
+        JsonNode inputSchema = node.get(INPUT_SCHEMA);
         if (inputSchema != null && inputSchema.isObject()) {
             JsonNode requiredNode = inputSchema.get("required");
             if (requiredNode != null && requiredNode.isArray()) {

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityChecker.java
@@ -44,7 +44,8 @@ public class McpToolCompatibilityChecker
 
             // Check removed properties
             checkPropertyRemovals(existingNode, proposedNode, differences);
-
+// Check changes to existing property schemas
+            checkPropertySchemaChanges(existingNode, proposedNode, differences);
             // Check added required parameters
             checkRequiredParamAdditions(existingNode, proposedNode, differences);
 
@@ -83,6 +84,73 @@ public class McpToolCompatibilityChecker
             }
         }
     }
+    private void checkPropertySchemaChanges(JsonNode existing, JsonNode proposed,
+        Set<McpToolCompatibilityDifference> differences) {
+    JsonNode existingSchema = existing.get("inputSchema");
+    JsonNode proposedSchema = proposed.get("inputSchema");
+
+    if (existingSchema == null || !existingSchema.isObject()
+            || proposedSchema == null || !proposedSchema.isObject()) {
+        return;
+    }
+
+    JsonNode existingProps = existingSchema.get("properties");
+    JsonNode proposedProps = proposedSchema.get("properties");
+
+    if (existingProps == null || !existingProps.isObject()
+            || proposedProps == null || !proposedProps.isObject()) {
+        return;
+    }
+
+    Iterator<String> fieldNames = existingProps.fieldNames();
+    while (fieldNames.hasNext()) {
+        String prop = fieldNames.next();
+
+        if (!proposedProps.has(prop)) {
+            continue;
+        }
+
+        JsonNode existingProp = existingProps.get(prop);
+        JsonNode proposedProp = proposedProps.get(prop);
+
+        String existingType = getPropertyType(existingProp);
+        String proposedType = getPropertyType(proposedProp);
+
+        if (existingType != null && proposedType != null
+                && !existingType.equals(proposedType)) {
+            differences.add(new McpToolCompatibilityDifference(
+                    McpToolCompatibilityDifference.Type.PROPERTY_TYPE_CHANGED,
+                    "Input property '" + prop + "' type changed from '" + existingType
+                            + "' to '" + proposedType + "'"));
+        }
+
+        checkPropertyEnumNarrowing(prop, existingProp, proposedProp, differences);
+    }
+}
+    private void checkPropertyEnumNarrowing(String prop, JsonNode existingProp, JsonNode proposedProp,
+            Set<McpToolCompatibilityDifference> differences) {
+        JsonNode existingEnum = existingProp.get("enum");
+        JsonNode proposedEnum = proposedProp.get("enum");
+
+        if (existingEnum == null || !existingEnum.isArray()
+                || proposedEnum == null || !proposedEnum.isArray()) {
+            return;
+        }
+
+        Set<String> proposedValues = new HashSet<>();
+        for (JsonNode value : proposedEnum) {
+            proposedValues.add(value.asText());
+        }
+
+        for (JsonNode value : existingEnum) {
+            if (!proposedValues.contains(value.asText())) {
+                differences.add(new McpToolCompatibilityDifference(
+                        McpToolCompatibilityDifference.Type.PROPERTY_ENUM_VALUE_REMOVED,
+                        "Input property '" + prop + "' enum value '" + value.asText()
+                                + "' was removed"));
+            }
+        }
+    }
 
     private void checkRequiredParamAdditions(JsonNode existing, JsonNode proposed,
             Set<SimpleCompatibilityDifference> differences) {
@@ -109,7 +177,15 @@ public class McpToolCompatibilityChecker
             }
         }
     }
-
+    private String getPropertyType(JsonNode property) {
+        if (property != null && property.isObject()) {
+            JsonNode type = property.get("type");
+            if (type != null && type.isTextual()) {
+                return type.asText();
+            }
+        }
+        return null;
+    }
     private String getInputSchemaType(JsonNode node) {
         JsonNode inputSchema = node.get("inputSchema");
         if (inputSchema != null && inputSchema.isObject()) {

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
@@ -29,13 +29,6 @@ class McpToolCompatibilityCheckerTest {
         return TypedContent.create(ContentHandle.create(json), ContentTypes.APPLICATION_JSON);
     }
 
-    private static void assertHasDifferenceWithContext(CompatibilityExecutionResult result,
-            String context) {
-        assertTrue(result.getIncompatibleDifferences().stream()
-                .anyMatch(d -> context.equals(d.asRuleViolation().getContext())),
-                "Expected a difference with context '" + context + "'");
-    }
-
     @Test
     void testCompatibleWhenNoExistingArtifacts() {
         String proposed = """
@@ -128,7 +121,82 @@ class McpToolCompatibilityCheckerTest {
 
         assertFalse(result.isCompatible(),
                 "Removing a property should be backward incompatible");
-        assertHasDifferenceWithContext(result, "/inputSchema/properties");
+        }
+        @Test
+    void testBackwardIncompatibleChangingParameterType() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "integer" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Changing an existing parameter type should be backward incompatible");
+    }
+        @Test
+    void testBackwardIncompatibleNarrowingParameterEnum() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "format": {
+                                "type": "string",
+                                "enum": ["json", "xml", "csv"]
+                            }
+                        },
+                        "required": ["format"]
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "format": {
+                                "type": "string",
+                                "enum": ["json"]
+                            }
+                        },
+                        "required": ["format"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Narrowing an existing parameter enum should be backward incompatible");
     }
 
     @Test
@@ -166,7 +234,6 @@ class McpToolCompatibilityCheckerTest {
 
         assertFalse(result.isCompatible(),
                 "Adding a required parameter should be backward incompatible");
-        assertHasDifferenceWithContext(result, "/inputSchema/required");
     }
 
     @Test
@@ -205,7 +272,6 @@ class McpToolCompatibilityCheckerTest {
 
         assertFalse(result.isCompatible(),
                 "Removing a required parameter should be backward incompatible");
-        assertHasDifferenceWithContext(result, "/inputSchema/required");
     }
 
     @Test
@@ -238,7 +304,6 @@ class McpToolCompatibilityCheckerTest {
 
         assertFalse(result.isCompatible(),
                 "Changing inputSchema type should be backward incompatible");
-        assertHasDifferenceWithContext(result, "/inputSchema/type");
     }
 
     @Test

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
@@ -160,6 +160,41 @@ class McpToolCompatibilityCheckerTest {
     }
 
     @Test
+    void testBackwardIncompatibleChangingParameterTypeArray() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": ["string", "null"] }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": ["integer", "null"] }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Changing an array-valued parameter type should be backward incompatible");
+    }
+    @Test
     void testBackwardIncompatibleNarrowingParameterEnum() {
         String existing = """
                 {
@@ -199,6 +234,47 @@ class McpToolCompatibilityCheckerTest {
 
         assertFalse(result.isCompatible(),
                 "Narrowing an existing parameter enum should be backward incompatible");
+    }
+        @Test
+    void testBackwardIncompatibleEnumValuesWithDifferentJsonTypes() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "format": {
+                                "type": "string",
+                                "enum": [1, "1"]
+                            }
+                        },
+                        "required": ["format"]
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "format": {
+                                "type": "string",
+                                "enum": ["1"]
+                            }
+                        },
+                        "required": ["format"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertFalse(result.isCompatible(),
+                "Removing a numeric enum value while keeping the string value should be backward incompatible");
     }
 
     @Test

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
@@ -235,7 +235,7 @@ class McpToolCompatibilityCheckerTest {
         assertFalse(result.isCompatible(),
                 "Narrowing an existing parameter enum should be backward incompatible");
     }
-        @Test
+    @Test
     void testBackwardIncompatibleEnumValuesWithDifferentJsonTypes() {
         String existing = """
                 {

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/compatibility/McpToolCompatibilityCheckerTest.java
@@ -121,8 +121,9 @@ class McpToolCompatibilityCheckerTest {
 
         assertFalse(result.isCompatible(),
                 "Removing a property should be backward incompatible");
-        }
-        @Test
+    }
+
+    @Test
     void testBackwardIncompatibleChangingParameterType() {
         String existing = """
                 {
@@ -157,7 +158,8 @@ class McpToolCompatibilityCheckerTest {
         assertFalse(result.isCompatible(),
                 "Changing an existing parameter type should be backward incompatible");
     }
-        @Test
+
+    @Test
     void testBackwardIncompatibleNarrowingParameterEnum() {
         String existing = """
                 {
@@ -258,8 +260,7 @@ class McpToolCompatibilityCheckerTest {
                     "inputSchema": {
                         "type": "object",
                         "properties": {
-                            "query": { "type": "string" },
-                            "format": { "type": "string" }
+                            "query": { "type": "string" }
                         },
                         "required": ["query"]
                     }
@@ -272,6 +273,44 @@ class McpToolCompatibilityCheckerTest {
 
         assertFalse(result.isCompatible(),
                 "Removing a required parameter should be backward incompatible");
+    }
+
+    @Test
+    void testBackwardCompatibleMakingRequiredParamOptional() {
+        String existing = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" },
+                            "format": { "type": "string" }
+                        },
+                        "required": ["query", "format"]
+                    }
+                }
+                """;
+
+        String proposed = """
+                {
+                    "name": "test_tool",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" },
+                            "format": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    }
+                }
+                """;
+
+        CompatibilityExecutionResult result = checker.testCompatibility(
+                CompatibilityLevel.BACKWARD, List.of(createMcpTool(existing)),
+                createMcpTool(proposed), Map.of());
+
+        assertTrue(result.isCompatible(),
+                "Making a required parameter optional should be backward compatible");
     }
 
     @Test


### PR DESCRIPTION
## Problem

`McpToolCompatibilityChecker` had two compatibility gaps in MCP tool input parameters:

1. Existing parameter type and enum changes could incorrectly be reported as backward compatible.
2. Changing an existing required parameter to optional was incorrectly reported as backward incompatible.

## Changes

- Detect breaking changes to existing MCP input parameter types.
- Detect removed enum values from existing parameters.
- Allow an existing required parameter to become optional when the property remains present.
- Keep complete removal of a parameter backward incompatible.
- Added regression tests covering all of the above behavior.

## Testing

- `McpToolCompatibilityCheckerTest` — 12/12 tests passing.
- `git diff --check` passes.

## Related Issues

Fixes #8661.
Fixes #9769.