### PR TITLE
docs: add Paolo Antinori as a maintainer

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -80,6 +80,7 @@ any other maintainer.
 | Jakub Senko | [@jsenko](https://github.com/jsenko) | Red Hat |
 | Carles Arnal | [@carlesarnal](https://github.com/carlesarnal) | Red Hat |
 | Andrea Peruffo | [@andreaTP](https://github.com/andreaTP) | Red Hat |
+| Paolo Antinori | [@paoloantinori](https://github.com/paoloantinori) | Red Hat |
 
 We actively encourage maintainer nominations from other organizations. Contributor
 diversity is a project health goal — see [ADOPTERS.md](ADOPTERS.md) for organizations


### PR DESCRIPTION
## What
Adds Paolo Antinori (@paoloantinori, Red Hat) to the maintainers table in `GOVERNANCE.md`.

## Why
Per project governance, new maintainer additions require nomination and supermajority approval of current maintainers, as tracked in the related CNCF foundation PR.