### PR TITLE
fix(a2a): add agent-card routing to well-known schema endpoint

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -926,6 +926,8 @@ public class WellKnownResourceImpl implements WellKnownResource {
             return "schemas/model-schema-v1.json";
         } else if ("mcp-tool".equals(type) && "v1".equals(version)) {
             return "schemas/mcp-tool-v1.json";
+        } else if ("agent-card".equals(type) && "v1".equals(version)) {
+            return "schemas/agent-card-v1.json";
         }
         return null;
     }


### PR DESCRIPTION
The agent-card-v1.json schema file already exists in resources/schemas/ but getSchemaResourcePath() had no case for "agent-card", so /.well-known/schemas/agent-card/v1 returned 404 while the equivalent mcp-tool and prompt-template endpoints worked correctly.

Fixes #9161

## Summary

Added the missing routing case in WellKnownResourceImpl.getSchemaResourcePath() that maps "agent-card" / "v1" to "schemas/agent-card-v1.json". The schema file itself already exists — only the routing was missing. This is the same pattern used by the three existing schema types (mcp-tool, prompt-template, model-schema).

## Checklist

- [x] Linked issue has maintainer approval
- [x] No overlapping open PRs for the same issue
- [x] Checked the Tried & Rejected list
- [x] Tests added for new code paths
- [x] Tested locally: ./mvnw test -pl app -am -Dlocal
- [x] ./mvnw checkstyle:check -pl app passes
- [x] All commits have DCO sign-off (git commit -s)