### PR TITLE
enhancement(cli): safely publish registry exports after successful download (#9875)

### DIFF
--- a/cli/src/main/java/io/apicurio/registry/cli/admin/ExportCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/admin/ExportCommand.java
@@ -3,8 +3,12 @@ package io.apicurio.registry.cli.admin;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.CliException;
 import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.vertx.core.Vertx;
+import io.vertx.core.file.AsyncFile;
+import io.vertx.core.file.OpenOptions;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.AtomicMoveNotSupportedException;
@@ -29,6 +33,10 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 public class ExportCommand extends AbstractCommand {
 
     private static final Logger log = Logger.getLogger(ExportCommand.class);
+
+    @Inject
+    Vertx vertx;
+
     private static final int DOWNLOAD_TIMEOUT_SECONDS = 300;
     private static final int HTTP_OK = 200;
     private static final int DEFAULT_HTTP_PORT = 80;
@@ -112,9 +120,7 @@ public class ExportCommand extends AbstractCommand {
                     "apicurio-export-",
                     ".tmp");
 
-            final var content = download(url);
-
-            Files.write(tempFile, content);
+            download(url, tempFile);
 
             moveFile(tempFile, outputPath);
             tempFile = null;
@@ -130,9 +136,9 @@ public class ExportCommand extends AbstractCommand {
         }
     }
 
-    private byte[] download(final URI url) {
+    private void download(final URI url, final Path tempFile) {
         final var httpClient = client.getHttpClient();
-        final var future = new CompletableFuture<byte[]>();
+        final var future = new CompletableFuture<Void>();
 
         final boolean ssl = HTTPS_SCHEME.equals(url.getScheme());
 
@@ -163,15 +169,24 @@ public class ExportCommand extends AbstractCommand {
                                 return;
                             }
 
-                            response.body()
-                                    .onSuccess(buffer -> future.complete(buffer.getBytes()))
+                            response.pause();
+
+                            vertx.fileSystem()
+                                    .open(
+                                            tempFile.toString(),
+                                            new OpenOptions()
+                                                    .setWrite(true)
+                                                    .setCreate(true)
+                                                    .setTruncateExisting(true))
+                                    .onSuccess(asyncFile ->
+                                            streamResponse(response, asyncFile, future))
                                     .onFailure(future::completeExceptionally);
                         })
                         .onFailure(future::completeExceptionally))
                 .onFailure(future::completeExceptionally);
 
         try {
-            return future.get(
+            future.get(
                     DOWNLOAD_TIMEOUT_SECONDS,
                     TimeUnit.SECONDS);
 
@@ -206,6 +221,16 @@ public class ExportCommand extends AbstractCommand {
                     ex,
                     APPLICATION_ERROR_RETURN_CODE);
         }
+    }
+
+    private void streamResponse(
+            final io.vertx.core.http.HttpClientResponse response,
+            final AsyncFile asyncFile,
+            final CompletableFuture<Void> future) {
+
+        response.pipeTo(asyncFile)
+                .onSuccess(ignored -> future.complete(null))
+                .onFailure(future::completeExceptionally);
     }
 
     private static void moveFile(final Path source, final Path target)

--- a/cli/src/main/java/io/apicurio/registry/cli/admin/ExportCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/admin/ExportCommand.java
@@ -7,6 +7,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
@@ -18,6 +19,8 @@ import picocli.CommandLine.Option;
 
 import static io.apicurio.registry.cli.common.CliException.APPLICATION_ERROR_RETURN_CODE;
 import static io.apicurio.registry.cli.common.CliException.VALIDATION_ERROR_RETURN_CODE;
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 @Command(
         name = "export",
@@ -49,8 +52,10 @@ public class ExportCommand extends AbstractCommand {
     public void run(final OutputBuffer output) throws Exception {
         final var outputPath = Path.of(file);
         final var parentDir = outputPath.getParent();
+
         if (parentDir != null && !Files.isDirectory(parentDir)) {
-            throw new CliException("Parent directory does not exist: " + parentDir,
+            throw new CliException(
+                    "Parent directory does not exist: " + parentDir,
                     VALIDATION_ERROR_RETURN_CODE);
         }
 
@@ -62,7 +67,8 @@ public class ExportCommand extends AbstractCommand {
         });
 
         if (downloadRef == null || downloadRef.getHref() == null) {
-            throw new CliException("Server did not return a download reference.",
+            throw new CliException(
+                    "Server did not return a download reference.",
                     APPLICATION_ERROR_RETURN_CODE);
         }
 
@@ -72,7 +78,9 @@ public class ExportCommand extends AbstractCommand {
         downloadFile(downloadUrl, outputPath);
 
         output.writeStdOutChunk(out ->
-                out.append("Registry data exported to '").append(file).append("'.\n"));
+                out.append("Registry data exported to '")
+                        .append(file)
+                        .append("'.\n"));
     }
 
     private URI resolveBaseUri() {
@@ -80,77 +88,155 @@ public class ExportCommand extends AbstractCommand {
         final var contextName = configModel.getCurrentContext();
         final var context = configModel.getContext().get(contextName);
         final var registryUrl = context.getRegistryUrl();
+
         final var suffix = "/apis/registry/v3";
         final var idx = registryUrl.indexOf(suffix);
+
         if (idx >= 0) {
             return URI.create(registryUrl.substring(0, idx));
         }
+
         return URI.create(registryUrl);
     }
 
     private void downloadFile(final URI url, final Path outputPath) {
         log.debugf("Downloading export from: %s", url);
 
+        Path tempFile = null;
+
         try {
-            final var httpClient = client.getHttpClient();
-            final var future = new CompletableFuture<byte[]>();
+            final var parentDir = outputPath.toAbsolutePath().getParent();
 
-            final boolean ssl = HTTPS_SCHEME.equals(url.getScheme());
-            final int defaultPort = ssl ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
-            final int port = url.getPort() != -1 ? url.getPort() : defaultPort;
-            final var requestOptions = new RequestOptions()
-                    .setMethod(HttpMethod.GET)
-                    .setPort(port)
-                    .setHost(url.getHost())
-                    .setURI(url.getPath() + (url.getQuery() != null ? "?" + url.getQuery() : ""))
-                    .setSsl(ssl);
+            tempFile = Files.createTempFile(
+                    parentDir,
+                    "apicurio-export-",
+                    ".tmp");
 
-            httpClient.request(requestOptions)
-                    .onSuccess(req -> req.send()
-                            .onSuccess(response -> {
-                                if (response.statusCode() != HTTP_OK) {
-                                    future.completeExceptionally(new CliException(
-                                            "Failed to download export: HTTP " + response.statusCode(),
-                                            APPLICATION_ERROR_RETURN_CODE));
-                                    return;
-                                }
-                                response.body()
-                                        .onSuccess(buffer -> future.complete(buffer.getBytes()))
-                                        .onFailure(future::completeExceptionally);
-                            })
-                            .onFailure(future::completeExceptionally))
-                    .onFailure(future::completeExceptionally);
+            final var content = download(url);
 
-            final var bytes = future.get(DOWNLOAD_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            Files.write(outputPath, bytes);
+            Files.write(tempFile, content);
+
+            moveFile(tempFile, outputPath);
+            tempFile = null;
+
         } catch (IOException ex) {
-            deleteQuietly(outputPath);
-            throw new CliException("Failed to write export file: " + ex.getMessage(), ex,
+            throw new CliException(
+                    "Failed to write export file: " + ex.getMessage(),
+                    ex,
                     APPLICATION_ERROR_RETURN_CODE);
+
+        } finally {
+            deleteQuietly(tempFile);
+        }
+    }
+
+    private byte[] download(final URI url) {
+        final var httpClient = client.getHttpClient();
+        final var future = new CompletableFuture<byte[]>();
+
+        final boolean ssl = HTTPS_SCHEME.equals(url.getScheme());
+
+        final int defaultPort = ssl ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
+
+        final int port = url.getPort() != -1 ? url.getPort() : defaultPort;
+
+        final var requestOptions = new RequestOptions()
+                .setMethod(HttpMethod.GET)
+                .setPort(port)
+                .setHost(url.getHost())
+                .setURI(url.getPath()
+                        + (url.getQuery() != null
+                                ? "?" + url.getQuery()
+                                : ""))
+                .setSsl(ssl)
+                .setFollowRedirects(true);
+
+        httpClient.request(requestOptions)
+                .onSuccess(req -> req.send()
+                        .onSuccess(response -> {
+                            if (response.statusCode() != HTTP_OK) {
+                                future.completeExceptionally(
+                                        new CliException(
+                                                "Failed to download export: HTTP "
+                                                        + response.statusCode(),
+                                                APPLICATION_ERROR_RETURN_CODE));
+                                return;
+                            }
+
+                            response.body()
+                                    .onSuccess(buffer -> future.complete(buffer.getBytes()))
+                                    .onFailure(future::completeExceptionally);
+                        })
+                        .onFailure(future::completeExceptionally))
+                .onFailure(future::completeExceptionally);
+
+        try {
+            return future.get(
+                    DOWNLOAD_TIMEOUT_SECONDS,
+                    TimeUnit.SECONDS);
+
         } catch (InterruptedException ex) {
-            deleteQuietly(outputPath);
             Thread.currentThread().interrupt();
-            throw new CliException("Download interrupted.", ex, APPLICATION_ERROR_RETURN_CODE);
+
+            throw new CliException(
+                    "Download interrupted.",
+                    ex,
+                    APPLICATION_ERROR_RETURN_CODE);
+
         } catch (TimeoutException ex) {
-            deleteQuietly(outputPath);
-            throw new CliException("Export download timed out after " + DOWNLOAD_TIMEOUT_SECONDS
-                    + " seconds.", ex, APPLICATION_ERROR_RETURN_CODE);
+            throw new CliException(
+                    "Export download timed out after "
+                            + DOWNLOAD_TIMEOUT_SECONDS
+                            + " seconds.",
+                    ex,
+                    APPLICATION_ERROR_RETURN_CODE);
+
         } catch (Exception ex) {
-            deleteQuietly(outputPath);
-            final var cause = ex.getCause() instanceof CliException ce ? ce : null;
+            final var cause =
+                    ex.getCause() instanceof CliException cliException
+                            ? cliException
+                            : null;
+
             if (cause != null) {
                 throw cause;
             }
-            throw new CliException("Failed to download export: " + ex.getMessage(), ex,
+
+            throw new CliException(
+                    "Failed to download export: " + ex.getMessage(),
+                    ex,
                     APPLICATION_ERROR_RETURN_CODE);
         }
     }
 
+    private static void moveFile(final Path source, final Path target)
+            throws IOException {
+
+        try {
+            Files.move(
+                    source,
+                    target,
+                    ATOMIC_MOVE,
+                    REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException ex) {
+            Files.move(
+                    source,
+                    target,
+                    REPLACE_EXISTING);
+        }
+    }
+
     private void deleteQuietly(final Path path) {
+        if (path == null) {
+            return;
+        }
+
         try {
             Files.deleteIfExists(path);
         } catch (IOException cleanupEx) {
-            log.debugf(cleanupEx, "Failed to delete partial export file: %s", path);
+            log.debugf(
+                    cleanupEx,
+                    "Failed to delete temporary export file: %s",
+                    path);
         }
     }
 }

--- a/cli/src/test/java/io/apicurio/registry/cli/ImportExportCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/ImportExportCommandTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.zip.ZipFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -71,6 +72,15 @@ public class ImportExportCommandTest extends AbstractCLITest {
         assertThat(Files.size(exportFile))
                 .as("Export file should not be empty")
                 .isGreaterThan(0);
+
+        try (ZipFile zipFile = new ZipFile(exportFile.toFile())) {
+            assertThat(zipFile.stream()
+                    .map(entry -> entry.getName())
+                    .toList())
+                    .as("Export ZIP should contain a manifest")
+                    .anyMatch(name -> name.contains("manifest"));
+        }
+
     }
 
     @Test


### PR DESCRIPTION
# enhancement(cli): safely publish registry exports after successful download (#9875)

Closes #9875

## Summary

This PR improves the CLI registry export flow by ensuring that the requested destination file is only replaced after the export has been successfully downloaded and written to disk.

The export response is streamed directly to a temporary file in the destination directory, avoiding buffering the entire export in memory. Once the download and file write complete successfully, the temporary file is moved to the requested output path using an atomic move where supported, with a fallback to a regular replace move.

If a download or file operation fails, the temporary file is cleaned up, preventing partial files from being left behind and preserving an existing destination file.

This change preserves the existing timeout, interruption, and application error handling behavior.

## Checklist

* Linked issue has maintainer approval
* No overlapping open PRs for the same issue
* Checked the Tried & Rejected list
* Tests added for new code paths
* Tested locally: `./mvnw test -pl cli -am -Dlocal`
* `./mvnw checkstyle:check -pl cli` passes
* All commits have DCO sign-off (`git commit -s`)
