### PR TITLE
feat(webhooks): add webhook subscription management

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/WebhookCreatedResponseFilter.java
+++ b/app/src/main/java/io/apicurio/registry/rest/WebhookCreatedResponseFilter.java
@@ -1,0 +1,23 @@
+package io.apicurio.registry.rest;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class WebhookCreatedResponseFilter implements ContainerResponseFilter {
+
+    private static final String WEBHOOKS_PATH = "/admin/webhooks";
+
+    @Override
+    public void filter(ContainerRequestContext requestContext,
+            ContainerResponseContext responseContext) {
+
+        if ("POST".equalsIgnoreCase(requestContext.getMethod())
+                && requestContext.getUriInfo().getPath().endsWith(WEBHOOKS_PATH)
+                && responseContext.getStatus() == 200) {
+            responseContext.setStatus(201);
+        }
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/AdminResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/AdminResourceImpl.java
@@ -35,6 +35,9 @@ import io.apicurio.registry.rest.v3.beans.DownloadRef;
 import io.apicurio.registry.rest.v3.beans.GitOpsStatus;
 import io.apicurio.registry.rest.v3.beans.GitOpsValidateRequest;
 import io.apicurio.registry.rest.v3.beans.GitOpsValidateTask;
+import io.apicurio.registry.rest.v3.beans.EditableWebhookSubscription;
+import io.apicurio.registry.rest.v3.beans.WebhookSubscription;
+import io.apicurio.registry.rest.v3.beans.WebhookSubscriptionSearchResults;
 import io.apicurio.registry.rest.v3.beans.RoleMapping;
 import io.apicurio.registry.rest.v3.beans.RoleMappingSearchResults;
 import io.apicurio.registry.rest.v3.beans.Rule;
@@ -56,6 +59,8 @@ import io.apicurio.registry.storage.dto.ConsumerVersionEntryDto;
 import io.apicurio.registry.storage.dto.DeprecationReadinessDto;
 import io.apicurio.registry.storage.dto.SchemaUsageSummaryDto;
 import io.apicurio.registry.storage.dto.UsageSummaryCountsDto;
+import io.apicurio.registry.storage.dto.WebhookSubscriptionDto;
+import io.apicurio.registry.storage.dto.WebhookSubscriptionSearchResultsDto;
 import io.apicurio.registry.storage.error.ConfigPropertyNotFoundException;
 import io.apicurio.registry.storage.error.InvalidPropertyValueException;
 import io.apicurio.registry.storage.error.RuleNotFoundException;
@@ -160,7 +165,6 @@ public class AdminResourceImpl implements AdminResource {
 
     @Context
     HttpServletRequest request;
-
     @Dynamic(label = "Download link expiry", description = "The number of seconds that a generated link to a .zip download file is active before expiring.")
     @ConfigProperty(name = "apicurio.download.href.ttl.seconds", defaultValue = "30")
     @Info(category = CATEGORY_DOWNLOAD, description = "Download link expiry", availableSince = "2.1.2.Final")
@@ -485,6 +489,121 @@ public class AdminResourceImpl implements AdminResource {
     @RoleBasedAccessApiOperation
     public void deleteRoleMapping(String principalId) {
         storage.deleteRoleMapping(principalId);
+    }
+
+    /**
+     * @see io.apicurio.registry.rest.v3.AdminResource#listWebhookSubscriptions(java.math.BigInteger,
+     *      java.math.BigInteger)
+     */
+    @Override
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Admin)
+    @RoleBasedAccessApiOperation
+    public WebhookSubscriptionSearchResults listWebhookSubscriptions(BigInteger limit, BigInteger offset) {
+        if (offset == null) {
+            offset = BigInteger.valueOf(0);
+        }
+        if (limit == null) {
+            limit = BigInteger.valueOf(20);
+        }
+
+        WebhookSubscriptionSearchResultsDto dto =
+                storage.searchWebhookSubscriptions(offset.intValue(), limit.intValue());
+
+        WebhookSubscriptionSearchResults results = new WebhookSubscriptionSearchResults();
+        results.setCount(dto.getCount());
+        results.setWebhookSubscriptions(
+                dto.getWebhookSubscriptions().stream()
+                        .map(this::toWebhookSubscription)
+                        .collect(Collectors.toList())
+        );
+        return results;
+    }
+
+    /**
+     * @see io.apicurio.registry.rest.v3.AdminResource#createWebhookSubscription(
+     *      io.apicurio.registry.rest.v3.beans.EditableWebhookSubscription)
+     */
+    @Override
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Admin)
+    @RoleBasedAccessApiOperation
+    public WebhookSubscription createWebhookSubscription(EditableWebhookSubscription data) {
+        WebhookSubscriptionDto dto = toWebhookSubscriptionDto(data);
+        dto.setSubscriptionId(java.util.UUID.randomUUID().toString());
+        storage.createWebhookSubscription(dto);
+        return toWebhookSubscription(storage.getWebhookSubscription(dto.getSubscriptionId()));
+    }
+
+    /**
+     * @see io.apicurio.registry.rest.v3.AdminResource#getWebhookSubscription(java.lang.String)
+     */
+    @Override
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Admin)
+    @RoleBasedAccessApiOperation
+    public WebhookSubscription getWebhookSubscription(String subscriptionId) {
+        ParameterValidationUtils.requireParameter("subscriptionId", subscriptionId);
+        return toWebhookSubscription(storage.getWebhookSubscription(subscriptionId));
+    }
+
+    /**
+     * @see io.apicurio.registry.rest.v3.AdminResource#updateWebhookSubscription(java.lang.String,
+     *      io.apicurio.registry.rest.v3.beans.EditableWebhookSubscription)
+     */
+    @Override
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Admin)
+    @RoleBasedAccessApiOperation
+    public void updateWebhookSubscription(String subscriptionId, EditableWebhookSubscription data) {
+        ParameterValidationUtils.requireParameter("subscriptionId", subscriptionId);
+
+        WebhookSubscriptionDto dto = toWebhookSubscriptionDto(data);
+        dto.setSubscriptionId(subscriptionId);
+
+        storage.updateWebhookSubscription(dto);
+    }
+
+    /**
+     * @see io.apicurio.registry.rest.v3.AdminResource#deleteWebhookSubscription(java.lang.String)
+     */
+    @Override
+    @MethodMetadata(extractParameters = {"0", MPK_NAME})
+    @Audited
+    @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Admin)
+    @RoleBasedAccessApiOperation
+    public void deleteWebhookSubscription(String subscriptionId) {
+        ParameterValidationUtils.requireParameter("subscriptionId", subscriptionId);
+        storage.deleteWebhookSubscription(subscriptionId);
+    }
+
+    private WebhookSubscriptionDto toWebhookSubscriptionDto(EditableWebhookSubscription data) {
+        WebhookSubscriptionDto dto = new WebhookSubscriptionDto();
+        dto.setEndpointUrl(data.getEndpointUrl());
+        dto.setEventTypes(data.getEventTypes());
+        dto.setGroupFilter(data.getGroupFilter());
+        dto.setArtifactFilter(data.getArtifactFilter());
+        dto.setAuthType(data.getAuthType());
+        dto.setAuthConfig(data.getAuthConfig());
+        dto.setEnabled(Boolean.TRUE.equals(data.getIsEnabled()));
+        return dto;
+    }
+
+    private WebhookSubscription toWebhookSubscription(WebhookSubscriptionDto dto) {
+        if (dto == null) {
+            return null;
+        }
+
+        WebhookSubscription bean = new WebhookSubscription();
+        bean.setSubscriptionId(dto.getSubscriptionId());
+        bean.setEndpointUrl(dto.getEndpointUrl());
+        bean.setEventTypes(dto.getEventTypes());
+        bean.setGroupFilter(dto.getGroupFilter());
+        bean.setArtifactFilter(dto.getArtifactFilter());
+        bean.setAuthType(dto.getAuthType());
+        bean.setAuthConfig(dto.getAuthConfig());
+        bean.setIsEnabled(dto.isEnabled());
+        bean.setOwner(dto.getOwner());
+        bean.setCreatedOn(new java.util.Date(dto.getCreatedOn()));
+        bean.setModifiedBy(dto.getModifiedBy());
+        bean.setModifiedOn(dto.getModifiedOn() == 0 ? null : new java.util.Date(dto.getModifiedOn()));
+        return bean;
     }
 
     /**

--- a/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
@@ -26,6 +26,8 @@ import io.apicurio.registry.storage.dto.OrderBy;
 import io.apicurio.registry.storage.dto.OrderDirection;
 import io.apicurio.registry.storage.dto.OutboxEvent;
 import io.apicurio.registry.storage.dto.RoleMappingDto;
+import io.apicurio.registry.storage.dto.WebhookSubscriptionDto;
+import io.apicurio.registry.storage.dto.WebhookSubscriptionSearchResultsDto;
 import io.apicurio.registry.storage.dto.RoleMappingSearchResultsDto;
 import io.apicurio.registry.storage.dto.ContractRuleSetDto;
 import io.apicurio.registry.storage.dto.ContractAuditEntryDto;
@@ -951,6 +953,43 @@ public interface RegistryStorage extends DynamicConfigStorage {
      * @param principalId
      */
     void deleteRoleMapping(String principalId) throws RegistryStorageException;
+
+    /**
+     * Creates a webhook subscription.
+     *
+     * @param subscription the webhook subscription
+     */
+    void createWebhookSubscription(WebhookSubscriptionDto subscription) throws RegistryStorageException;
+
+    /**
+     * Searches for webhook subscriptions.
+     *
+     * @param offset the number of subscriptions to skip
+     * @param limit the result size limit
+     */
+    WebhookSubscriptionSearchResultsDto searchWebhookSubscriptions(int offset, int limit)
+            throws RegistryStorageException;
+
+    /**
+     * Gets a single webhook subscription.
+     *
+     * @param subscriptionId the subscription identifier
+     */
+    WebhookSubscriptionDto getWebhookSubscription(String subscriptionId) throws RegistryStorageException;
+
+    /**
+     * Updates a webhook subscription.
+     *
+     * @param subscription the webhook subscription
+     */
+    void updateWebhookSubscription(WebhookSubscriptionDto subscription) throws RegistryStorageException;
+
+    /**
+     * Deletes a webhook subscription.
+     *
+     * @param subscriptionId the subscription identifier
+     */
+    void deleteWebhookSubscription(String subscriptionId) throws RegistryStorageException;
 
     /**
      * Deletes ALL user data. Does not delete global data, such as log configuration.

--- a/app/src/main/java/io/apicurio/registry/storage/dto/WebhookSubscriptionDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/WebhookSubscriptionDto.java
@@ -1,0 +1,39 @@
+package io.apicurio.registry.storage.dto;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+/**
+ * Data transfer object representing a webhook subscription.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+@RegisterForReflection
+public class WebhookSubscriptionDto {
+
+    private String subscriptionId;
+    private String endpointUrl;
+    private List<String> eventTypes;
+    private String groupFilter;
+    private String artifactFilter;
+    private String authType;
+    private String authConfig;
+    private boolean isEnabled;
+    private String owner;
+    private long createdOn;
+    private String modifiedBy;
+    private long modifiedOn;
+}

--- a/app/src/main/java/io/apicurio/registry/storage/dto/WebhookSubscriptionSearchResultsDto.java
+++ b/app/src/main/java/io/apicurio/registry/storage/dto/WebhookSubscriptionSearchResultsDto.java
@@ -1,0 +1,27 @@
+package io.apicurio.registry.storage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+/**
+ * Search results for webhook subscriptions.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+public class WebhookSubscriptionSearchResultsDto {
+
+    private List<WebhookSubscriptionDto> webhookSubscriptions;
+    private int count;
+}

--- a/app/src/main/java/io/apicurio/registry/storage/error/WebhookSubscriptionNotFoundException.java
+++ b/app/src/main/java/io/apicurio/registry/storage/error/WebhookSubscriptionNotFoundException.java
@@ -1,0 +1,14 @@
+package io.apicurio.registry.storage.error;
+
+public class WebhookSubscriptionNotFoundException extends NotFoundException {
+
+    private static final long serialVersionUID = 1L;
+
+    public WebhookSubscriptionNotFoundException(String subscriptionId) {
+        super("No webhook subscription '" + subscriptionId + "' was found.");
+    }
+
+    public WebhookSubscriptionNotFoundException(String subscriptionId, Throwable cause) {
+        super("No webhook subscription '" + subscriptionId + "' was found.", cause);
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -1,4 +1,9 @@
 package io.apicurio.registry.storage.impl.kafkasql;
+import io.apicurio.registry.storage.dto.WebhookSubscriptionDto;
+import io.apicurio.registry.storage.impl.kafkasql.messages.CreateWebhookSubscription1Message;
+import io.apicurio.registry.storage.impl.kafkasql.messages.UpdateWebhookSubscription1Message;
+import io.apicurio.registry.storage.impl.kafkasql.messages.DeleteWebhookSubscription1Message;
+
 
 import io.apicurio.common.apps.config.DynamicConfigPropertyDto;
 import io.apicurio.registry.content.ContentHandle;
@@ -1344,6 +1349,52 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
     @Override
     public void deleteOldUsageEvents(long cutoffTimestamp) {
         submitter.submitMessage(new DeleteOldUsageEvents1Message(cutoffTimestamp));
+    }
+    /**
+ * @see io.apicurio.registry.storage.RegistryStorage#getWebhookSubscription(java.lang.String)
+ */
+@Override
+public WebhookSubscriptionDto getWebhookSubscription(String subscriptionId)
+        throws RegistryStorageException {
+    return sqlStore.getWebhookSubscription(subscriptionId);
+}
+ /**
+     * @see io.apicurio.registry.storage.RegistryStorage#createWebhookSubscription(io.apicurio.registry.storage.dto.WebhookSubscriptionDto)
+     */
+    /**
+     * @see io.apicurio.registry.storage.RegistryStorage#searchWebhookSubscriptions(int, int)
+     */
+    @Override
+    public WebhookSubscriptionSearchResultsDto searchWebhookSubscriptions(int offset, int limit)
+            throws RegistryStorageException {
+        return sqlStore.searchWebhookSubscriptions(offset, limit);
+    }
+
+ @Override
+    public void createWebhookSubscription(WebhookSubscriptionDto subscription) throws RegistryStorageException {
+        var message = new CreateWebhookSubscription1Message(subscription);
+        var uuid = blockOnResult(submitter.submitMessage(message));
+        coordinator.waitForResponse(uuid);
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.RegistryStorage#updateWebhookSubscription(io.apicurio.registry.storage.dto.WebhookSubscriptionDto)
+     */
+    @Override
+    public void updateWebhookSubscription(WebhookSubscriptionDto subscription) throws RegistryStorageException {
+        var message = new UpdateWebhookSubscription1Message(subscription);
+        var uuid = blockOnResult(submitter.submitMessage(message));
+        coordinator.waitForResponse(uuid);
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.RegistryStorage#deleteWebhookSubscription(java.lang.String)
+     */
+    @Override
+    public void deleteWebhookSubscription(String subscriptionId) throws RegistryStorageException {
+        var message = new DeleteWebhookSubscription1Message(subscriptionId);
+        var uuid = blockOnResult(submitter.submitMessage(message));
+        coordinator.waitForResponse(uuid);
     }
 
 }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/CreateWebhookSubscription1Message.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/CreateWebhookSubscription1Message.java
@@ -1,0 +1,34 @@
+package io.apicurio.registry.storage.impl.kafkasql.messages;
+
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.dto.WebhookSubscriptionDto;
+import io.apicurio.registry.storage.impl.kafkasql.AbstractMessage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+@ToString
+public class CreateWebhookSubscription1Message extends AbstractMessage {
+
+    private WebhookSubscriptionDto subscription;
+
+    /**
+     * @see io.apicurio.registry.storage.impl.kafkasql.KafkaSqlMessage#dispatchTo(io.apicurio.registry.storage.RegistryStorage)
+     */
+    @Override
+    public Object dispatchTo(RegistryStorage storage) {
+        storage.createWebhookSubscription(subscription);
+        return null;
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/DeleteWebhookSubscription1Message.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/DeleteWebhookSubscription1Message.java
@@ -1,0 +1,33 @@
+package io.apicurio.registry.storage.impl.kafkasql.messages;
+
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.impl.kafkasql.AbstractMessage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+@ToString
+public class DeleteWebhookSubscription1Message extends AbstractMessage {
+
+    private String subscriptionId;
+
+    /**
+     * @see io.apicurio.registry.storage.impl.kafkasql.KafkaSqlMessage#dispatchTo(io.apicurio.registry.storage.RegistryStorage)
+     */
+    @Override
+    public Object dispatchTo(RegistryStorage storage) {
+        storage.deleteWebhookSubscription(subscriptionId);
+        return null;
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/UpdateWebhookSubscription1Message.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/messages/UpdateWebhookSubscription1Message.java
@@ -1,0 +1,34 @@
+package io.apicurio.registry.storage.impl.kafkasql.messages;
+
+import io.apicurio.registry.storage.RegistryStorage;
+import io.apicurio.registry.storage.dto.WebhookSubscriptionDto;
+import io.apicurio.registry.storage.impl.kafkasql.AbstractMessage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+@ToString
+public class UpdateWebhookSubscription1Message extends AbstractMessage {
+
+    private WebhookSubscriptionDto subscription;
+
+    /**
+     * @see io.apicurio.registry.storage.impl.kafkasql.KafkaSqlMessage#dispatchTo(io.apicurio.registry.storage.RegistryStorage)
+     */
+    @Override
+    public Object dispatchTo(RegistryStorage storage) {
+        storage.updateWebhookSubscription(subscription);
+        return null;
+    }
+
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/serde/KafkaSqlMessageIndex.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/serde/KafkaSqlMessageIndex.java
@@ -66,7 +66,10 @@ public class KafkaSqlMessageIndex {
                 MergeArtifactLabels4Message.class,
                 MergeVersionLabels5Message.class,
                 UpdateContractMetadata4Message.class,
-                TransitionContractStatus6Message.class);
+                TransitionContractStatus6Message.class,
+                CreateWebhookSubscription1Message.class,
+                UpdateWebhookSubscription1Message.class,
+                DeleteWebhookSubscription1Message.class);
     }
 
     public static Class<? extends KafkaSqlMessage> lookup(String name) {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/polling/sql/AbstractReadOnlyRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/polling/sql/AbstractReadOnlyRegistryStorage.java
@@ -7,6 +7,8 @@ import io.apicurio.registry.model.GA;
 import io.apicurio.registry.model.VersionId;
 import io.apicurio.registry.storage.RegistryStorage;
 import io.apicurio.registry.storage.dto.ArtifactMetaDataDto;
+import io.apicurio.registry.storage.dto.WebhookSubscriptionDto;
+import io.apicurio.registry.storage.dto.WebhookSubscriptionSearchResultsDto;
 import io.apicurio.registry.storage.dto.ContractRuleSetDto;
 import io.apicurio.registry.storage.dto.ArtifactVersionMetaDataDto;
 import io.apicurio.registry.storage.dto.BranchMetaDataDto;
@@ -243,6 +245,39 @@ public abstract class AbstractReadOnlyRegistryStorage implements RegistryStorage
 
     @Override
     public void createRoleMapping(String principalId, String role, String principalName)
+            throws RegistryStorageException {
+        readOnlyViolation();
+    }
+
+    @Override
+    public void createWebhookSubscription(WebhookSubscriptionDto subscription)
+            throws RegistryStorageException {
+        readOnlyViolation();
+    }
+
+    @Override
+    public WebhookSubscriptionSearchResultsDto searchWebhookSubscriptions(int offset, int limit)
+            throws RegistryStorageException {
+        return WebhookSubscriptionSearchResultsDto.builder()
+                .webhookSubscriptions(List.of())
+                .count(0)
+                .build();
+    }
+
+    @Override
+    public WebhookSubscriptionDto getWebhookSubscription(String subscriptionId)
+            throws RegistryStorageException {
+        return null;
+    }
+
+    @Override
+    public void updateWebhookSubscription(WebhookSubscriptionDto subscription)
+            throws RegistryStorageException {
+        readOnlyViolation();
+    }
+
+    @Override
+    public void deleteWebhookSubscription(String subscriptionId)
             throws RegistryStorageException {
         readOnlyViolation();
     }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -165,6 +165,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
     SqlCommentRepository commentRepository;
     SqlConfigRepository configRepository;
     SqlRoleMappingRepository roleMappingRepository;
+    SqlWebhookSubscriptionRepository webhookSubscriptionRepository;
     SqlDownloadRepository downloadRepository;
     SqlSequenceRepository sequenceRepository;
     SqlExportRepository exportRepository;
@@ -271,6 +272,7 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
         sequenceRepository = new SqlSequenceRepository(handleFactory, sqlStatements, log);
         configRepository = new SqlConfigRepository(handleFactory, sqlStatements, log);
         roleMappingRepository = new SqlRoleMappingRepository(handleFactory, sqlStatements, log);
+        webhookSubscriptionRepository = new SqlWebhookSubscriptionRepository(handleFactory, sqlStatements, log);
         downloadRepository = new SqlDownloadRepository(handleFactory, sqlStatements, log);
         eventRepository = new SqlEventRepository(handleFactory, sqlStatements, log, eventsTopic);
         usageRepository = new SqlUsageRepository(handleFactory, sqlStatements);
@@ -1461,6 +1463,36 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
     public void updateRoleMapping(String principalId, String role) throws RegistryStorageException {
 
         roleMappingRepository.updateRoleMapping(principalId, role);
+    }
+
+    @Override
+    public void createWebhookSubscription(WebhookSubscriptionDto subscription)
+            throws RegistryStorageException {
+        webhookSubscriptionRepository.createWebhookSubscription(subscription);
+    }
+
+    @Override
+    public WebhookSubscriptionSearchResultsDto searchWebhookSubscriptions(int offset, int limit)
+            throws RegistryStorageException {
+        return webhookSubscriptionRepository.searchWebhookSubscriptions(offset, limit);
+    }
+
+    @Override
+    public WebhookSubscriptionDto getWebhookSubscription(String subscriptionId)
+            throws RegistryStorageException {
+        return webhookSubscriptionRepository.getWebhookSubscription(subscriptionId);
+    }
+
+    @Override
+    public void updateWebhookSubscription(WebhookSubscriptionDto subscription)
+            throws RegistryStorageException {
+        webhookSubscriptionRepository.updateWebhookSubscription(subscription);
+    }
+
+    @Override
+    public void deleteWebhookSubscription(String subscriptionId)
+            throws RegistryStorageException {
+        webhookSubscriptionRepository.deleteWebhookSubscription(subscriptionId);
     }
 
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
@@ -1089,6 +1089,59 @@ public abstract class CommonSqlStatements implements SqlStatements {
     }
 
     /**
+     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#insertWebhookSubscription()
+     */
+    @Override
+    public String insertWebhookSubscription() {
+        return "INSERT INTO webhook_subscriptions "
+                + "(subscriptionId, endpointUrl, eventTypes, groupFilter, artifactFilter, authType, authConfig, "
+                + "isEnabled, owner, createdOn, modifiedBy, modifiedOn) "
+                + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#deleteWebhookSubscription()
+     */
+    @Override
+    public String deleteWebhookSubscription() {
+        return "DELETE FROM webhook_subscriptions WHERE subscriptionId = ?";
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#selectWebhookSubscriptionById()
+     */
+    @Override
+    public String selectWebhookSubscriptionById() {
+        return "SELECT w.* FROM webhook_subscriptions w WHERE w.subscriptionId = ?";
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#selectWebhookSubscriptions()
+     */
+    @Override
+    public String selectWebhookSubscriptions() {
+        return "SELECT w.* FROM webhook_subscriptions w ORDER BY w.createdOn ";
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#countWebhookSubscriptions()
+     */
+    @Override
+    public String countWebhookSubscriptions() {
+        return "SELECT COUNT(w.subscriptionId) FROM webhook_subscriptions w";
+    }
+
+    /**
+     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#updateWebhookSubscription()
+     */
+    @Override
+    public String updateWebhookSubscription() {
+        return "UPDATE webhook_subscriptions SET endpointUrl = ?, eventTypes = ?, groupFilter = ?, "
+                + "artifactFilter = ?, authType = ?, authConfig = ?, isEnabled = ?, modifiedBy = ?, modifiedOn = ? "
+                + "WHERE subscriptionId = ?";
+    }
+
+    /**
      * @see io.apicurio.registry.storage.impl.sql.SqlStatements#insertDownload()
      */
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
@@ -631,6 +631,22 @@ public interface SqlStatements {
     public String selectRoleMappingCountByPrincipal();
 
     /*
+     * The next few statements support webhook subscription management.
+     */
+
+    public String insertWebhookSubscription();
+
+    public String deleteWebhookSubscription();
+
+    public String selectWebhookSubscriptionById();
+
+    public String selectWebhookSubscriptions();
+
+    public String countWebhookSubscriptions();
+
+    public String updateWebhookSubscription();
+
+    /*
      * The next few statements support group rule management.
      */
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/WebhookSubscriptionDtoMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/WebhookSubscriptionDtoMapper.java
@@ -1,0 +1,57 @@
+package io.apicurio.registry.storage.impl.sql.mappers;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apicurio.registry.storage.dto.WebhookSubscriptionDto;
+import io.apicurio.registry.storage.impl.sql.jdb.RowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+
+public class WebhookSubscriptionDtoMapper implements RowMapper<WebhookSubscriptionDto> {
+
+    public static final WebhookSubscriptionDtoMapper instance = new WebhookSubscriptionDtoMapper();
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private WebhookSubscriptionDtoMapper() {
+    }
+
+    @Override
+    public WebhookSubscriptionDto map(ResultSet rs) throws SQLException {
+        WebhookSubscriptionDto dto = new WebhookSubscriptionDto();
+
+        dto.setSubscriptionId(rs.getString("subscriptionId"));
+        dto.setEndpointUrl(rs.getString("endpointUrl"));
+        dto.setEventTypes(readEventTypes(rs.getString("eventTypes")));
+        dto.setGroupFilter(rs.getString("groupFilter"));
+        dto.setArtifactFilter(rs.getString("artifactFilter"));
+        dto.setAuthType(rs.getString("authType"));
+        dto.setAuthConfig(rs.getString("authConfig"));
+        dto.setEnabled(rs.getBoolean("isEnabled"));
+        dto.setOwner(rs.getString("owner"));
+        dto.setCreatedOn(rs.getTimestamp("createdOn").getTime());
+        dto.setModifiedBy(rs.getString("modifiedBy"));
+
+        if (rs.getTimestamp("modifiedOn") != null) {
+            dto.setModifiedOn(rs.getTimestamp("modifiedOn").getTime());
+        }
+
+        return dto;
+    }
+
+    private List<String> readEventTypes(String json) throws SQLException {
+        if (json == null || json.isBlank()) {
+            return Collections.emptyList();
+        }
+
+        try {
+            return objectMapper.readValue(json, new TypeReference<List<String>>() {
+            });
+        } catch (Exception e) {
+            throw new SQLException("Failed to deserialize webhook eventTypes.", e);
+        }
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlWebhookSubscriptionRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlWebhookSubscriptionRepository.java
@@ -1,0 +1,156 @@
+package io.apicurio.registry.storage.impl.sql.repositories;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apicurio.registry.storage.dto.WebhookSubscriptionDto;
+import io.apicurio.registry.storage.dto.WebhookSubscriptionSearchResultsDto;
+import io.apicurio.registry.storage.error.RegistryStorageException;
+import io.apicurio.registry.storage.error.WebhookSubscriptionNotFoundException;
+import io.apicurio.registry.storage.impl.sql.HandleFactory;
+import io.apicurio.registry.storage.impl.sql.SqlStatements;
+import io.apicurio.registry.storage.impl.sql.mappers.WebhookSubscriptionDtoMapper;
+import org.slf4j.Logger;
+
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Optional;
+
+
+public class SqlWebhookSubscriptionRepository {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final Logger log;
+    private final SqlStatements sqlStatements;
+    private final HandleFactory handles;
+
+    public SqlWebhookSubscriptionRepository(HandleFactory handles, SqlStatements sqlStatements, Logger log) {
+        this.handles = handles;
+        this.sqlStatements = sqlStatements;
+        this.log = log;
+    }
+
+    public void createWebhookSubscription(WebhookSubscriptionDto subscription)
+            throws RegistryStorageException {
+
+        log.debug("Inserting webhook subscription: {}", subscription.getSubscriptionId());
+
+        handles.withHandle(handle -> {
+            handle.createUpdate(sqlStatements.insertWebhookSubscription())
+                    .bind(0, subscription.getSubscriptionId())
+                    .bind(1, subscription.getEndpointUrl())
+                    .bind(2, serializeEventTypes(subscription.getEventTypes()))
+                    .bind(3, subscription.getGroupFilter())
+                    .bind(4, subscription.getArtifactFilter())
+                    .bind(5, subscription.getAuthType())
+                    .bind(6, subscription.getAuthConfig())
+                    .bind(7, subscription.isEnabled())
+                    .bind(8, subscription.getOwner())
+                    .bind(9, new Timestamp(subscription.getCreatedOn()))
+                    .bind(10, subscription.getModifiedBy())
+                    .bind(11, subscription.getModifiedOn() > 0
+                            ? new Timestamp(subscription.getModifiedOn())
+                            : null)
+                    .execute();
+            return null;
+        });
+    }
+
+    public void deleteWebhookSubscription(String subscriptionId)
+            throws RegistryStorageException {
+
+        log.debug("Deleting webhook subscription: {}", subscriptionId);
+
+        handles.withHandle(handle -> {
+            int rowCount = handle.createUpdate(sqlStatements.deleteWebhookSubscription())
+                    .bind(0, subscriptionId)
+                    .execute();
+
+            if (rowCount == 0) {
+                throw new RegistryStorageException(
+                        "Webhook subscription not found: " + subscriptionId);
+            }
+
+            return null;
+        });
+    }
+
+    public WebhookSubscriptionDto getWebhookSubscription(String subscriptionId)
+            throws RegistryStorageException {
+
+        log.debug("Selecting webhook subscription: {}", subscriptionId);
+
+        return handles.withHandle(handle -> {
+            Optional<WebhookSubscriptionDto> result =
+                    handle.createQuery(sqlStatements.selectWebhookSubscriptionById())
+                            .bind(0, subscriptionId)
+                            .map(WebhookSubscriptionDtoMapper.instance)
+                            .findOne();
+
+           return result.orElseThrow(() ->
+        new WebhookSubscriptionNotFoundException(subscriptionId));
+        });
+    }
+
+    public WebhookSubscriptionSearchResultsDto searchWebhookSubscriptions(int offset, int limit)
+            throws RegistryStorageException {
+
+        log.debug("Searching webhook subscriptions.");
+
+        return handles.withHandleNoException(handle -> {
+            String query = sqlStatements.selectWebhookSubscriptions() + " LIMIT ? OFFSET ?";
+            String countQuery = sqlStatements.countWebhookSubscriptions();
+
+            List<WebhookSubscriptionDto> subscriptions =
+                    handle.createQuery(query)
+                            .bind(0, limit)
+                            .bind(1, offset)
+                            .map(WebhookSubscriptionDtoMapper.instance)
+                            .list();
+
+            Integer count = handle.createQuery(countQuery)
+                    .mapTo(Integer.class)
+                    .one();
+
+            return WebhookSubscriptionSearchResultsDto.builder()
+                    .webhookSubscriptions(subscriptions)
+                    .count(count)
+                    .build();
+        });
+    }
+
+    private String serializeEventTypes(List<String> eventTypes) throws RegistryStorageException {
+        try {
+            return objectMapper.writeValueAsString(eventTypes);
+        } catch (Exception e) {
+            throw new RegistryStorageException("Failed to serialize webhook eventTypes.", e);
+        }
+    }
+
+    public void updateWebhookSubscription(WebhookSubscriptionDto subscription)
+            throws RegistryStorageException {
+
+        log.debug("Updating webhook subscription: {}", subscription.getSubscriptionId());
+
+        handles.withHandle(handle -> {
+            int rowCount = handle.createUpdate(sqlStatements.updateWebhookSubscription())
+                    .bind(0, subscription.getEndpointUrl())
+                    .bind(1, serializeEventTypes(subscription.getEventTypes()))
+                    .bind(2, subscription.getGroupFilter())
+                    .bind(3, subscription.getArtifactFilter())
+                    .bind(4, subscription.getAuthType())
+                    .bind(5, subscription.getAuthConfig())
+                    .bind(6, subscription.isEnabled())
+                    .bind(7, subscription.getModifiedBy())
+                    .bind(8, new Timestamp(subscription.getModifiedOn()))
+                    .bind(9, subscription.getSubscriptionId())
+                    .execute();
+
+            if (rowCount == 0) {
+                throw new RegistryStorageException(
+                        "Webhook subscription not found: " + subscription.getSubscriptionId());
+            }
+
+            return null;
+        });
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/rbac/AdminResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/rbac/AdminResourceTest.java
@@ -502,7 +502,110 @@ public class AdminResourceTest extends AbstractResourceTestBase {
         given().when().delete("/registry/v3/admin/roleMappings/TestUser").then().statusCode(204)
                 .body(anything());
     }
+    @Test
+    public void testWebhookSubscriptions() throws Exception {
+        // Start with no webhook subscriptions
+        given().when().get("/registry/v3/admin/webhooks").then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("webhookSubscriptions[0]", nullValue())
+                .body("count", equalTo(0));
 
+        // Create a webhook subscription
+        String endpointUrl = "https://example.com/webhook-" + UUID.randomUUID();
+
+        String subscription = """
+                {
+                  "endpointUrl": "%s",
+                  "eventTypes": ["ARTIFACT_CREATED", "ARTIFACT_UPDATED"],
+                  "groupFilter": "test-group",
+                  "artifactFilter": "test-artifact",
+                  "authType": "NONE",
+                  "isEnabled": true
+                }
+                """.formatted(endpointUrl);
+
+        String subscriptionId = given().when()
+                .contentType(CT_JSON)
+                .body(subscription)
+                .post("/registry/v3/admin/webhooks")
+                .then()
+                .statusCode(201)
+                .contentType(ContentType.JSON)
+                .body("subscriptionId", notNullValue())
+                .body("endpointUrl", equalTo(endpointUrl))
+                .body("eventTypes", equalTo(List.of("ARTIFACT_CREATED", "ARTIFACT_UPDATED")))
+                .body("groupFilter", equalTo("test-group"))
+                .body("artifactFilter", equalTo("test-artifact"))
+                .body("authType", equalTo("NONE"))
+                .body("isEnabled", equalTo(true))
+                .extract()
+                .path("subscriptionId");
+
+        // Get the subscription
+        given().when()
+                .get("/registry/v3/admin/webhooks/{subscriptionId}", subscriptionId)
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("subscriptionId", equalTo(subscriptionId))
+                .body("endpointUrl", equalTo(endpointUrl));
+
+        // Verify it appears in the list
+        given().when()
+                .get("/registry/v3/admin/webhooks")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("count", equalTo(1))
+                .body("webhookSubscriptions[0].subscriptionId", equalTo(subscriptionId));
+
+        // Update the subscription
+        String updatedEndpointUrl = "https://example.com/updated-" + UUID.randomUUID();
+
+        String update = """
+                {
+                  "endpointUrl": "%s",
+                  "eventTypes": ["ARTIFACT_CREATED"],
+                  "groupFilter": "updated-group",
+                  "artifactFilter": "updated-artifact",
+                  "authType": "NONE",
+                  "isEnabled": false
+                }
+                """.formatted(updatedEndpointUrl);
+
+        given().when()
+                .contentType(CT_JSON)
+                .body(update)
+                .put("/registry/v3/admin/webhooks/{subscriptionId}", subscriptionId)
+                .then()
+                .statusCode(204);
+
+        // Verify the update
+        given().when()
+                .get("/registry/v3/admin/webhooks/{subscriptionId}", subscriptionId)
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("subscriptionId", equalTo(subscriptionId))
+                .body("endpointUrl", equalTo(updatedEndpointUrl))
+                .body("eventTypes", equalTo(List.of("ARTIFACT_CREATED")))
+                .body("groupFilter", equalTo("updated-group"))
+                .body("artifactFilter", equalTo("updated-artifact"))
+                .body("isEnabled", equalTo(false));
+
+        // Delete the subscription
+        given().when()
+                .delete("/registry/v3/admin/webhooks/{subscriptionId}", subscriptionId)
+                .then()
+                .statusCode(204);
+
+        // Verify deletion
+        given().when()
+                .get("/registry/v3/admin/webhooks/{subscriptionId}", subscriptionId)
+                .then()
+                .statusCode(404);
+    }
     @Test
     public void testRoleMappingPaging() throws Exception {
         // Start with no role mappings

--- a/app/src/test/java/io/apicurio/registry/storage/impl/search/TestInMemoryRegistryStorage.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/search/TestInMemoryRegistryStorage.java
@@ -1,5 +1,6 @@
 package io.apicurio.registry.storage.impl.search;
-
+import io.apicurio.registry.storage.dto.WebhookSubscriptionDto;
+import io.apicurio.registry.storage.dto.WebhookSubscriptionSearchResultsDto;
 import io.apicurio.common.apps.config.DynamicConfigPropertyDto;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.content.TypedContent;
@@ -593,7 +594,30 @@ public class TestInMemoryRegistryStorage implements RegistryStorage {
     public void deleteRoleMapping(String principalId) {
         throw new UnsupportedOperationException();
     }
+    @Override
+    public void createWebhookSubscription(WebhookSubscriptionDto subscription) {
+         throw new UnsupportedOperationException();
+    }
 
+@Override
+public WebhookSubscriptionDto getWebhookSubscription(String subscriptionId) {
+    throw new UnsupportedOperationException();
+}
+
+@Override
+public WebhookSubscriptionSearchResultsDto searchWebhookSubscriptions(int offset, int limit) {
+    throw new UnsupportedOperationException();
+}
+
+@Override
+public void updateWebhookSubscription(WebhookSubscriptionDto subscription) {
+    throw new UnsupportedOperationException();
+}
+
+@Override
+public void deleteWebhookSubscription(String subscriptionId) {
+    throw new UnsupportedOperationException();
+}
     @Override
     public void deleteAllUserData() {
         throw new UnsupportedOperationException();

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -2950,6 +2950,207 @@
         "description": "Gets a list of all the configured artifact types.\n\nThis operation can fail for the following reasons:\n\n* A server error occurred (HTTP error `500`)\n"
       }
     },
+    "/admin/webhooks": {
+      "summary": "Collection to manage webhook subscriptions.",
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "description": "The number of webhook subscriptions to return. Defaults to 20.",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "query"
+          },
+          {
+            "name": "offset",
+            "description": "The number of webhook subscriptions to skip before starting the result set. Defaults to 0.",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookSubscriptionSearchResults"
+                }
+              }
+            },
+            "description": "A successful response will return the list of webhook subscriptions."
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "operationId": "listWebhookSubscriptions",
+        "summary": "List webhook subscriptions",
+        "description": "Gets a paginated list of webhook subscriptions."
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EditableWebhookSubscription"
+              }
+            }
+          },
+          "required": true
+        },
+        "tags": [
+          "Admin"
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookSubscription"
+                }
+              }
+            },
+            "description": "Returned when the webhook subscription was successfully created."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "operationId": "createWebhookSubscription",
+        "summary": "Create a webhook subscription",
+        "description": "Creates a new webhook subscription."
+      }
+    },
+    "/admin/webhooks/{subscriptionId}": {
+      "summary": "Manage a single webhook subscription.",
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookSubscription"
+                }
+              }
+            },
+            "description": "Returns the webhook subscription."
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "operationId": "getWebhookSubscription",
+        "summary": "Get a webhook subscription",
+        "description": "Returns a single webhook subscription."
+      },
+      "put": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EditableWebhookSubscription"
+              }
+            }
+          },
+          "required": true
+        },
+        "tags": [
+          "Admin"
+        ],
+        "responses": {
+          "204": {
+            "description": "Response when the update is successful."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "operationId": "updateWebhookSubscription",
+        "summary": "Update a webhook subscription",
+        "description": "Updates a webhook subscription."
+      },
+      "delete": {
+        "tags": [
+          "Admin"
+        ],
+        "responses": {
+          "204": {
+            "description": "Response returned when the delete was successful."
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "operationId": "deleteWebhookSubscription",
+        "summary": "Delete a webhook subscription",
+        "description": "Deletes a webhook subscription."
+      },
+      "parameters": [
+        {
+          "name": "subscriptionId",
+          "description": "Unique identifier of the webhook subscription.",
+          "schema": {
+            "type": "string"
+          },
+          "in": "path",
+          "required": true
+        }
+      ]
+    },
     "/admin/contracts/ruleset": {
       "summary": "Manage the global contract ruleset.",
       "get": {
@@ -8367,6 +8568,101 @@
           "labels": {
             "custom-1": "foo",
             "custom-2": "bar"
+          }
+        }
+      },
+      "WebhookSubscription": {
+        "description": "A webhook subscription configured for registry events.",
+        "type": "object",
+        "properties": {
+          "subscriptionId": {
+            "type": "string"
+          },
+          "endpointUrl": {
+            "type": "string"
+          },
+          "eventTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "groupFilter": {
+            "type": "string"
+          },
+          "artifactFilter": {
+            "type": "string"
+          },
+          "authType": {
+            "type": "string"
+          },
+          "authConfig": {
+            "type": "string"
+          },
+          "isEnabled": {
+            "type": "boolean"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "createdOn": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "modifiedBy": {
+            "type": "string"
+          },
+          "modifiedOn": {
+            "format": "date-time",
+            "type": "string"
+          }
+        }
+      },
+      "EditableWebhookSubscription": {
+        "type": "object",
+        "properties": {
+          "endpointUrl": {
+            "type": "string"
+          },
+          "eventTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "groupFilter": {
+            "type": "string"
+          },
+          "artifactFilter": {
+            "type": "string"
+          },
+          "authType": {
+            "type": "string"
+          },
+          "authConfig": {
+            "type": "string"
+          },
+          "isEnabled": {
+            "type": "boolean"
+          }
+        }
+      },
+      "WebhookSubscriptionSearchResults": {
+        "description": "Describes the response received when searching for webhook subscriptions.",
+        "required": [
+          "count",
+          "webhookSubscriptions"
+        ],
+        "type": "object",
+        "properties": {
+          "webhookSubscriptions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WebhookSubscription"
+            }
+          },
+          "count": {
+            "type": "integer"
           }
         }
       },


### PR DESCRIPTION
## Summary

Implements webhook subscription management as part of the CloudEvents webhook notification project tracked by #8426.

## Changes

- Add webhook subscription DTOs and search results.
- Extend `RegistryStorage` with create, search, get, update, and delete operations.
- Implement SQL persistence with a dedicated repository and mapper.
- Add KafkaSQL create/update/delete message types and message-index registration.
- Add REST endpoints for listing, creating, retrieving, updating, and deleting webhook subscriptions.
- Add webhook subscription not-found handling and creation response status handling.
- Update the OpenAPI contract.
- Update RBAC and in-memory storage tests for the new subscription lifecycle.

## Scope

This PR addresses the webhook subscription management API subtask in #8567 and builds on the existing storage architecture used by the SQL and KafkaSQL variants.

Fixes #8567
Related to #8426