### PR TITLE
fix(ci): use install instead of package for parallel builds to prevent test-jar race

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -216,7 +216,7 @@ non-Java changes (docs, UI).
 | Workflow | Trigger | Purpose | Duration |
 |----------|---------|---------|----------|
 | `verify.yaml` | PR, push to main | Main orchestrator: `decide` job determines what to run, `gate` (Verification Gate) is the single required check | N/A |
-| `build-java`/`build-ui` (jobs in `verify.yaml`) | Called by verify | Parallel Java (`mvnw package -T 0.5C`) + UI (`npm build`) builds. Produces Docker images and build artifacts uploaded with 1-day retention. The sole build for a commit, shared by every other job in the same run via `needs:` | ~6 min |
+| `build-java`/`build-ui` (jobs in `verify.yaml`) | Called by verify | Parallel Java (`mvnw install -T 0.5C`) + UI (`npm build`) builds. Produces Docker images and build artifacts uploaded with 1-day retention. The sole build for a commit, shared by every other job in the same run via `needs:` | ~6 min |
 | `verify-unit-tests.yaml` | Called by verify | Unit tests in 7 parallel shards (see above) | ~14 min (critical path) |
 | `scalpel-report` (job in `verify.yaml`) | PR with java changes | Scalpel affected-module analysis in report mode; uploads JSON artifact for offline analysis. Not in the Verification Gate. Opt out per PR with the `ci/disable-scalpel` label | ~2 min |
 | `verify-integration-tests.yaml` | Called by verify | 13-job matrix across storage backends, each with Minikube | ~15 min per job |

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -110,7 +110,7 @@ jobs:
           # -DcliSkipNative: skip GraalVM native-image for CLI (separate verify-cli job handles this)
           # -Daether.syncContext.named.factory=noop: prevent Maven 3.9+ resolver lock deadlocks under -T
           # -Dmaven.wagon.http*: limit concurrent HTTP connections and retry on transient download failures
-          ./mvnw clean package -T 0.5C --no-transfer-progress -s ${{ github.workspace }}/.github/ci-settings.xml \
+          ./mvnw clean install -T 0.5C --no-transfer-progress -s ${{ github.workspace }}/.github/ci-settings.xml \
             -Pprod -Dfull -DskipTests -DskipCommitIdPlugin=false -DcliSkipNative \
             -Dmaven.source.skip=true -Dmaven.javadoc.skip=true \
             -Daether.syncContext.named.factory=noop \

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -596,6 +596,7 @@
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>
+            <phase>process-test-classes</phase>
             <goals>
               <goal>test-jar</goal>
             </goals>


### PR DESCRIPTION
## Summary

- Change `mvn package -T 0.5C` to `mvn install -T 0.5C` in `verify.yaml`
- Bind `app` module's test-jar goal to `process-test-classes` phase (matching `schema-util/common`)

Closes #9880

## Why

Intermittent "cannot find symbol" compilation failures in CI (observed on PR #9821). When the CI cache restores a stale test-jar from `~/.m2/repository` that predates a newly added class, Maven resolves the stale version instead of the reactor-built one. With `install`, the reactor-built test-jar is written to the local repo before dependent modules compile, eliminating the race.

The `process-test-classes` phase binding is belt-and-suspenders: it produces the test-jar earlier in the lifecycle, reducing the window for timing issues.

## Affected modules

Only 2 test-jar producers have cross-module consumers:
- `schema-util/common` (already bound to `process-test-classes`) -> json, avro, iceberg
- `app` (was default `package`, now `process-test-classes`) -> integration-tests

## Research

Full analysis at `claudedocs/research_test-jar-parallel-build-race_2026-08-28.md`

## Test plan

- [ ] CI builds succeed consistently (no more intermittent "cannot find symbol")
- [ ] Build time not significantly affected (install overhead is negligible on ephemeral runners)