### PR TITLE
fix(sonar): resolve BLOCKER and CRITICAL SonarCloud findings

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/JacksonJsonMappingExceptionMapper.java
+++ b/app/src/main/java/io/apicurio/registry/rest/JacksonJsonMappingExceptionMapper.java
@@ -25,33 +25,9 @@ public class JacksonJsonMappingExceptionMapper implements ExceptionMapper<JsonMa
 
     @Override
     public Response toResponse(JsonMappingException exception) {
-        String actualValue = null;
-        boolean isStatusEnum = false;
+        String actualValue = extractInvalidStatusValue(exception);
 
-        if (exception instanceof ValueInstantiationException) {
-            ValueInstantiationException vie = (ValueInstantiationException) exception;
-            if (vie.getType() != null && ContractStatusTransition.Status.class.equals(vie.getType().getRawClass())) {
-                isStatusEnum = true;
-                if (vie.getCause() instanceof IllegalArgumentException) {
-                    String message = vie.getCause().getMessage();
-                    if (message != null && !message.isBlank()
-                            && !message.contains(" ")
-                            && !message.contains(".")) {
-                        actualValue = message;
-                    }
-                }
-            }
-        } else if (exception instanceof InvalidFormatException) {
-            InvalidFormatException ife = (InvalidFormatException) exception;
-            if (ContractStatusTransition.Status.class.equals(ife.getTargetType())) {
-                isStatusEnum = true;
-                if (ife.getValue() != null) {
-                    actualValue = String.valueOf(ife.getValue());
-                }
-            }
-        }
-
-        if (isStatusEnum && actualValue != null) {
+        if (actualValue != null) {
             return coreMapper.mapException(new InvalidParameterValueException("status", "valid status enum value", actualValue));
         }
 
@@ -64,5 +40,35 @@ public class JacksonJsonMappingExceptionMapper implements ExceptionMapper<JsonMa
         return coreMapper.mapException(
             new BadRequestException("Not able to deserialize data provided.")
         );
+    }
+
+    /**
+     * If the given exception represents an invalid value assigned to a
+     * {@link ContractStatusTransition.Status} enum field, and the offending raw value can be
+     * determined, returns that raw value. Returns null otherwise (either the exception is
+     * unrelated to that enum, or the raw value could not be determined), in which case the
+     * caller falls back to generic message-based handling.
+     */
+    private String extractInvalidStatusValue(JsonMappingException exception) {
+        if (exception instanceof ValueInstantiationException vie) {
+            if (vie.getType() != null && ContractStatusTransition.Status.class.equals(vie.getType().getRawClass())) {
+                return extractValueFromCause(vie.getCause());
+            }
+        } else if (exception instanceof InvalidFormatException ife) {
+            if (ContractStatusTransition.Status.class.equals(ife.getTargetType()) && ife.getValue() != null) {
+                return String.valueOf(ife.getValue());
+            }
+        }
+        return null;
+    }
+
+    private String extractValueFromCause(Throwable cause) {
+        if (cause instanceof IllegalArgumentException) {
+            String message = cause.getMessage();
+            if (message != null && !message.isBlank() && !message.contains(" ") && !message.contains(".")) {
+                return message;
+            }
+        }
+        return null;
     }
 }

--- a/app/src/main/java/io/apicurio/registry/rest/v3/impl/SearchResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/v3/impl/SearchResourceImpl.java
@@ -60,6 +60,7 @@ public class SearchResourceImpl implements SearchResource {
 
     private static final String EMPTY_CONTENT_ERROR_MESSAGE = "Empty content is not allowed.";
     private static final String CANONICAL_QUERY_PARAM_ERROR_MESSAGE = "When setting 'canonical' to 'true', the 'artifactType' query parameter is also required.";
+    private static final String CONTRACT_LABEL_PREFIX = "contract.*";
 
     @Inject
     @Current
@@ -439,20 +440,20 @@ public class SearchResourceImpl implements SearchResource {
         // (e.g. "contract.myid.status"). The trailing "*" is required for a prefix match
         // covering both forms, since the SQL layer only treats "*" as a wildcard. Without it
         // the filter becomes an exact match on "contract." and never matches anything.
-        filters.add(SearchFilter.ofLabel("contract.*"));
+        filters.add(SearchFilter.ofLabel(CONTRACT_LABEL_PREFIX));
 
         // Suffix filters match the label key by suffix. "contract.*" + suffix becomes
         // "contract.%{suffix}" in SQL, where "%" covers the optional "{contractId}." segment
         // (and the empty string), so both label forms above are matched.
         if (!StringUtil.isEmpty(status)) {
-            filters.add(SearchFilter.ofLabel("contract.*" + ContractLabels.SUFFIX_STATUS, status));
+            filters.add(SearchFilter.ofLabel(CONTRACT_LABEL_PREFIX + ContractLabels.SUFFIX_STATUS, status));
         }
         if (!StringUtil.isEmpty(ownerTeam)) {
-            filters.add(SearchFilter.ofLabel("contract.*" + ContractLabels.SUFFIX_OWNER_TEAM, ownerTeam));
+            filters.add(SearchFilter.ofLabel(CONTRACT_LABEL_PREFIX + ContractLabels.SUFFIX_OWNER_TEAM, ownerTeam));
         }
         if (!StringUtil.isEmpty(compatibilityGroup)) {
-            filters.add(SearchFilter.ofLabel("contract.*" + ContractLabels.SUFFIX_COMPATIBILITY_GROUP,
-                    compatibilityGroup));
+            filters.add(SearchFilter.ofLabel(
+                    CONTRACT_LABEL_PREFIX + ContractLabels.SUFFIX_COMPATIBILITY_GROUP, compatibilityGroup));
         }
 
         ArtifactSearchResultsDto results = storage.searchArtifacts(filters, oBy, oDir,

--- a/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchService.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/search/ElasticsearchSearchService.java
@@ -52,6 +52,12 @@ public class ElasticsearchSearchService {
     private static final Set<SearchFilterType> INDEX_ONLY_FILTER_TYPES = EnumSet.of(
             SearchFilterType.content, SearchFilterType.structure);
 
+    private static final String FIELD_GA_KEY = "ga_key";
+    private static final String FIELD_ARTIFACT_COUNT = "artifact_count";
+    private static final String FIELD_DESCRIPTION = "description";
+    private static final String FIELD_CREATED_ON = "createdOn";
+    private static final String FIELD_MODIFIED_ON = "modifiedOn";
+
     @Inject
     ElasticsearchClient client;
 
@@ -157,7 +163,7 @@ public class ElasticsearchSearchService {
         SearchResponse<Map> response = client.search(s -> {
             s.index(config.getIndexName())
                     .query(query)
-                    .collapse(c -> c.field("ga_key"))
+                    .collapse(c -> c.field(FIELD_GA_KEY))
                     .from(offset)
                     .size(limit);
 
@@ -165,11 +171,11 @@ public class ElasticsearchSearchService {
                 s.sort(sortOption);
             }
             s.sort(SortOptions.of(so -> so.field(FieldSort.of(f -> f
-                    .field("ga_key").order(SortOrder.Asc)))));
+                    .field(FIELD_GA_KEY).order(SortOrder.Asc)))));
 
             if (!skipCount) {
-                s.aggregations("artifact_count", a -> a
-                        .cardinality(ca -> ca.field("ga_key").precisionThreshold(40000)));
+                s.aggregations(FIELD_ARTIFACT_COUNT, a -> a
+                        .cardinality(ca -> ca.field(FIELD_GA_KEY).precisionThreshold(40000)));
             }
 
             return s;
@@ -177,9 +183,9 @@ public class ElasticsearchSearchService {
 
         long totalCount = 0;
         if (!skipCount && response.aggregations() != null
-                && response.aggregations().containsKey("artifact_count")) {
+                && response.aggregations().containsKey(FIELD_ARTIFACT_COUNT)) {
             totalCount = (long) response.aggregations()
-                    .get("artifact_count").cardinality().value();
+                    .get(FIELD_ARTIFACT_COUNT).cardinality().value();
         }
 
         List<SearchedArtifactDto> artifacts = new ArrayList<>();
@@ -279,7 +285,7 @@ public class ElasticsearchSearchService {
             return buildNameQuery(filter.getStringValue());
 
         case description:
-            return buildTextQuery("description", filter.getStringValue());
+            return buildTextQuery(FIELD_DESCRIPTION, filter.getStringValue());
 
         case content:
             return buildTextQuery("content", filter.getStringValue());
@@ -431,10 +437,10 @@ public class ElasticsearchSearchService {
             fieldName = "name.keyword";
             break;
         case createdOn:
-            fieldName = "createdOn";
+            fieldName = FIELD_CREATED_ON;
             break;
         case modifiedOn:
-            fieldName = "modifiedOn";
+            fieldName = FIELD_MODIFIED_ON;
             break;
         case globalId:
             fieldName = "globalId";
@@ -487,7 +493,7 @@ public class ElasticsearchSearchService {
         builder.version(toStr(source.get("version")));
         builder.artifactType(toStr(source.get("artifactType")));
         builder.name(toStr(source.get("name")));
-        builder.description(toStr(source.get("description")));
+        builder.description(toStr(source.get(FIELD_DESCRIPTION)));
         builder.owner(toStr(source.get("owner")));
         builder.modifiedBy(toStr(source.get("modifiedBy")));
 
@@ -498,12 +504,12 @@ public class ElasticsearchSearchService {
         }
 
         // Timestamps
-        Object createdOn = source.get("createdOn");
+        Object createdOn = source.get(FIELD_CREATED_ON);
         if (createdOn != null) {
             builder.createdOn(new Date(toLong(createdOn)));
         }
 
-        Object modifiedOn = source.get("modifiedOn");
+        Object modifiedOn = source.get(FIELD_MODIFIED_ON);
         if (modifiedOn != null) {
             builder.modifiedOn(new Date(toLong(modifiedOn)));
         }
@@ -528,17 +534,17 @@ public class ElasticsearchSearchService {
         builder.groupId(toStr(source.get("groupId")));
         builder.artifactId(toStr(source.get("artifactId")));
         builder.name(toStr(source.get("name")));
-        builder.description(toStr(source.get("description")));
+        builder.description(toStr(source.get(FIELD_DESCRIPTION)));
         builder.artifactType(toStr(source.get("artifactType")));
         builder.owner(toStr(source.get("owner")));
         builder.modifiedBy(toStr(source.get("modifiedBy")));
 
-        Object createdOn = source.get("createdOn");
+        Object createdOn = source.get(FIELD_CREATED_ON);
         if (createdOn != null) {
             builder.createdOn(new Date(toLong(createdOn)));
         }
 
-        Object modifiedOn = source.get("modifiedOn");
+        Object modifiedOn = source.get(FIELD_MODIFIED_ON);
         if (modifiedOn != null) {
             builder.modifiedOn(new Date(toLong(modifiedOn)));
         }

--- a/cli/src/test/java/io/apicurio/registry/cli/VerboseHttpLoggingTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/VerboseHttpLoggingTest.java
@@ -115,10 +115,12 @@ public class VerboseHttpLoggingTest {
 
             @Override
             public void flush() {
+                // no-op: log records are captured directly in the publish() method above
             }
 
             @Override
             public void close() {
+                // no-op: this in-memory test handler holds no resources to release
             }
         };
         captureHandler.setLevel(Level.ALL);

--- a/java-sdk/adapter-vertx/src/test/java/io/apicurio/registry/client/common/HttpLoggingInterceptorTest.java
+++ b/java-sdk/adapter-vertx/src/test/java/io/apicurio/registry/client/common/HttpLoggingInterceptorTest.java
@@ -92,10 +92,12 @@ class HttpLoggingInterceptorTest {
 
             @Override
             public void flush() {
+                // no-op: log records are captured directly in the publish() method above
             }
 
             @Override
             public void close() {
+                // no-op: this in-memory test handler holds no resources to release
             }
         };
         captureHandler.setLevel(Level.ALL);

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/AgentCardCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/AgentCardCompatibilityChecker.java
@@ -36,6 +36,7 @@ public class AgentCardCompatibilityChecker
     private static final String CONTEXT_SECURITY_SCHEMES = "/securitySchemes";
     private static final String CONTEXT_MODES = "/modes";
     private static final String CONTEXT_DOCUMENT = "/document";
+    private static final String MSG_WAS_REMOVED = "' was removed";
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
@@ -73,7 +74,7 @@ public class AgentCardCompatibilityChecker
         for (String key : existingKeys) {
             if (!proposedKeys.contains(key)) {
                 differences.add(new SimpleCompatibilityDifference(
-                        "Interface '" + key + "' was removed", CONTEXT_INTERFACES));
+                        "Interface '" + key + MSG_WAS_REMOVED, CONTEXT_INTERFACES));
             }
         }
 
@@ -122,7 +123,7 @@ public class AgentCardCompatibilityChecker
         for (String skillId : existingSkills) {
             if (!proposedSkills.contains(skillId)) {
                 differences.add(new SimpleCompatibilityDifference(
-                        "Skill '" + skillId + "' was removed", CONTEXT_SKILLS));
+                        "Skill '" + skillId + MSG_WAS_REMOVED, CONTEXT_SKILLS));
             }
         }
     }
@@ -173,7 +174,7 @@ public class AgentCardCompatibilityChecker
         for (String uri : existingUris) {
             if (!proposedUris.contains(uri)) {
                 differences.add(new SimpleCompatibilityDifference(
-                        "Capability extension '" + uri + "' was removed",
+                        "Capability extension '" + uri + MSG_WAS_REMOVED,
                         CONTEXT_CAPABILITY_EXTENSIONS));
             }
         }
@@ -187,7 +188,7 @@ public class AgentCardCompatibilityChecker
         for (String scheme : existingSchemes) {
             if (!proposedSchemes.contains(scheme)) {
                 differences.add(new SimpleCompatibilityDifference(
-                        "Security scheme '" + scheme + "' was removed", CONTEXT_SECURITY_SCHEMES));
+                        "Security scheme '" + scheme + MSG_WAS_REMOVED, CONTEXT_SECURITY_SCHEMES));
             }
         }
     }
@@ -200,7 +201,7 @@ public class AgentCardCompatibilityChecker
         for (String mode : existingModes) {
             if (!proposedModes.contains(mode)) {
                 differences.add(new SimpleCompatibilityDifference(
-                        "The " + modeType + " '" + mode + "' was removed", CONTEXT_MODES));
+                        "The " + modeType + " '" + mode + MSG_WAS_REMOVED, CONTEXT_MODES));
             }
         }
     }

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/PromptTemplateCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/PromptTemplateCompatibilityChecker.java
@@ -30,6 +30,7 @@ public class PromptTemplateCompatibilityChecker
     private static final String CONTEXT_OUTPUT_SCHEMA = "/outputSchema";
     private static final String CONTEXT_OUTPUT_SCHEMA_PROPERTIES = "/outputSchema/properties";
     private static final String CONTEXT_DOCUMENT = "/document";
+    private static final String MSG_VARIABLE_PREFIX = "Variable '";
 
     private static final ObjectMapper jsonMapper = new ObjectMapper();
     private static final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
@@ -84,7 +85,7 @@ public class PromptTemplateCompatibilityChecker
             if (proposedVars == null || !proposedVars.has(varName)) {
                 if (proposedTemplateVars.contains(varName)) {
                     differences.add(new SimpleCompatibilityDifference(
-                            "Variable '" + varName + "' was removed but is still used in the template.",
+                            MSG_VARIABLE_PREFIX + varName + "' was removed but is still used in the template.",
                             CONTEXT_VARIABLES));
                 }
                 continue;
@@ -106,7 +107,7 @@ public class PromptTemplateCompatibilityChecker
 
         if (existingType != null && proposedType != null && !existingType.equals(proposedType)) {
             differences.add(new SimpleCompatibilityDifference(
-                    "Variable '" + varName + "' type changed from '" + existingType
+                    MSG_VARIABLE_PREFIX + varName + "' type changed from '" + existingType
                             + "' to '" + proposedType + "'.",
                     CONTEXT_VARIABLES));
         }
@@ -119,7 +120,7 @@ public class PromptTemplateCompatibilityChecker
 
         if (!wasRequired && isRequired) {
             differences.add(new SimpleCompatibilityDifference(
-                    "Variable '" + varName + "' changed from optional to required.", CONTEXT_VARIABLES));
+                    MSG_VARIABLE_PREFIX + varName + "' changed from optional to required.", CONTEXT_VARIABLES));
         }
     }
 
@@ -141,7 +142,7 @@ public class PromptTemplateCompatibilityChecker
         for (JsonNode val : existingEnum) {
             if (!proposedValues.contains(val.asText())) {
                 differences.add(new SimpleCompatibilityDifference(
-                        "Variable '" + varName + "' enum value '" + val.asText() + "' was removed.",
+                        MSG_VARIABLE_PREFIX + varName + "' enum value '" + val.asText() + "' was removed.",
                         CONTEXT_VARIABLES));
             }
         }

--- a/serdes/generic/serde-common-avro/src/test/java/io/apicurio/registry/serde/avro/AvroSerializerWriterSchemaValidationTest.java
+++ b/serdes/generic/serde-common-avro/src/test/java/io/apicurio/registry/serde/avro/AvroSerializerWriterSchemaValidationTest.java
@@ -230,11 +230,13 @@ public class AvroSerializerWriterSchemaValidationTest {
 
         @Override
         public void setClientFacade(RegistryClientFacade clientFacade) {
+            // no-op: this stub never talks to a registry, so no client facade is needed
         }
 
         @Override
         public void setArtifactResolverStrategy(
                 ArtifactReferenceResolverStrategy<Schema, D> artifactResolverStrategy) {
+            // no-op: this stub always resolves the fixed schema regardless of strategy
         }
 
         @Override
@@ -254,10 +256,12 @@ public class AvroSerializerWriterSchemaValidationTest {
 
         @Override
         public void reset() {
+            // no-op: this stub holds no mutable state that needs resetting
         }
 
         @Override
         public void close() {
+            // no-op: this stub holds no resources to release
         }
     }
 }

--- a/utils/converter/src/main/java/io/apicurio/registry/utils/converter/avro/AvroData.java
+++ b/utils/converter/src/main/java/io/apicurio/registry/utils/converter/avro/AvroData.java
@@ -380,7 +380,7 @@ public class AvroData {
     private boolean discardTypeDocDefault;
     private boolean allowOptionalMapKey;
 
-    private final String namespace;
+    private final String configuredNamespace;
     private final String defaultSchemaFullName;
     private final String avroRecordDocProp;
     private final String avroEnumDocPrefixProp;
@@ -443,21 +443,21 @@ public class AvroData {
         // this.scrubInvalidNames = avroDataConfig.isScrubInvalidNames();
         // this.discardTypeDocDefault = avroDataConfig.isDiscardTypeDocDefault();
         // this.allowOptionalMapKey = avroDataConfig.isAllowOptionalMapKeys();
-        this.namespace = avroDataConfig.getAvroNamespace();
-        this.defaultSchemaFullName = namespace + "." + DEFAULT_SCHEMA_NAME;
-        this.avroRecordDocProp = namespace + ".record.doc";
-        this.avroEnumDocPrefixProp = namespace + ".enum.doc.";
-        this.avroFieldDocPrefixProp = namespace + ".field.doc.";
-        this.avroFieldDefaultFlagProp = namespace + ".field.default";
-        this.avroEnumDefaultPrefixProp = namespace + ".enum.default.";
-        this.avroTypeUnion = namespace + ".Union";
-        this.avroTypeEnum = namespace + ".Enum";
-        this.avroTypeAnything = namespace + ".Anything";
-        if (NAMESPACE.equals(namespace)) {
+        this.configuredNamespace = avroDataConfig.getAvroNamespace();
+        this.defaultSchemaFullName = configuredNamespace + "." + DEFAULT_SCHEMA_NAME;
+        this.avroRecordDocProp = configuredNamespace + ".record.doc";
+        this.avroEnumDocPrefixProp = configuredNamespace + ".enum.doc.";
+        this.avroFieldDocPrefixProp = configuredNamespace + ".field.doc.";
+        this.avroFieldDefaultFlagProp = configuredNamespace + ".field.default";
+        this.avroEnumDefaultPrefixProp = configuredNamespace + ".enum.default.";
+        this.avroTypeUnion = configuredNamespace + ".Union";
+        this.avroTypeEnum = configuredNamespace + ".Enum";
+        this.avroTypeAnything = configuredNamespace + ".Anything";
+        if (NAMESPACE.equals(configuredNamespace)) {
             this.anythingSchema = ANYTHING_SCHEMA;
             this.anythingSchemaMapElement = ANYTHING_SCHEMA_MAP_ELEMENT;
         } else {
-            this.anythingSchema = buildAnythingSchema(namespace, avroTypeAnything);
+            this.anythingSchema = buildAnythingSchema(configuredNamespace, avroTypeAnything);
             this.anythingSchemaMapElement = this.anythingSchema.getField("map").schema().getTypes().get(1)
                     .getElementType();
         }
@@ -942,8 +942,8 @@ public class AvroData {
                     List<org.apache.avro.Schema.Field> fields = new ArrayList<>();
                     final org.apache.avro.Schema mapSchema;
                     if (schema.name() == null) {
-                        mapSchema = org.apache.avro.Schema.createRecord(MAP_ENTRY_TYPE_NAME, null, namespace,
-                                false);
+                        mapSchema = org.apache.avro.Schema.createRecord(MAP_ENTRY_TYPE_NAME, null,
+                                configuredNamespace, false);
                     } else {
                         Pair<String, String> names = getNameOrDefault(fromConnectContext, schema.name());
                         String namespace = names.getKey();
@@ -1079,7 +1079,7 @@ public class AvroData {
             return new Pair<>(split[0], split[1]);
         } else {
             int nameIndex = ctx.incrementAndGetNameIndex();
-            return new Pair<>(namespace, DEFAULT_SCHEMA_NAME + (nameIndex > 1 ? nameIndex : ""));
+            return new Pair<>(configuredNamespace, DEFAULT_SCHEMA_NAME + (nameIndex > 1 ? nameIndex : ""));
         }
     }
 
@@ -1305,7 +1305,7 @@ public class AvroData {
         if (!elemSchema.getType().equals(org.apache.avro.Schema.Type.RECORD)) {
             return false;
         }
-        if (namespace.equals(elemSchema.getNamespace()) && MAP_ENTRY_TYPE_NAME.equals(elemSchema.getName())) {
+        if (configuredNamespace.equals(elemSchema.getNamespace()) && MAP_ENTRY_TYPE_NAME.equals(elemSchema.getName())) {
             return true;
         }
         if (Objects.equals(elemSchema.getProp(CONNECT_INTERNAL_TYPE_NAME), MAP_ENTRY_TYPE_NAME)) {


### PR DESCRIPTION
## What
Fixes the BLOCKER and a sample of CRITICAL open SonarCloud issues reported at
https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=Apicurio_apicurio-registry

- **java:S1845 (BLOCKER)**: renamed `AvroData#namespace` field to `configuredNamespace` to
  avoid a case-only clash with the static constant `NAMESPACE`.
- **java:S1192 (CRITICAL)**: extracted duplicated string literals into named constants in
  `SearchResourceImpl`, `ElasticsearchSearchService`, `AgentCardCompatibilityChecker`, and
  `PromptTemplateCompatibilityChecker`.
- **java:S3776 / java:S6201 (CRITICAL)**: refactored `JacksonJsonMappingExceptionMapper.toResponse()`
  into smaller helper methods to bring cognitive complexity under the allowed threshold, using
  pattern-matching `instanceof`.
- **java:S1186 (CRITICAL)**: documented intentionally empty no-op method overrides in test doubles
  (`VerboseHttpLoggingTest`, `HttpLoggingInterceptorTest`, `AvroSerializerWriterSchemaValidationTest`).

## Why
Reduce the SonarCloud quality backlog, starting with the highest-severity findings, without
changing any behavior.

## Testing
- `./mvnw test-compile` and `./mvnw checkstyle:check` pass on all touched modules
  (`app`, `schema-util/common`, `cli`, `java-sdk/adapter-vertx`,
  `serdes/generic/serde-common-avro`, `utils/converter`).
- Existing unit tests pass, including `AvroDataTest` (19), `AgentCardCompatibilityCheckerTest` (24),
  `PromptTemplateCompatibilityCheckerTest` (10), `VerboseHttpLoggingTest` (2),
  `HttpLoggingInterceptorTest` (7), `AvroSerializerWriterSchemaValidationTest` (7),
  `ElasticsearchSearchServiceTest`, `ArtifactSearchTest`, and `DataContractsResourceTest`.
- No public API or default configuration values changed.