### PR TITLE
fix(sonar): resolve new-code BLOCKER/CRITICAL/MAJOR bugs (S2259, S5783, S2142)

### DIFF
--- a/app/src/test/java/io/apicurio/registry/tls/HttpSslCipherSuiteRuntimeTest.java
+++ b/app/src/test/java/io/apicurio/registry/tls/HttpSslCipherSuiteRuntimeTest.java
@@ -53,12 +53,10 @@ public class HttpSslCipherSuiteRuntimeTest {
         SSLContext disallowedCtx = SSLContext.getInstance("TLSv1.3");
         disallowedCtx.init(null, trustAllCerts, new SecureRandom());
         SSLSocketFactory disallowedFactory = disallowedCtx.getSocketFactory();
-        Assertions.assertThrows(IOException.class, () -> {
-            try (SSLSocket socket = (SSLSocket) disallowedFactory.createSocket(host, port)) {
-                socket.setEnabledProtocols(new String[]{"TLSv1.3"});
-                socket.setEnabledCipherSuites(new String[]{"TLS_AES_128_GCM_SHA256"});
-                socket.startHandshake();
-            }
-        });
+        try (SSLSocket socket = (SSLSocket) disallowedFactory.createSocket(host, port)) {
+            socket.setEnabledProtocols(new String[]{"TLSv1.3"});
+            socket.setEnabledCipherSuites(new String[]{"TLS_AES_128_GCM_SHA256"});
+            Assertions.assertThrows(IOException.class, socket::startHandshake);
+        }
     }
 }

--- a/app/src/test/java/io/apicurio/registry/tls/HttpSslRuntimeTest.java
+++ b/app/src/test/java/io/apicurio/registry/tls/HttpSslRuntimeTest.java
@@ -54,11 +54,9 @@ public class HttpSslRuntimeTest {
 
         // 2. Connection with TLSv1.2 should fail because TLSv1.2 is restricted
         SSLSocketFactory factory12 = sslContext12.getSocketFactory();
-        Assertions.assertThrows(IOException.class, () -> {
-            try (SSLSocket socket = (SSLSocket) factory12.createSocket(host, port)) {
-                socket.setEnabledProtocols(new String[]{"TLSv1.2"});
-                socket.startHandshake();
-            }
-        });
+        try (SSLSocket socket = (SSLSocket) factory12.createSocket(host, port)) {
+            socket.setEnabledProtocols(new String[]{"TLSv1.2"});
+            Assertions.assertThrows(IOException.class, socket::startHandshake);
+        }
     }
 }

--- a/cli/src/main/java/io/apicurio/registry/cli/auth/FileCredentialProvider.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/auth/FileCredentialProvider.java
@@ -201,11 +201,19 @@ class FileCredentialProvider implements CredentialProvider {
     }
 
     private Path credentialsPath() {
-        return config.getAcrCurrentHomePath().resolve(CREDENTIALS_FILE);
+        return acrCurrentHomePath().resolve(CREDENTIALS_FILE);
     }
 
     private Path keyPath() {
-        return config.getAcrCurrentHomePath().resolve(KEY_FILE);
+        return acrCurrentHomePath().resolve(KEY_FILE);
+    }
+
+    private Path acrCurrentHomePath() {
+        final Path homePath = config.getAcrCurrentHomePath();
+        if (homePath == null) {
+            throw new CredentialStoreException("ACR_CURRENT_HOME is not configured.");
+        }
+        return homePath;
     }
 
     private synchronized CredentialEncryption encryption() {

--- a/examples/odcs-data-contracts/src/main/java/io/apicurio/registry/examples/OdcsDataContractsDemo.java
+++ b/examples/odcs-data-contracts/src/main/java/io/apicurio/registry/examples/OdcsDataContractsDemo.java
@@ -352,6 +352,9 @@ public class OdcsDataContractsDemo {
                             topic, "key2", (org.apache.avro.generic.GenericRecord) invalidRecord);
                     producer.send(record).get();
                     fail("ERROR: Message should have been rejected!");
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    fail("Interrupted while waiting for message rejection: " + e.getMessage());
                 } catch (Exception e) {
                     ok("Message correctly REJECTED by contract rule!");
                     String cause = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
@@ -414,6 +417,9 @@ public class OdcsDataContractsDemo {
             System.out.println(C + "    3. Explore > odcs-example > OrderEvent > Contract tab" + X);
             System.out.println();
 
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            System.err.println("\n" + R + "Interrupted: " + e.getMessage() + X);
         } catch (Exception e) {
             System.err.println("\n" + R + "Error: " + e.getMessage() + X);
         } finally {

--- a/examples/odcs-data-contracts/src/main/java/io/apicurio/registry/examples/OdcsDataContractsDemo.java
+++ b/examples/odcs-data-contracts/src/main/java/io/apicurio/registry/examples/OdcsDataContractsDemo.java
@@ -419,7 +419,7 @@ public class OdcsDataContractsDemo {
 
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            System.err.println("\n" + R + "Interrupted: " + e.getMessage() + X);
+            fail("Interrupted: " + e.getMessage());
         } catch (Exception e) {
             System.err.println("\n" + R + "Error: " + e.getMessage() + X);
         } finally {


### PR DESCRIPTION
Closes #9888

## What
Follow-up to #9881, addressing the "new code" SonarCloud bug findings at
https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&types=BUG&severities=BLOCKER%2CCRITICAL%2CMAJOR%2CMINOR&inNewCodePeriod=true&sinceLeakPeriod=true&id=Apicurio_apicurio-registry

- **`FileCredentialProvider`** (`javabugs:S2259`, BLOCKER): guard against a
  null `Path` from `Config.getAcrCurrentHomePath()` before calling
  `resolve()`, avoiding a potential NullPointerException flagged by
  symbolic execution.
- **`HttpSslCipherSuiteRuntimeTest` / `HttpSslRuntimeTest`** (`java:S5783`,
  CRITICAL x2): restructured the `assertThrows(...)` lambdas so only a
  single call (`SSLSocket::startHandshake`) can throw the checked
  `IOException`, instead of both `createSocket(...)` and
  `startHandshake()`.
- **`OdcsDataContractsDemo`** (`java:S2142`, MAJOR x2): added explicit
  `catch (InterruptedException e)` blocks that re-interrupt the current
  thread before the broader `catch (Exception e)` blocks, so a thread
  interrupt from `Future.get()` is no longer silently swallowed. Uses the
  file's existing `fail()` console helper (not `System.err`) to avoid
  introducing a new `java:S106` finding.

## Testing
- `./mvnw test-compile` and `./mvnw checkstyle:check` pass for `cli`, `app`,
  and `examples/odcs-data-contracts` (`-Pexamples`).
- `FileCredentialProviderTest` (12) and `FileCredentialProviderAclTest` (2)
  pass.
- No public API or default configuration values changed.