### PR TITLE
fix(ccompat): replace evictable subjectLocks Cache with Striped lazyWeakLock 

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SubjectsResourceImpl.java
@@ -1,7 +1,6 @@
 package io.apicurio.registry.ccompat.rest.v7.impl;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.google.common.util.concurrent.Striped;
 import io.apicurio.registry.auth.Authorized;
 import io.apicurio.registry.auth.AuthorizedLevel;
 import io.apicurio.registry.auth.AuthorizedStyle;
@@ -45,17 +44,13 @@ import io.apicurio.registry.util.ArtifactTypeUtil;
 import jakarta.inject.Inject;
 import jakarta.interceptor.Interceptors;
 import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.InternalServerErrorException;
 
 import java.math.BigInteger;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -69,10 +64,7 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
     @Inject
     SchemaFormatService formatService;
 
-    private final Cache<GA, Lock> subjectLocks = CacheBuilder.newBuilder()
-            .expireAfterAccess(1, TimeUnit.HOURS) // Evict locks after 1 hour of inactivity
-            .maximumSize(10000) // Limit the cache size to 10,000 locks
-            .build();
+    private final Striped<Lock> subjectLocks = Striped.lazyWeakLock(1024);
 
     @Override
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
@@ -269,17 +261,7 @@ public class SubjectsResourceImpl extends AbstractResource implements SubjectsRe
             throw new UnprocessableEntityException("The schema provided is null.");
         }
 
-        Lock lock;
-        try {
-            // Get or create a lock for the specific subject (GA) using the cache
-            // ReentrantLock::new is called only if the key 'ga' is not already present
-            lock = subjectLocks.get(ga, ReentrantLock::new);
-        } catch (ExecutionException e) {
-            // Handle exception during lock creation if necessary
-            log.error("Error creating lock for subject: " + ga, e.getCause());
-            throw new InternalServerErrorException("Error processing request", e.getCause());
-        }
-
+        Lock lock = subjectLocks.get(ga);
         lock.lock(); // Acquire the lock
 
         try {

--- a/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/SubjectsLockConcurrencyTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/SubjectsLockConcurrencyTest.java
@@ -1,0 +1,41 @@
+package io.apicurio.registry.noprofile.ccompat.rest.v7;
+
+import io.apicurio.registry.ccompat.rest.v7.impl.SubjectsResourceImpl;
+import io.apicurio.registry.model.GA;
+import com.google.common.util.concurrent.Striped;
+import org.junit.jupiter.api.Test;
+import java.lang.reflect.Field;
+import java.util.concurrent.locks.Lock;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class SubjectsLockConcurrencyTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void testActiveLockIsNeverReplacedByGC() throws Exception {
+        SubjectsResourceImpl resource = new SubjectsResourceImpl();
+        Field field = SubjectsResourceImpl.class.getDeclaredField("subjectLocks");
+        field.setAccessible(true);
+        Striped<Lock> subjectLocks = (Striped<Lock>) field.get(resource);
+
+        GA ga = new GA("test-group", "test-subject");
+
+        // Thread A obtains the lock and keeps a strong reference to it
+        Lock lockA = subjectLocks.get(ga);
+        lockA.lock();
+
+        try {
+            // Trigger JVM garbage collection
+            System.gc();
+
+            // Thread B requests the lock for the same subject
+            Lock lockB = subjectLocks.get(ga);
+
+            // Assert they are the exact same lock object instance
+            assertSame(lockA, lockB, "Active lock must not be replaced/recreated while in use");
+        } finally {
+            lockA.unlock();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR resolves #9842 by replacing the evictable Guava `Cache<GA, Lock>` in `SubjectsResourceImpl` with Guava's `Striped<Lock>` configured as a `lazyWeakLock`.

### The Problem
The previous cache configuration had a `maximumSize(10000)` and `expireAfterAccess(1H)`. Under load or size pressure, the cache could evict keys while their associated locks were still held by active threads in the critical section. 
When another request for the same subject arrived, a cache miss occurred, and the cache loader instantiated a *new* lock object. This broke mutual exclusion, allowing concurrent threads to register schemas under the same subject simultaneously (leading to duplicate versions or database transaction failures).

### The Fix
Swapping the cache for `Striped.lazyWeakLock(1024)` solves both problems:
1. **Thread Safety / Lock Preservation:** The striped lock pool utilizes weak references. Active locks are pinned in memory by thread stack references, meaning a lock **cannot** be garbage-collected or replaced while a thread is holding it.
2. **Memory Safety:** It maps arbitrary subjects to a fixed set of 1,024 lock stripes, capping memory usage by construction without requiring an evictable cache structure.
3. **Code Cleanup:** It removes the try/catch block for `ExecutionException` during lock retrieval since `Striped.get()` does not throw checked exceptions.

---

## Verification Plan

### Automated Tests
1. **Added Concurrency Unit Test:** Created a dedicated unit test `SubjectsLockConcurrencyTest.java` that locks a subject, triggers garbage collection, and asserts that subsequent lookups for the same subject return the *exact same* lock instance.
2. **Build and Test execution:**
   ```bash
   ./mvnw test -pl :apicurio-registry-app -Dtest=SubjectsLockConcurrencyTest