### PR TITLE
fix(ci): activate performance tests Maven profile

### DIFF
--- a/.github/workflows/perf-main.yaml
+++ b/.github/workflows/perf-main.yaml
@@ -58,8 +58,8 @@ jobs:
       # -Dfull: include the operator module needed for the operator image build.
       - name: Build app, operator, and perf-tests artifacts
         run: |
-          ./mvnw -s ${{ github.workspace }}/.github/ci-settings.xml -B clean package -Dfull -Dperf-tests \
-            -pl app,distro/docker,operator,perf-tests -am -Pprod -DskipTests -Dmaven.javadoc.skip \
+          ./mvnw -s ${{ github.workspace }}/.github/ci-settings.xml -B clean package -Dfull \
+            -pl app,distro/docker,operator,perf-tests -am -Pprod,perf-tests -DskipTests -Dmaven.javadoc.skip \
             -Daether.syncContext.named.factory=noop
 
       - name: Build app image


### PR DESCRIPTION
## What

- activate the `perf-tests` Maven profile explicitly in the post-merge performance workflow
- align both opt-in performance module parent versions with main's `3.3.3-SNAPSHOT`
- keep the existing app, operator, Docker distribution, and performance-test reactor selection

## Why

`perf-tests` is declared as a module inside the `perf-tests` Maven profile. The workflow passed `-Dperf-tests`, which defines a property but does not activate that profile, so both PostgreSQL and KafkaSQL jobs failed before deployment with:

```text
Could not find the selected project in the reactor: perf-tests
```

After profile activation was fixed, the next run exposed stale `3.3.2-SNAPSHOT` parent versions in `perf-tests` and `perf-comparison-tests`; main is now `3.3.3-SNAPSHOT`.

## Verification

- `./mvnw -q -Dfull -Pprod,perf-tests -pl app,distro/docker,operator,perf-tests -am validate -DskipTests -Dmaven.javadoc.skip -Daether.syncContext.named.factory=noop`
- `./mvnw -q -Pperf-comparison-tests -pl perf-comparison-tests validate -DskipTests -Daether.syncContext.named.factory=noop`
- previously ran the equivalent `clean package` workflow command successfully across all 46 selected reactor projects

Fixes #9905.
