### PR TITLE
fix(perf-tests): report measured-window throughput

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -74,6 +74,9 @@ jobs:
       - name: Test PR lifecycle scripts
         run: node --test .github/scripts/pr-lifecycle.test.js
 
+      - name: Test performance comparison result parser
+        run: python3 -m unittest discover -s perf-comparison-tests/scripts -p 'test_*.py' -v
+
       - name: Verify docs generation
         run: |
           if [ -n "$(git status --untracked-files=no --porcelain docs)" ]; then

--- a/perf-comparison-tests/README.md
+++ b/perf-comparison-tests/README.md
@@ -87,7 +87,11 @@ Use `run-product.sh` for a single product during development:
 
 `run-comparison.sh` randomizes product order for every repetition. Five repetitions are the
 minimum for publishing a comparison. The aggregation script emits JSON, CSV, and Markdown with
-median successful RPS, p99, p99.9, failure rate, and bootstrap confidence intervals.
+median successful measured-window RPS, p99, p99.9, failure rate, and bootstrap confidence
+intervals. Measured-window RPS is the number of successful requests in the measured scenario
+divided by its configured duration. JSON and CSV output also retain Gatling's simulation-wide
+mean as `gatlingSimulationWindowRps`; that diagnostic includes warm-up and in-flight request drain
+and must not be used as measured-phase throughput.
 With only five repetitions, bootstrap confidence intervals are indicative and discrete; use more
 runs for external claims.
 

--- a/perf-comparison-tests/scripts/compare-results.py
+++ b/perf-comparison-tests/scripts/compare-results.py
@@ -31,13 +31,17 @@ def parse_run(stats_path):
     total = metric(block, "numberOfRequests")
     ok = metric(block, "numberOfRequests", "ok")
     ko = metric(block, "numberOfRequests", "ko")
+    duration = metadata.get("duration")
+    if not isinstance(duration, (int, float)) or duration <= 0:
+        raise ValueError(f"Invalid measured duration for {run_dir}: {duration}")
     return {
         **metadata,
         "total": int(total),
         "ok": int(ok),
         "ko": int(ko),
         "failedPercent": 100.0 * ko / total if total else 0.0,
-        "rps": metric(block, "meanNumberOfRequestsPerSecond", "ok"),
+        "rps": ok / duration,
+        "gatlingSimulationWindowRps": metric(block, "meanNumberOfRequestsPerSecond", "ok"),
         "meanMs": metric(block, "meanResponseTime", "ok"),
         "p50Ms": metric(block, "percentiles1", "ok"),
         "p95Ms": metric(block, "percentiles2", "ok"),
@@ -68,7 +72,7 @@ def main():
         writer.writeheader()
         writer.writerows(runs)
 
-    lines = ["# Product-neutral schema registry comparison", "", "| Operation | Product | Runs | Median successful RPS (95% CI) | Median p99 ms (95% CI) | Median p99.9 ms | Median failures |", "| --- | --- | ---: | ---: | ---: | ---: | ---: |"]
+    lines = ["# Product-neutral schema registry comparison", "", "| Operation | Product | Runs | Median successful measured-window RPS (95% CI) | Median p99 ms (95% CI) | Median p99.9 ms | Median failures |", "| --- | --- | ---: | ---: | ---: | ---: | ---: |"]
     for operation, product in sorted({(run["operation"], run["product"]) for run in runs}):
         group = [run for run in runs if run["operation"] == operation and run["product"] == product]
         comparable = {(run["users"], run["warmup"], run["duration"], run["seeds"]) for run in group}

--- a/perf-comparison-tests/scripts/test_compare_results.py
+++ b/perf-comparison-tests/scripts/test_compare_results.py
@@ -1,0 +1,71 @@
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+
+
+SCRIPT_PATH = pathlib.Path(__file__).with_name("compare-results.py")
+SPEC = importlib.util.spec_from_file_location("compare_results", SCRIPT_PATH)
+COMPARE_RESULTS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(COMPARE_RESULTS)
+
+
+class CompareResultsTest(unittest.TestCase):
+
+    def test_rps_uses_configured_measured_window(self):
+        with tempfile.TemporaryDirectory() as directory:
+            run_dir = pathlib.Path(directory) / "run-1"
+            stats_path = run_dir / "gatling" / "simulation" / "js" / "stats.js"
+            stats_path.parent.mkdir(parents=True)
+            (run_dir / "deployment-metadata.json").write_text(json.dumps({
+                "product": "apicurio",
+                "operation": "READ_ID",
+                "duration": 180
+            }))
+            stats_path.write_text("""
+var stats = {
+    contents: {
+        measured: {
+            type: "REQUEST", name: "Measured READ_ID",
+            stats: {
+                "numberOfRequests": {"total": "900002", "ok": "900000", "ko": "2"},
+                "meanNumberOfRequestsPerSecond": {"total": "2500.01", "ok": "2500", "ko": "0.01"},
+                "meanResponseTime": {"total": "12", "ok": "10", "ko": "60000"},
+                "percentiles1": {"total": "8", "ok": "8", "ko": "60000"},
+                "percentiles2": {"total": "20", "ok": "20", "ko": "60000"},
+                "percentiles3": {"total": "30", "ok": "30", "ko": "60000"},
+                "percentiles4": {"total": "40", "ok": "40", "ko": "60000"}
+            }
+        }
+    }
+}
+""")
+
+            result = COMPARE_RESULTS.parse_run(stats_path)
+
+            self.assertEqual(5000, result["rps"])
+            self.assertEqual(2500, result["gatlingSimulationWindowRps"])
+            self.assertEqual(900002, result["total"])
+            self.assertEqual(900000, result["ok"])
+            self.assertEqual(2, result["ko"])
+
+    def test_rejects_invalid_measured_duration(self):
+        with tempfile.TemporaryDirectory() as directory:
+            run_dir = pathlib.Path(directory) / "run-1"
+            stats_path = run_dir / "gatling" / "simulation" / "js" / "stats.js"
+            stats_path.parent.mkdir(parents=True)
+            (run_dir / "deployment-metadata.json").write_text(json.dumps({"duration": 0}))
+            stats_path.write_text("""
+type: "REQUEST", name: "Measured READ_ID",
+"numberOfRequests": {"total": 1, "ok": 1, "ko": 0}
+    }
+}
+""")
+
+            with self.assertRaisesRegex(ValueError, "Invalid measured duration"):
+                COMPARE_RESULTS.parse_run(stats_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

- calculate successful RPS from the measured request count and configured measured duration
- preserve Gatling's simulation-wide mean under the explicit `gatlingSimulationWindowRps` field
- document the distinction in the comparison harness README
- add standard-library parser regression tests to the required verification pipeline

## Why

Gatling's `meanNumberOfRequestsPerSecond` uses the complete simulation timeline. The comparison workflow runs warm-up and measurement sequentially, so that denominator includes warm-up and any drain from in-flight requests after a phase ends. Different tail behavior can therefore give products different denominators despite identical measured durations.

For the existing five-run `READ_ID` dataset, the corrected 180-second measured-window medians are:

| Product | Previous reported RPS | Corrected measured-window RPS |
| --- | ---: | ---: |
| Redpanda | 5,733 | 7,708 |
| Confluent | 4,528 | 6,088 |
| Apicurio | 3,715 | 4,995 |
| Karapace | 468 | 629 |

The product order is unchanged, but the prior values were not measured-phase throughput.

## Verification

- `python3 -m unittest discover -s perf-comparison-tests/scripts -p 'test_*.py' -v`
- `./mvnw -q -Pperf-comparison-tests -pl perf-comparison-tests package checkstyle:check -DskipTests -Daether.syncContext.named.factory=noop`
- `./scripts/validate-files.sh`
- regenerated the existing five-run local dataset with the corrected aggregator

Fixes #9893.

This PR is independent from #9892, which only repairs Maven profile activation in the post-merge performance workflow.
