### PR TITLE
fix(ccompat): resolve GET /schemas/ids/{id} with a single storage query

### DIFF
--- a/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemasResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/ccompat/rest/v7/impl/SchemasResourceImpl.java
@@ -57,15 +57,10 @@ public class SchemasResourceImpl extends AbstractResource implements SchemasReso
             ArtifactVersionMetaDataDto vmd = storage.getArtifactVersionMetaData(id.longValue());
             artifactType = vmd.getArtifactType();
         } else {
-            ContentWrapperDto contentWrapper = storage.getContentById(id.longValue());
+            ContentWrapperDto contentWrapper = storage.getContentAndArtifactTypeById(id.longValue());
             contentHandle = contentWrapper.getContent();
             references = contentWrapper.getReferences();
-            List<ArtifactVersionMetaDataDto> versions = storage.getArtifactVersionsByContentId(id.longValue());
-            if (versions == null || versions.isEmpty()) {
-                //the contentId points to an orphaned content
-                throw new ArtifactNotFoundException("ContentId: " + id);
-            }
-            artifactType = versions.get(0).getArtifactType();
+            artifactType = contentWrapper.getArtifactType();
         }
 
         // Apply default format if configured and no format was explicitly provided
@@ -103,15 +98,10 @@ public class SchemasResourceImpl extends AbstractResource implements SchemasReso
             ArtifactVersionMetaDataDto vmd = storage.getArtifactVersionMetaData(id.longValue());
             artifactType = vmd.getArtifactType();
         } else {
-            ContentWrapperDto contentWrapper = storage.getContentById(id.longValue());
+            ContentWrapperDto contentWrapper = storage.getContentAndArtifactTypeById(id.longValue());
             contentHandle = contentWrapper.getContent();
             references = contentWrapper.getReferences();
-            List<ArtifactVersionMetaDataDto> versions = storage.getArtifactVersionsByContentId(id.longValue());
-            if (versions == null || versions.isEmpty()) {
-                //the contentId points to an orphaned content
-                throw new ArtifactNotFoundException("ContentId: " + id);
-            }
-            artifactType = versions.get(0).getArtifactType();
+            artifactType = contentWrapper.getArtifactType();
         }
 
         // Apply default format if configured and no format was explicitly provided

--- a/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/RegistryStorage.java
@@ -160,6 +160,22 @@ public interface RegistryStorage extends DynamicConfigStorage {
             throws ContentNotFoundException, RegistryStorageException;
 
     /**
+     * Gets some artifact content by the unique contentId, together with the artifact type of one of the
+     * artifact versions that references it. This is a single-query variant of calling
+     * {@link #getContentById(long)} followed by {@link #getArtifactVersionsByContentId(long)} just to
+     * discover the artifact type - useful for read paths (e.g. ccompat's "get schema by id") that only need
+     * the type and not the full version meta-data. Throws {@link ContentNotFoundException} both when the
+     * content does not exist and when the content exists but is orphaned (not referenced by any artifact
+     * version), matching the semantics callers previously implemented by combining the two calls above.
+     *
+     * @param contentId
+     * @throws ContentNotFoundException
+     * @throws RegistryStorageException
+     */
+    ContentWrapperDto getContentAndArtifactTypeById(long contentId)
+            throws ContentNotFoundException, RegistryStorageException;
+
+    /**
      * Gets some artifact content by the SHA-256 hash of that content. This method of getting content from
      * storage does not allow extra meta-data to be returned, because the content hash only points to a piece
      * of content/data - it is divorced from any artifact version.

--- a/app/src/main/java/io/apicurio/registry/storage/decorator/ReadOnlyDelegatingStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/decorator/ReadOnlyDelegatingStorage.java
@@ -95,6 +95,12 @@ public abstract class ReadOnlyDelegatingStorage implements RegistryStorage {
     }
 
     @Override
+    public ContentWrapperDto getContentAndArtifactTypeById(long contentId)
+            throws ContentNotFoundException, RegistryStorageException {
+        return delegate.getContentAndArtifactTypeById(contentId);
+    }
+
+    @Override
     public ContentWrapperDto getContentByHash(String contentHash)
             throws ContentNotFoundException, RegistryStorageException {
         return delegate.getContentByHash(contentHash);

--- a/app/src/main/java/io/apicurio/registry/storage/impl/polling/AbstractPollingRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/polling/AbstractPollingRegistryStorage.java
@@ -378,6 +378,11 @@ public abstract class AbstractPollingRegistryStorage<MARKER extends SourceMarker
     }
 
     @Override
+    public ContentWrapperDto getContentAndArtifactTypeById(long contentId) {
+        return proxy(storage -> storage.getContentAndArtifactTypeById(contentId));
+    }
+
+    @Override
     public ContentWrapperDto getContentByHash(String contentHash) {
         return proxy(storage -> storage.getContentByHash(contentHash));
     }

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/AbstractSqlRegistryStorage.java
@@ -459,6 +459,13 @@ public abstract class AbstractSqlRegistryStorage implements RegistryStorage {
         return contentRepository.getContentById(contentId);
     }
 
+    @Override
+    public ContentWrapperDto getContentAndArtifactTypeById(long contentId)
+            throws ContentNotFoundException, RegistryStorageException {
+
+        return contentRepository.getContentAndArtifactTypeById(contentId);
+    }
+
     public ContentWrapperDto getContentByIdRaw(Handle handle, long contentId)
             throws ContentNotFoundException, RegistryStorageException {
         return contentRepository.getContentByIdRaw(handle, contentId);

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/CommonSqlStatements.java
@@ -668,6 +668,17 @@ public abstract class CommonSqlStatements implements SqlStatements {
     }
 
     /**
+     * @see io.apicurio.registry.storage.impl.sql.SqlStatements#selectContentAndArtifactTypeById()
+     */
+    @Override
+    public String selectContentAndArtifactTypeById() {
+        return "SELECT c.content, c.contentType, c.refs, c.contentHash, a.type AS artifactType FROM content c "
+                + "JOIN versions v ON v.contentId = c.contentId "
+                + "JOIN artifacts a ON v.groupId = a.groupId AND v.artifactId = a.artifactId "
+                + "WHERE c.contentId = ? LIMIT 1";
+    }
+
+    /**
      * @see io.apicurio.registry.storage.impl.sql.SqlStatements#selectContentByContentHash()
      */
     @Override

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SQLServerSqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SQLServerSqlStatements.java
@@ -110,6 +110,14 @@ public class SQLServerSqlStatements extends CommonSqlStatements {
     }
 
     @Override
+    public String selectContentAndArtifactTypeById() {
+        return "SELECT TOP (1) c.content, c.contentType, c.refs, c.contentHash, a.type AS artifactType FROM content c "
+                + "JOIN versions v ON v.contentId = c.contentId "
+                + "JOIN artifacts a ON v.groupId = a.groupId AND v.artifactId = a.artifactId "
+                + "WHERE c.contentId = ?";
+    }
+
+    @Override
     public String selectBranchTipFilteredByState() {
         return "SELECT bv.groupId, bv.artifactId, bv.version FROM branch_versions bv "
                 + "JOIN versions v ON bv.groupId = v.groupId AND bv.artifactId = v.artifactId AND bv.version = v.version "

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/SqlStatements.java
@@ -437,6 +437,13 @@ public interface SqlStatements {
     public String selectContentById();
 
     /**
+     * A statement to select the bytes of a content row by contentId, joined with one artifact version that
+     * references it, so that the artifact type can be returned in the same query. Returns no rows if the
+     * content does not exist or if it is orphaned (not referenced by any artifact version).
+     */
+    public String selectContentAndArtifactTypeById();
+
+    /**
      * A statement template for batch loading artifact version metadata. The REFERENCES_CONDITION placeholder
      * is replaced at runtime with OR conditions for each reference.
      */

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ContentMapper.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/mappers/ContentMapper.java
@@ -10,12 +10,21 @@ import java.sql.SQLException;
 
 public class ContentMapper implements RowMapper<ContentWrapperDto> {
 
-    public static final ContentMapper instance = new ContentMapper();
+    public static final ContentMapper instance = new ContentMapper(false);
+
+    /**
+     * Variant that also reads an "artifactType" column from the result set, for queries that join content
+     * with an artifact/version so the artifact type can be returned without a second round-trip.
+     */
+    public static final ContentMapper instanceWithArtifactType = new ContentMapper(true);
+
+    private final boolean includeArtifactType;
 
     /**
      * Constructor.
      */
-    private ContentMapper() {
+    private ContentMapper(boolean includeArtifactType) {
+        this.includeArtifactType = includeArtifactType;
     }
 
     /**
@@ -30,6 +39,9 @@ public class ContentMapper implements RowMapper<ContentWrapperDto> {
         contentWrapperDto.setContentType(rs.getString("contentType"));
         contentWrapperDto.setReferences(RegistryContentUtils.deserializeReferences(rs.getString("refs")));
         contentWrapperDto.setContentHash(rs.getString("contentHash"));
+        if (includeArtifactType) {
+            contentWrapperDto.setArtifactType(rs.getString("artifactType"));
+        }
         return contentWrapperDto;
     }
 

--- a/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlContentRepository.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/sql/repositories/SqlContentRepository.java
@@ -80,6 +80,21 @@ public class SqlContentRepository {
     }
 
     /**
+     * Get content by contentId, together with the artifact type of one artifact version that references it,
+     * in a single query. Throws {@link ContentNotFoundException} if the content does not exist or is
+     * orphaned (i.e. not referenced by any artifact version), since the join used to fetch the artifact type
+     * would return no rows in either case.
+     */
+    public ContentWrapperDto getContentAndArtifactTypeById(long contentId)
+            throws ContentNotFoundException, RegistryStorageException {
+        return handles.<ContentWrapperDto, RuntimeException>withHandleNoException(handle -> {
+            Optional<ContentWrapperDto> res = handle.createQuery(sqlStatements.selectContentAndArtifactTypeById())
+                    .bind(0, contentId).map(ContentMapper.instanceWithArtifactType).findFirst();
+            return res.orElseThrow(() -> new ContentNotFoundException(contentId));
+        });
+    }
+
+    /**
      * Get content by content hash.
      */
     public ContentWrapperDto getContentByHash(String contentHash)

--- a/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/ConfluentClientTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/ccompat/rest/v7/ConfluentClientTest.java
@@ -772,6 +772,35 @@ public class ConfluentClientTest extends AbstractResourceTestBase {
     }
 
     @Test
+    public void testGetSchemaByIdReturnsCorrectTypeAndOrphanIs404() throws Exception {
+        String subject = "testGetSchemaByIdOrphan";
+        List<String> schemas = ConfluentTestUtils.getRandomCanonicalAvroString(1);
+
+        int id = ConfluentTestUtils.registerAndVerifySchema(confluentClient, schemas.get(0), subject);
+
+        // Sanity check: the id resolves to a Schema whose schemaType reflects the AVRO artifact type
+        // (single-query path in SchemasResourceImpl#getSchemaById / getContentAndArtifactTypeById).
+        SchemaString schema = confluentClient.getId(id);
+        Assertions.assertNotNull(schema);
+        Assertions.assertNotNull(schema.getSchemaString());
+
+        // Permanently delete the only version referencing this content, then run the orphaned-content
+        // cleanup so the contentId genuinely has no artifact version pointing at it any more.
+        confluentClient.deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "1");
+        confluentClient.deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "1", true);
+        storage.deleteAllOrphanedContent();
+
+        try {
+            confluentClient.getId(id);
+            fail("Schema lookup by an orphaned contentId should fail with "
+                    + ErrorCode.SCHEMA_NOT_FOUND.value() + " (schema not found)");
+        } catch (RestClientException rce) {
+            assertEquals(ErrorCode.SCHEMA_NOT_FOUND.value(), rce.getErrorCode(),
+                    "Should get a 404 status for an orphaned contentId");
+        }
+    }
+
+    @Test
     public void testGetSchemaTypes() throws Exception {
         assertEquals(new HashSet<>(Arrays.asList("AVRO", "JSON", "PROTOBUF")),
                 new HashSet<>(confluentClient.getSchemaTypes()));

--- a/app/src/test/java/io/apicurio/registry/storage/impl/readonly/ReadOnlyRegistryStorageTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/readonly/ReadOnlyRegistryStorageTest.java
@@ -92,6 +92,8 @@ public class ReadOnlyRegistryStorageTest {
                 entry("forEachVersion2", new State(false, s -> s.forEachVersion(System.currentTimeMillis(), null))),
                 entry("getContentByHash1", new State(false, s -> s.getContentByHash(null))),
                 entry("getContentById1", new State(false, s -> s.getContentById(0))),
+                entry("getContentAndArtifactTypeById1",
+                        new State(false, s -> s.getContentAndArtifactTypeById(0))),
                 entry("getBranchMetaData2", new State(false, s -> s.getBranchMetaData(null, null))),
                 entry("getBranches3", new State(false, s -> s.getBranches(null, 0, 0))),
                 entry("getBranchVersions4", new State(false, s -> s.getBranchVersions(null, null, 0, 0))),

--- a/app/src/test/java/io/apicurio/registry/storage/impl/search/TestInMemoryRegistryStorage.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/search/TestInMemoryRegistryStorage.java
@@ -300,6 +300,11 @@ public class TestInMemoryRegistryStorage implements RegistryStorage {
     }
 
     @Override
+    public ContentWrapperDto getContentAndArtifactTypeById(long contentId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public ContentWrapperDto getContentByHash(String contentHash) {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
## What

Adds `RegistryStorage#getContentAndArtifactTypeById(long)`, a single-query path
for resolving a ccompat `contentId` to its content + references + artifact
type, and switches `SchemasResourceImpl#getSchemaById` / `#getSchemaContentById`
(ccompat v7, also used by v8 which delegates to v7) to use it.

## Why

Part of the performance epic tracked in #9887 (Workstream 1: ccompat hot path).

JFR profiling in that issue found that `GET /schemas/ids/{id}` issued two
separate storage round trips per request:

1. `getContentById(contentId)` — fetch content bytes + references.
2. `getArtifactVersionsByContentId(contentId)` — used **only** to discover the
   artifact type of one referencing version, but this maps the entire
   `ArtifactVersionMetaDataDto` (labels, name, description, owner, timestamps,
   etc.) that the ccompat response never uses.

Removing the redundant second query and its unnecessary metadata mapping was
measured in the linked issue to close a significant part of the throughput gap
between Apicurio's ccompat endpoint and Confluent's schema registry for this
same operation.

## How

* New `SqlContentRepository#getContentAndArtifactTypeById`, backed by a new
  common SQL statement (`selectContentAndArtifactTypeById`) that joins
  `content` with one referencing `versions`/`artifacts` row and returns
  content, contentType, refs, contentHash and artifactType in one query. A
  SQL Server-specific `TOP (1)` override is added, mirroring the existing
  `selectBranchTip` pattern (H2/PostgreSQL/MySQL all support `LIMIT 1`
  directly via `CommonSqlStatements`).
* `ContentMapper` gets a second instance (`instanceWithArtifactType`) that also
  reads the extra `artifactType` column, so the existing `getContentById` path
  is untouched.
* Wired through every `RegistryStorage` implementor: `AbstractSqlRegistryStorage`
  (and therefore `SqlRegistryStorage` and the Blue/Green polling storage used
  by GitOps/KubernetesOps), `ReadOnlyDelegatingStorage` (KafkaSQL, delegates to
  the underlying SQL storage), `AbstractPollingRegistryStorage` (GitOps,
  KubernetesOps), and the `TestInMemoryRegistryStorage` test double.
* The join naturally returns no rows both when the contentId doesn't exist and
  when it's orphaned (no version references it any more), so the explicit
  `getArtifactVersionsByContentId(...).isEmpty()` → `ArtifactNotFoundException`
  check is no longer needed. `getContentAndArtifactTypeById` throws
  `ContentNotFoundException` in both cases, which already maps to ccompat's
  `SCHEMA_NOT_FOUND` (40403) — the same code the existing
  `testGetSchemaNonExistingId` test asserts for the plain missing-id case, so
  this is a compatible (arguably more correct) 404 for the orphan case too.

## Testing

* Added `ConfluentClientTest#testGetSchemaByIdReturnsCorrectTypeAndOrphanIs404`:
  registers a schema, verifies `GET /schemas/ids/{id}` still resolves it, then
  permanently deletes the only referencing version, runs
  `deleteAllOrphanedContent()`, and asserts the now-orphaned contentId returns
  `SCHEMA_NOT_FOUND` (40403).
* Added a `getContentAndArtifactTypeById1` entry to
  `ReadOnlyRegistryStorageTest`'s exhaustive read-only-mode method table.
* Full existing ccompat v7/v8 suites (`ConfluentClientTest`,
  `CCompatV8BasicTest`, `CCompatV7EnhancementsTest`, `FormatParameterTest`,
  `CCompatSemanticVersionLookupTest`, `SemanticVersionReferenceTest`) pass
  unchanged — 98+ tests, 0 failures.
* `./mvnw -pl app -am test-compile -DskipTests` compiles cleanly.
* `./mvnw -pl app checkstyle:check` passes with no new violations.

Only the SQL storage variant is touched directly; KafkaSQL, GitOps, and
Kubernetes-Ops all read through the same SQL implementation via delegation, so
no storage-variant-specific behavior changes are introduced. No REST API
contract, KafkaSQL journal format, or persisted-data format changes.

Ref: #9887 (Workstream 1 of 10 — the other nine workstreams in that issue are
intentionally out of scope for this PR and will be follow-ups).