### PR TITLE
feat(operator): report Registry metrics in the CR status

### DIFF
--- a/app/src/main/java/io/apicurio/registry/metrics/MetricsConstants.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/MetricsConstants.java
@@ -27,6 +27,10 @@ public interface MetricsConstants {
     String STORAGE_PREFIX = "storage.";
     String STORAGE_METHOD_CALL = STORAGE_PREFIX + "method.call";
     String STORAGE_METHOD_CALL_DESCRIPTION = "Timing and results of storage methods calls";
+    String STORAGE_ARTIFACTS = STORAGE_PREFIX + "artifacts";
+    String STORAGE_ARTIFACTS_DESCRIPTION = "Number of artifacts currently held in storage";
+    String STORAGE_ARTIFACT_VERSIONS = STORAGE_PREFIX + "artifact.versions";
+    String STORAGE_ARTIFACT_VERSIONS_DESCRIPTION = "Number of artifact versions currently held in storage";
 
     // Storage tags/labels
 

--- a/app/src/main/java/io/apicurio/registry/metrics/StorageUsageMetrics.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/StorageUsageMetrics.java
@@ -1,0 +1,76 @@
+package io.apicurio.registry.metrics;
+
+import io.apicurio.common.apps.config.Info;
+import io.apicurio.registry.storage.metrics.StorageMetricsStore;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+
+import java.util.function.ToDoubleFunction;
+
+import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_OBSERVABILITY;
+import static io.apicurio.registry.metrics.MetricsConstants.STORAGE_ARTIFACTS;
+import static io.apicurio.registry.metrics.MetricsConstants.STORAGE_ARTIFACTS_DESCRIPTION;
+import static io.apicurio.registry.metrics.MetricsConstants.STORAGE_ARTIFACT_VERSIONS;
+import static io.apicurio.registry.metrics.MetricsConstants.STORAGE_ARTIFACT_VERSIONS_DESCRIPTION;
+
+/**
+ * Publishes how much is stored in the registry as Prometheus gauges.
+ * <p>
+ * The counts come from {@link StorageMetricsStore}, which already keeps them behind a short-lived cache for
+ * the limits and health checks. Reading them here adds no queries of its own beyond that cache's refresh.
+ */
+@ApplicationScoped
+public class StorageUsageMetrics {
+
+    @Inject
+    Logger log;
+
+    @Inject
+    MeterRegistry registry;
+
+    @Inject
+    StorageMetricsStore storageMetricsStore;
+
+    @Info(description = """
+                    Publish the number of stored artifacts and artifact versions as metrics.
+            """, category = CATEGORY_OBSERVABILITY, availableSince = "3.3.2")
+    @ConfigProperty(name = "apicurio.metrics.storage-usage.enabled", defaultValue = "true")
+    boolean enabled;
+
+    void onStart(@Observes StartupEvent ev) {
+        if (!enabled) {
+            log.debug("Storage usage metrics are disabled.");
+            return;
+        }
+        register(STORAGE_ARTIFACTS, STORAGE_ARTIFACTS_DESCRIPTION,
+                store -> store.getOrInitializeArtifactsCounter());
+        register(STORAGE_ARTIFACT_VERSIONS, STORAGE_ARTIFACT_VERSIONS_DESCRIPTION,
+                store -> store.getOrInitializeTotalSchemasCounter());
+    }
+
+    private void register(String name, String description, ToDoubleFunction<StorageMetricsStore> value) {
+        Gauge.builder(name, storageMetricsStore, store -> safely(name, store, value))
+                .description(description)
+                .register(registry);
+    }
+
+    /**
+     * A gauge is read while a scrape is in flight, which may be before storage is ready or while it is
+     * unavailable. Reporting NaN leaves the sample out of the scrape rather than failing it, and is
+     * preferable to reporting a zero that reads as "nothing stored".
+     */
+    private double safely(String name, StorageMetricsStore store, ToDoubleFunction<StorageMetricsStore> value) {
+        try {
+            return value.applyAsDouble(store);
+        } catch (Exception ex) {
+            log.debug("Could not read {}: {}", name, ex.getMessage());
+            return Double.NaN;
+        }
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/metrics/StorageUsageMetrics.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/StorageUsageMetrics.java
@@ -22,8 +22,16 @@ import static io.apicurio.registry.metrics.MetricsConstants.STORAGE_ARTIFACT_VER
 /**
  * Publishes how much is stored in the registry as Prometheus gauges.
  * <p>
- * The counts come from {@link StorageMetricsStore}, which already keeps them behind a short-lived cache for
- * the limits and health checks. Reading them here adds no queries of its own beyond that cache's refresh.
+ * The counts come from {@link StorageMetricsStore}, which keeps them behind a cache that expires after
+ * {@code apicurio.storage.metrics.cache.check-period.ms}. Reading them here issues no queries of its own,
+ * but it does drive that cache: a gauge is evaluated on every scrape, so each expiry costs one
+ * {@code countArtifacts} and one {@code countTotalArtifactVersions}. Those are aggregate counts over the
+ * whole dataset, and on a large registry they are not cheap.
+ * <p>
+ * That is why this is off by default. Every storage limit defaults to disabled and returns before touching
+ * these counters, so on a default deployment nothing loads them today, and turning this on would introduce
+ * that load rather than share it. Enable it when the numbers are worth the queries, for instance when the
+ * Operator is configured to report them in the custom resource status.
  */
 @ApplicationScoped
 public class StorageUsageMetrics {
@@ -38,9 +46,12 @@ public class StorageUsageMetrics {
     StorageMetricsStore storageMetricsStore;
 
     @Info(description = """
-                    Publish the number of stored artifacts and artifact versions as metrics.
+                    Publish the number of stored artifacts and artifact versions as metrics. Disabled by \
+                    default: each cache expiry costs an aggregate count over the whole dataset, which is \
+                    not cheap on a large registry. The cache period is controlled by \
+                    apicurio.storage.metrics.cache.check-period.ms.
             """, category = CATEGORY_OBSERVABILITY, availableSince = "3.3.2")
-    @ConfigProperty(name = "apicurio.metrics.storage-usage.enabled", defaultValue = "true")
+    @ConfigProperty(name = "apicurio.metrics.storage-usage.enabled", defaultValue = "false")
     boolean enabled;
 
     void onStart(@Observes StartupEvent ev) {

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlFactory.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlFactory.java
@@ -6,7 +6,10 @@ import io.apicurio.registry.storage.impl.kafkasql.serde.KafkaSqlValueDeserialize
 import io.apicurio.registry.storage.impl.kafkasql.serde.KafkaSqlValueSerializer;
 import io.apicurio.registry.storage.impl.util.AsyncProducer;
 import io.apicurio.registry.storage.impl.util.ProducerActions;
+import io.apicurio.common.apps.config.Info;
 import io.apicurio.registry.cdi.LazyResource;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics;
 import io.quarkus.arc.lookup.LookupIfProperty;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
@@ -19,9 +22,12 @@ import org.apache.kafka.common.serialization.BytesDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
 
 import java.util.function.Supplier;
 
+import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_OBSERVABILITY;
 import static io.apicurio.registry.utils.CollectionsUtil.toProperties;
 
 @ApplicationScoped
@@ -30,6 +36,24 @@ public class KafkaSqlFactory {
 
     @Inject
     Instance<KafkaSqlConfiguration> config;
+
+    @Inject
+    MeterRegistry meterRegistry;
+
+    @Inject
+    Logger log;
+
+    @Info(description = """
+                    Publish Kafka client metrics, including the journal consumer lag, for KafkaSQL storage.
+            """, category = CATEGORY_OBSERVABILITY, availableSince = "3.3.2")
+    @ConfigProperty(name = "apicurio.metrics.kafka.enabled", defaultValue = "true")
+    boolean kafkaMetricsEnabled;
+
+    /**
+     * Held so that the binder, and through it the meters it registered, is not collected while the consumer
+     * is still in use.
+     */
+    private KafkaClientMetrics journalConsumerMetrics;
 
     @Produces
     @ApplicationScoped
@@ -44,7 +68,29 @@ public class KafkaSqlFactory {
     @Named("KafkaSqlJournalConsumer")
     @LookupIfProperty(name = "apicurio.storage.kind", stringValue = "kafkasql")
     public KafkaConsumer<KafkaSqlMessageKey, KafkaSqlMessage> createKafkaJournalConsumer() {
-        return new KafkaConsumer<>(toProperties(config.get().getConsumerProperties()), new KafkaSqlKeyDeserializer(), new KafkaSqlValueDeserializer());
+        var consumer = new KafkaConsumer<>(toProperties(config.get().getConsumerProperties()), new KafkaSqlKeyDeserializer(), new KafkaSqlValueDeserializer());
+        journalConsumerMetrics = bindKafkaMetrics(consumer);
+        return consumer;
+    }
+
+    /**
+     * Exposes the Kafka client's own metrics, most usefully the journal consumer lag, which tells an operator
+     * how far behind this replica is in applying the journal. The consumers here are constructed directly
+     * rather than through a Quarkus extension, so nothing binds them automatically.
+     */
+    private KafkaClientMetrics bindKafkaMetrics(KafkaConsumer<?, ?> consumer) {
+        if (!kafkaMetricsEnabled) {
+            return null;
+        }
+        try {
+            var metrics = new KafkaClientMetrics(consumer);
+            metrics.bindTo(meterRegistry);
+            return metrics;
+        } catch (Exception ex) {
+            // Reporting is best effort and must not stop storage from starting.
+            log.warn("Could not publish Kafka client metrics: {}", ex.getMessage());
+            return null;
+        }
     }
 
     @Produces

--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlFactory.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlFactory.java
@@ -11,6 +11,7 @@ import io.apicurio.registry.cdi.LazyResource;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics;
 import io.quarkus.arc.lookup.LookupIfProperty;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
@@ -51,9 +52,28 @@ public class KafkaSqlFactory {
 
     /**
      * Held so that the binder, and through it the meters it registered, is not collected while the consumer
-     * is still in use.
+     * is still in use, and so that it can be closed on shutdown.
      */
     private KafkaClientMetrics journalConsumerMetrics;
+
+    /**
+     * Removes the meters the binder registered. Without this the binder outlives the bean and keeps a
+     * reference to a consumer that is on its way to being closed, which a scrape arriving during shutdown
+     * would then read from. Only the binder is closed here; the consumer's own lifecycle is unchanged.
+     */
+    @PreDestroy
+    void closeKafkaMetrics() {
+        if (journalConsumerMetrics == null) {
+            return;
+        }
+        try {
+            journalConsumerMetrics.close();
+        } catch (Exception ex) {
+            log.debug("Could not close Kafka client metrics: {}", ex.getMessage());
+        } finally {
+            journalConsumerMetrics = null;
+        }
+    }
 
     @Produces
     @ApplicationScoped

--- a/app/src/test/java/io/apicurio/registry/metrics/StorageUsageMetricsTest.java
+++ b/app/src/test/java/io/apicurio/registry/metrics/StorageUsageMetricsTest.java
@@ -1,0 +1,108 @@
+package io.apicurio.registry.metrics;
+
+import io.apicurio.registry.storage.metrics.StorageMetricsStore;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link StorageUsageMetrics}.
+ */
+class StorageUsageMetricsTest {
+
+    /**
+     * The names are asserted as literals rather than through {@link MetricsConstants}, so that renaming a
+     * constant fails here. The Operator reads these off the Prometheus endpoint as `storage_artifacts` and
+     * `storage_artifact_versions`, and it has no way to notice a rename on its own.
+     */
+    private static final String ARTIFACTS = "storage.artifacts";
+    private static final String ARTIFACT_VERSIONS = "storage.artifact.versions";
+
+    @Test
+    void testGaugesReportTheStoredCounts() {
+        var registry = new SimpleMeterRegistry();
+        var store = counting(40, 120);
+        var metrics = metrics(registry, store, true);
+
+        metrics.onStart(null);
+
+        assertEquals(40.0, registry.get(ARTIFACTS).gauge().value());
+        assertEquals(120.0, registry.get(ARTIFACT_VERSIONS).gauge().value());
+    }
+
+    /**
+     * A gauge is read while a scrape is in flight, which may be before storage is ready or while it is
+     * unavailable. Reporting NaN leaves the sample out of the scrape entirely, where a zero would be
+     * published and read as "nothing stored".
+     */
+    @Test
+    void testAnUnreadableCountIsReportedAsNaNRatherThanZero() {
+        var registry = new SimpleMeterRegistry();
+        var store = failing();
+        var metrics = metrics(registry, store, true);
+
+        metrics.onStart(null);
+
+        assertTrue(Double.isNaN(registry.get(ARTIFACTS).gauge().value()));
+        assertTrue(Double.isNaN(registry.get(ARTIFACT_VERSIONS).gauge().value()));
+    }
+
+    /**
+     * Off unless asked for. Every storage limit defaults to disabled and returns before touching these
+     * counters, so on a default deployment nothing loads them, and registering the gauges would introduce an
+     * aggregate count over the whole dataset on every cache expiry rather than share an existing one.
+     */
+    @Test
+    void testNoGaugesAreRegisteredWhenDisabled() {
+        var registry = new SimpleMeterRegistry();
+        var store = counting(40, 120);
+        var metrics = metrics(registry, store, false);
+
+        metrics.onStart(null);
+
+        assertNull(registry.find(ARTIFACTS).gauge());
+        assertNull(registry.find(ARTIFACT_VERSIONS).gauge());
+    }
+
+    private static StorageUsageMetrics metrics(SimpleMeterRegistry registry, StorageMetricsStore store,
+            boolean enabled) {
+        var metrics = new StorageUsageMetrics();
+        metrics.log = LoggerFactory.getLogger(StorageUsageMetricsTest.class);
+        metrics.registry = registry;
+        metrics.storageMetricsStore = store;
+        metrics.enabled = enabled;
+        return metrics;
+    }
+
+    private static StorageMetricsStore counting(long artifacts, long artifactVersions) {
+        return new StorageMetricsStore() {
+            @Override
+            public long getOrInitializeArtifactsCounter() {
+                return artifacts;
+            }
+
+            @Override
+            public long getOrInitializeTotalSchemasCounter() {
+                return artifactVersions;
+            }
+        };
+    }
+
+    private static StorageMetricsStore failing() {
+        return new StorageMetricsStore() {
+            @Override
+            public long getOrInitializeArtifactsCounter() {
+                throw new IllegalStateException("storage is not ready");
+            }
+
+            @Override
+            public long getOrInitializeTotalSchemasCounter() {
+                throw new IllegalStateException("storage is not ready");
+            }
+        };
+    }
+}

--- a/operator/controller/src/main/deploy/rbac/cluster/cluster-role.yaml
+++ b/operator/controller/src/main/deploy/rbac/cluster/cluster-role.yaml
@@ -131,3 +131,16 @@ rules:
       - update
       - patch
       - delete
+
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/operator/controller/src/main/deploy/rbac/namespaced/role.yaml
+++ b/operator/controller/src/main/deploy/rbac/namespaced/role.yaml
@@ -128,3 +128,16 @@ rules:
       - update
       - patch
       - delete
+
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/ApicurioRegistry3Reconciler.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/ApicurioRegistry3Reconciler.java
@@ -2,6 +2,8 @@ package io.apicurio.registry.operator;
 
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
 import io.apicurio.registry.operator.feat.ConsolePluginManager;
+import io.apicurio.registry.operator.feat.PrometheusRuleManager;
+import io.apicurio.registry.operator.metrics.MetricsManager;
 import io.apicurio.registry.operator.resource.ActivationConditions;
 import io.apicurio.registry.operator.resource.app.AppDeploymentResource;
 import io.apicurio.registry.operator.resource.app.AppHorizontalPodAutoscalerResource;
@@ -21,6 +23,7 @@ import io.apicurio.registry.operator.resource.ui.UIIngressResource;
 import io.apicurio.registry.operator.resource.ui.UINetworkPolicyResource;
 import io.apicurio.registry.operator.resource.ui.UIPodDisruptionBudgetResource;
 import io.apicurio.registry.operator.resource.ui.UIServiceResource;
+import io.apicurio.registry.operator.status.MetricsUnavailableConditionManager;
 import io.apicurio.registry.operator.status.OperatorErrorConditionManager;
 import io.apicurio.registry.operator.status.StatusManager;
 import io.apicurio.registry.operator.updater.IngressCRUpdater;
@@ -204,8 +207,23 @@ public class ApicurioRegistry3Reconciler implements Reconciler<ApicurioRegistry3
         }
 
         ConsolePluginManager.reconcileConsolePluginCR(context.getClient(), primary);
+        PrometheusRuleManager.reconcilePrometheusRule(context.getClient(), primary);
 
-        return UpdateControl.patchStatus(StatusManager.get(primary).applyStatus(primary, context));
+        // Has to run before the status is assembled, so that a collection failure is reported as a condition
+        // on this same pass.
+        if (MetricsManager.isEnabled(primary)) {
+            MetricsManager.get(primary).collect(primary, context.getClient(),
+                    StatusManager.get(primary).getConditionManager(MetricsUnavailableConditionManager.class));
+        }
+
+        var updateControl = UpdateControl.patchStatus(StatusManager.get(primary).applyStatus(primary, context));
+
+        if (MetricsManager.isEnabled(primary)) {
+            // Reconciliation is otherwise driven purely by watch events, which would leave the reported
+            // metrics untouched for as long as nothing else about the deployment changes.
+            return updateControl.rescheduleAfter(MetricsManager.scrapeInterval(primary));
+        }
+        return updateControl;
     }
 
     @Override
@@ -224,8 +242,10 @@ public class ApicurioRegistry3Reconciler implements Reconciler<ApicurioRegistry3
     @Override
     public DeleteControl cleanup(ApicurioRegistry3 primary, Context<ApicurioRegistry3> context) {
         ConsolePluginManager.deleteConsolePluginCR(context.getClient(), primary);
+        PrometheusRuleManager.deletePrometheusRule(context.getClient(), primary);
         deleteCRContext(primary);
         StatusManager.clean(primary);
+        MetricsManager.clean(primary);
         return DeleteControl.defaultDelete();
     }
 }

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/feat/PrometheusRuleManager.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/feat/PrometheusRuleManager.java
@@ -1,0 +1,197 @@
+package io.apicurio.registry.operator.feat;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3Spec;
+import io.apicurio.registry.operator.api.v1.spec.AppSpec;
+import io.apicurio.registry.operator.api.v1.spec.MetricsSpec;
+import io.apicurio.registry.operator.resource.Labels;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.apicurio.registry.operator.metrics.MetricsManager.DEFAULT_ERROR_RATE_THRESHOLD;
+import static io.apicurio.registry.operator.metrics.MetricsManager.DEFAULT_KAFKA_CONSUMER_LAG_THRESHOLD;
+import static io.apicurio.registry.operator.metrics.MetricsManager.DEFAULT_POOL_UTILIZATION_THRESHOLD;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static java.util.Optional.ofNullable;
+
+/**
+ * Generates a PrometheusRule carrying the same thresholds the operator itself watches, so that a cluster
+ * already running the Prometheus Operator raises the same alerts through its normal alerting path.
+ * <p>
+ * The rules are evaluated over metrics Prometheus has already scraped. Nothing here arranges that scraping;
+ * that is what a ServiceMonitor is for. Until one exists the generated rules are inert, which is why this is
+ * opt-in and off by default.
+ * <p>
+ * PrometheusRule has no typed model on the operator's classpath, so it is managed as a generic resource in
+ * the same way as the OpenShift ConsolePlugin.
+ */
+public class PrometheusRuleManager {
+
+    private static final Logger log = LoggerFactory.getLogger(PrometheusRuleManager.class);
+
+    private static final String MONITORING_API_GROUP = "monitoring.coreos.com";
+    private static final String MONITORING_API_VERSION = "v1";
+    private static final String PROMETHEUS_RULE_KIND = "PrometheusRule";
+    private static final String PROMETHEUS_RULE_PLURAL = "prometheusrules";
+
+    private static final AtomicBoolean monitoringDetected = new AtomicBoolean(false);
+    private static volatile boolean detectionDone = false;
+
+    private PrometheusRuleManager() {
+    }
+
+    public static String getRuleName(ApicurioRegistry3 primary) {
+        return primary.getMetadata().getName() + "-" + COMPONENT_APP + "-metrics";
+    }
+
+    /**
+     * Whether the Prometheus Operator's CRDs are installed on this cluster.
+     */
+    public static boolean isMonitoringAvailable(KubernetesClient client) {
+        if (!detectionDone) {
+            synchronized (PrometheusRuleManager.class) {
+                if (!detectionDone) {
+                    try {
+                        var groups = client.getApiGroups();
+                        monitoringDetected.set(groups != null && groups.getGroups().stream()
+                                .anyMatch(g -> MONITORING_API_GROUP.equals(g.getName())));
+                    } catch (Exception ex) {
+                        log.warn("Failed to detect the Prometheus Operator API, assuming it is absent", ex);
+                        monitoringDetected.set(false);
+                    }
+                    detectionDone = true;
+                    log.info("Prometheus Operator API detected: {}", monitoringDetected.get());
+                }
+            }
+        }
+        return monitoringDetected.get();
+    }
+
+    public static boolean isEnabled(ApicurioRegistry3 primary) {
+        return metricsSpec(primary).map(MetricsSpec::getPrometheusRuleEnabled).orElse(false);
+    }
+
+    public static void reconcilePrometheusRule(KubernetesClient client, ApicurioRegistry3 primary) {
+        if (!isMonitoringAvailable(client) || !isEnabled(primary)) {
+            deletePrometheusRule(client, primary);
+            return;
+        }
+
+        var name = getRuleName(primary);
+        var namespace = primary.getMetadata().getNamespace();
+
+        var desired = new GenericKubernetesResourceBuilder()
+                .withApiVersion(MONITORING_API_GROUP + "/" + MONITORING_API_VERSION)
+                .withKind(PROMETHEUS_RULE_KIND)
+                .withNewMetadata()
+                .withName(name)
+                .withNamespace(namespace)
+                .withLabels(Labels.getSelectorLabels(primary, COMPONENT_APP))
+                .endMetadata()
+                .build();
+
+        desired.setAdditionalProperties(Map.of("spec", Map.of("groups", List.of(
+                Map.of("name", "apicurio-registry-" + primary.getMetadata().getName(),
+                        "rules", buildRules(primary, namespace))))));
+
+        try {
+            var context = ruleContext();
+            var existing = client.genericKubernetesResources(context).inNamespace(namespace).withName(name)
+                    .get();
+            if (existing == null) {
+                client.genericKubernetesResources(context).inNamespace(namespace).resource(desired).create();
+                log.info("Created PrometheusRule: {}", name);
+            } else {
+                desired.getMetadata().setResourceVersion(existing.getMetadata().getResourceVersion());
+                client.genericKubernetesResources(context).inNamespace(namespace).resource(desired).update();
+                log.debug("Updated PrometheusRule: {}", name);
+            }
+        } catch (Exception ex) {
+            log.warn("Failed to reconcile PrometheusRule {}", name, ex);
+        }
+    }
+
+    public static void deletePrometheusRule(KubernetesClient client, ApicurioRegistry3 primary) {
+        if (!isMonitoringAvailable(client)) {
+            return;
+        }
+        var name = getRuleName(primary);
+        var namespace = primary.getMetadata().getNamespace();
+        try {
+            var context = ruleContext();
+            var existing = client.genericKubernetesResources(context).inNamespace(namespace).withName(name)
+                    .get();
+            if (existing != null) {
+                client.genericKubernetesResources(context).inNamespace(namespace).withName(name).delete();
+                log.info("Deleted PrometheusRule: {}", name);
+            }
+        } catch (Exception ex) {
+            log.warn("Failed to delete PrometheusRule {}", name, ex);
+        }
+    }
+
+    /**
+     * The alert names and thresholds deliberately mirror the Events the operator emits, so that whichever
+     * path an admin is watching tells the same story.
+     */
+    static List<Map<String, Object>> buildRules(ApicurioRegistry3 primary, String namespace) {
+        var spec = metricsSpec(primary);
+        double poolThreshold = spec.map(MetricsSpec::getConnectionPoolUtilizationThreshold)
+                .orElse(DEFAULT_POOL_UTILIZATION_THRESHOLD);
+        double errorThreshold = spec.map(MetricsSpec::getErrorRateThreshold)
+                .orElse(DEFAULT_ERROR_RATE_THRESHOLD);
+        long lagThreshold = spec.map(MetricsSpec::getKafkaConsumerLagThreshold)
+                .orElse(DEFAULT_KAFKA_CONSUMER_LAG_THRESHOLD);
+        var selector = "namespace=\"%s\"".formatted(namespace);
+
+        return List.of(
+                rule("ApicurioRegistryConnectionPoolSaturated",
+                        """
+                        agroal_active_count{%s} / clamp_min(agroal_active_count{%s} + agroal_available_count{%s}, 1) >= %s"""
+                                .formatted(selector, selector, selector, poolThreshold),
+                        "Database connection pool utilization is at or above %s%%."
+                                .formatted(poolThreshold * 100)),
+                rule("ApicurioRegistryHighErrorRate",
+                        """
+                        sum(rate(rest_requests_seconds_count{%s,status_code_group=~"5.*"}[5m])) / clamp_min(sum(rate(rest_requests_seconds_count{%s}[5m])), 0.001) >= %s"""
+                                .formatted(selector, selector, errorThreshold),
+                        "More than %s%% of REST API requests are failing with a 5xx status."
+                                .formatted(errorThreshold * 100)),
+                rule("ApicurioRegistryKafkaConsumerLagHigh",
+                        "kafka_consumer_fetch_manager_records_lag_max{%s} >= %d"
+                                .formatted(selector, lagThreshold),
+                        "KafkaSQL consumer lag is at or above %d records.".formatted(lagThreshold)));
+    }
+
+    private static Map<String, Object> rule(String alert, String expr, String description) {
+        return Map.of(
+                "alert", alert,
+                "expr", expr,
+                "for", "5m",
+                "labels", Map.of("severity", "warning"),
+                "annotations", Map.of("description", description));
+    }
+
+    private static CustomResourceDefinitionContext ruleContext() {
+        return new CustomResourceDefinitionContext.Builder()
+                .withGroup(MONITORING_API_GROUP)
+                .withVersion(MONITORING_API_VERSION)
+                .withPlural(PROMETHEUS_RULE_PLURAL)
+                .withScope("Namespaced")
+                .build();
+    }
+
+    private static java.util.Optional<MetricsSpec> metricsSpec(ApicurioRegistry3 primary) {
+        return ofNullable(primary)
+                .map(ApicurioRegistry3::getSpec)
+                .map(ApicurioRegistry3Spec::getApp)
+                .map(AppSpec::getMetrics);
+    }
+}

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/feat/PrometheusRuleManager.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/feat/PrometheusRuleManager.java
@@ -6,6 +6,8 @@ import io.apicurio.registry.operator.api.v1.spec.AppSpec;
 import io.apicurio.registry.operator.api.v1.spec.MetricsSpec;
 import io.apicurio.registry.operator.resource.Labels;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import org.slf4j.Logger;
@@ -94,6 +96,7 @@ public class PrometheusRuleManager {
                 .withName(name)
                 .withNamespace(namespace)
                 .withLabels(Labels.getSelectorLabels(primary, COMPONENT_APP))
+                .withOwnerReferences(ownerReferences(primary))
                 .endMetadata()
                 .build();
 
@@ -140,6 +143,11 @@ public class PrometheusRuleManager {
     /**
      * The alert names and thresholds deliberately mirror the Events the operator emits, so that whichever
      * path an admin is watching tells the same story.
+     * <p>
+     * The pool expression is evaluated per series, so it fires when any one Pod crosses the threshold. That
+     * is the same rule the operator applies, which reports the highest utilization across Pods rather than
+     * the average. Keeping it per series also means the firing alert carries the labels of the Pod
+     * responsible, which an aggregate would throw away.
      */
     static List<Map<String, Object>> buildRules(ApicurioRegistry3 primary, String namespace) {
         var spec = metricsSpec(primary);
@@ -156,7 +164,7 @@ public class PrometheusRuleManager {
                         """
                         agroal_active_count{%s} / clamp_min(agroal_active_count{%s} + agroal_available_count{%s}, 1) >= %s"""
                                 .formatted(selector, selector, selector, poolThreshold),
-                        "Database connection pool utilization is at or above %s%%."
+                        "Database connection pool utilization on an application Pod is at or above %s%%."
                                 .formatted(poolThreshold * 100)),
                 rule("ApicurioRegistryHighErrorRate",
                         """
@@ -177,6 +185,33 @@ public class PrometheusRuleManager {
                 "for", "5m",
                 "labels", Map.of("severity", "warning"),
                 "annotations", Map.of("description", description));
+    }
+
+    /**
+     * Ties the generated rule to the custom resource that asked for it, so that deleting the Registry takes
+     * the rule with it even if the operator is not running at the time. Without this the only thing removing
+     * it is the explicit delete in the cleanup path, and a rule left behind keeps alerting for a deployment
+     * that no longer exists.
+     * <p>
+     * Unlike the OpenShift ConsolePlugin, which is cluster scoped and so cannot be owned by a namespaced
+     * resource, a PrometheusRule lives in the same namespace as the custom resource and can be.
+     *
+     * @return the owner reference, or an empty list when the resource has no UID yet, since the API server
+     *         rejects an owner reference without one
+     */
+    static List<OwnerReference> ownerReferences(ApicurioRegistry3 primary) {
+        var uid = primary.getMetadata().getUid();
+        if (uid == null || uid.isBlank()) {
+            return List.of();
+        }
+        return List.of(new OwnerReferenceBuilder()
+                .withApiVersion(primary.getApiVersion())
+                .withKind(primary.getKind())
+                .withName(primary.getMetadata().getName())
+                .withUid(uid)
+                .withController(true)
+                .withBlockOwnerDeletion(false)
+                .build());
     }
 
     private static CustomResourceDefinitionContext ruleContext() {

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/MetricSample.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/MetricSample.java
@@ -1,0 +1,17 @@
+package io.apicurio.registry.operator.metrics;
+
+import java.util.Map;
+
+/**
+ * A single sample parsed from the Prometheus text exposition format.
+ *
+ * @param name   the metric name, without labels
+ * @param labels the label set, empty when the sample carries no labels
+ * @param value  the sample value, which may be {@link Double#NaN} or infinite
+ */
+public record MetricSample(String name, Map<String, String> labels, double value) {
+
+    public String label(String key) {
+        return labels.get(key);
+    }
+}

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/MetricsCollectionException.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/MetricsCollectionException.java
@@ -1,0 +1,18 @@
+package io.apicurio.registry.operator.metrics;
+
+/**
+ * Raised when the operator cannot collect metrics from the operand.
+ * <p>
+ * This is deliberately not an {@code OperatorException}. A registry that is unreachable, still starting, or
+ * serving its management interface over TLS is not an operator error, and it must not fail reconciliation.
+ */
+public class MetricsCollectionException extends Exception {
+
+    public MetricsCollectionException(String message) {
+        super(message);
+    }
+
+    public MetricsCollectionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/MetricsCollector.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/MetricsCollector.java
@@ -4,6 +4,7 @@ import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3Spec;
 import io.apicurio.registry.operator.api.v1.spec.AppSpec;
 import io.apicurio.registry.operator.api.v1.spec.TLSSpec;
+import io.apicurio.registry.operator.metrics.RegistryMetricsSnapshot.RequestCounters;
 import io.apicurio.registry.operator.resource.Labels;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -16,8 +17,9 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static io.apicurio.registry.operator.metrics.RegistryMetricNames.KAFKA_RECORDS_LAG_MAX;
 import static io.apicurio.registry.operator.metrics.RegistryMetricNames.POOL_ACTIVE_COUNT;
@@ -29,6 +31,7 @@ import static io.apicurio.registry.operator.metrics.RegistryMetricNames.TAG_STAT
 import static io.apicurio.registry.operator.metrics.RegistryMetricNames.isServerError;
 import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
 import static io.apicurio.registry.operator.utils.Utils.isBlank;
+import static java.util.Comparator.comparing;
 import static java.util.Optional.ofNullable;
 
 /**
@@ -100,14 +103,16 @@ public class MetricsCollector {
             throw new MetricsCollectionException("No running Apicurio Registry application Pod was found.");
         }
 
-        var bodies = new ArrayList<String>();
+        // Keyed by Pod, so that two collections can be compared by which Pods they actually covered.
+        var bodies = new LinkedHashMap<String, String>();
         String lastFailure = null;
         for (var pod : pods) {
+            var name = pod.getMetadata().getName();
             try {
-                bodies.add(scrape(pod.getStatus().getPodIP()));
+                bodies.put(name, scrape(pod.getStatus().getPodIP()));
             } catch (Exception ex) {
-                lastFailure = pod.getMetadata().getName() + ": " + describe(ex);
-                log.debug("Could not scrape metrics from Pod {}", pod.getMetadata().getName(), ex);
+                lastFailure = name + ": " + describe(ex);
+                log.debug("Could not scrape metrics from Pod {}", name, ex);
             }
         }
         if (bodies.isEmpty()) {
@@ -146,6 +151,9 @@ public class MetricsCollector {
                 .filter(pod -> pod.getStatus() != null
                         && "Running".equals(pod.getStatus().getPhase())
                         && !isBlank(pod.getStatus().getPodIP()))
+                // Sorted so that a deployment larger than the cap is truncated to the same set of Pods on
+                // every collection. An unstable set would make consecutive readings incomparable.
+                .sorted(comparing(pod -> pod.getMetadata().getName()))
                 .limit(MAX_SCRAPED_PODS)
                 .toList();
 
@@ -167,18 +175,21 @@ public class MetricsCollector {
         return response.body();
     }
 
-    static RegistryMetricsSnapshot aggregate(List<String> bodies) {
-        var requestsTotal = 0.0;
-        var serverErrorsTotal = 0.0;
-        var requestMetricSeen = false;
-        var poolUtilizationSum = 0.0;
-        var poolUtilizationPods = 0;
+    /**
+     * @param bodiesByPod the Prometheus endpoint response of every Pod that answered, keyed by Pod name
+     */
+    static RegistryMetricsSnapshot aggregate(Map<String, String> bodiesByPod) {
+        var requestCounters = new LinkedHashMap<String, RequestCounters>();
+        Double poolUtilization = null;
         Long artifactCount = null;
         Long artifactVersionCount = null;
         Long kafkaConsumerLag = null;
 
-        for (var body : bodies) {
-            var samples = PrometheusTextParser.parse(body);
+        for (var pod : bodiesByPod.entrySet()) {
+            var samples = PrometheusTextParser.parse(pod.getValue());
+            var podRequests = 0.0;
+            var podServerErrors = 0.0;
+            var podRequestSeen = false;
             var podActive = 0.0;
             var podAvailable = 0.0;
             var podPoolSeen = false;
@@ -189,10 +200,10 @@ public class MetricsCollector {
                 }
                 switch (sample.name()) {
                     case REST_REQUESTS_COUNT -> {
-                        requestMetricSeen = true;
-                        requestsTotal += sample.value();
+                        podRequestSeen = true;
+                        podRequests += sample.value();
                         if (isServerError(sample.label(TAG_STATUS_CODE_GROUP))) {
-                            serverErrorsTotal += sample.value();
+                            podServerErrors += sample.value();
                         }
                     }
                     case POOL_ACTIVE_COUNT -> {
@@ -208,6 +219,8 @@ public class MetricsCollector {
                     case STORAGE_ARTIFACTS -> artifactCount = highest(artifactCount, sample.value());
                     case STORAGE_ARTIFACT_VERSIONS ->
                             artifactVersionCount = highest(artifactVersionCount, sample.value());
+                    // Each replica runs its own consumer over its own assigned partitions, so this reports
+                    // the replica that is furthest behind rather than a total.
                     case KAFKA_RECORDS_LAG_MAX ->
                             kafkaConsumerLag = highest(kafkaConsumerLag, sample.value());
                     default -> {
@@ -216,21 +229,27 @@ public class MetricsCollector {
                 }
             }
 
+            if (podRequestSeen) {
+                requestCounters.put(pod.getKey(), new RequestCounters(podRequests, podServerErrors));
+            }
             if (podPoolSeen) {
                 var poolSize = podActive + podAvailable;
                 // A pool that has not opened a connection yet is idle, not saturated.
-                poolUtilizationSum += poolSize > 0 ? podActive / poolSize : 0.0;
-                poolUtilizationPods++;
+                var utilization = poolSize > 0 ? podActive / poolSize : 0.0;
+                // Pool exhaustion is a per-Pod condition: a replica whose pool is full is already queueing
+                // or failing requests. Averaging across replicas would let that replica hide behind idle
+                // ones, which is the case the threshold exists to catch. This also agrees with the
+                // generated PrometheusRule, which evaluates the same ratio per series.
+                poolUtilization = poolUtilization == null ? utilization
+                        : Math.max(poolUtilization, utilization);
             }
         }
 
         return new RegistryMetricsSnapshot(
                 Instant.now(),
-                bodies.size(),
-                requestsTotal,
-                serverErrorsTotal,
-                requestMetricSeen,
-                poolUtilizationPods > 0 ? poolUtilizationSum / poolUtilizationPods : null,
+                bodiesByPod.size(),
+                requestCounters,
+                poolUtilization,
                 artifactCount,
                 artifactVersionCount,
                 kafkaConsumerLag);

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/MetricsCollector.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/MetricsCollector.java
@@ -1,0 +1,254 @@
+package io.apicurio.registry.operator.metrics;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3Spec;
+import io.apicurio.registry.operator.api.v1.spec.AppSpec;
+import io.apicurio.registry.operator.api.v1.spec.TLSSpec;
+import io.apicurio.registry.operator.resource.Labels;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.apicurio.registry.operator.metrics.RegistryMetricNames.KAFKA_RECORDS_LAG_MAX;
+import static io.apicurio.registry.operator.metrics.RegistryMetricNames.POOL_ACTIVE_COUNT;
+import static io.apicurio.registry.operator.metrics.RegistryMetricNames.POOL_AVAILABLE_COUNT;
+import static io.apicurio.registry.operator.metrics.RegistryMetricNames.REST_REQUESTS_COUNT;
+import static io.apicurio.registry.operator.metrics.RegistryMetricNames.STORAGE_ARTIFACTS;
+import static io.apicurio.registry.operator.metrics.RegistryMetricNames.STORAGE_ARTIFACT_VERSIONS;
+import static io.apicurio.registry.operator.metrics.RegistryMetricNames.TAG_STATUS_CODE_GROUP;
+import static io.apicurio.registry.operator.metrics.RegistryMetricNames.isServerError;
+import static io.apicurio.registry.operator.resource.ResourceFactory.COMPONENT_APP;
+import static io.apicurio.registry.operator.utils.Utils.isBlank;
+import static java.util.Optional.ofNullable;
+
+/**
+ * Reads the Prometheus endpoint of the Apicurio Registry application Pods.
+ * <p>
+ * Pods are contacted directly on their Pod IP rather than through the Service, because the Service only
+ * publishes the API ports. The management interface, which is where Quarkus serves the Prometheus endpoint,
+ * is not part of it.
+ * <p>
+ * Only plain HTTP is supported. An instance with TLS configured serves its management interface over HTTPS,
+ * and is skipped with an explanatory MetricsUnavailable condition rather than being contacted in vain.
+ */
+public class MetricsCollector {
+
+    private static final Logger log = LoggerFactory.getLogger(MetricsCollector.class);
+
+    /**
+     * Quarkus management interface port, where the Prometheus endpoint is served.
+     */
+    static final int MANAGEMENT_PORT = 9000;
+
+    /**
+     * Path of the Prometheus endpoint, relative to the management interface root.
+     */
+    static final String METRICS_PATH = "/metrics";
+
+    /**
+     * Upper bound on how many Pods are contacted per collection, so that a large deployment cannot turn a
+     * single reconciliation into an unbounded number of HTTP requests.
+     */
+    static final int MAX_SCRAPED_PODS = 10;
+
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(2);
+
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(3);
+
+    /**
+     * Shared across all custom resources. An {@link HttpClient} carries its own selector thread and executor,
+     * so one per watched instance would be wasteful.
+     */
+    private static final HttpClient SHARED_CLIENT = HttpClient.newBuilder()
+            .connectTimeout(CONNECT_TIMEOUT)
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build();
+
+    private final HttpClient httpClient;
+
+    public MetricsCollector() {
+        this(SHARED_CLIENT);
+    }
+
+    MetricsCollector(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    public RegistryMetricsSnapshot collect(KubernetesClient client, ApicurioRegistry3 primary)
+            throws MetricsCollectionException {
+
+        if (servesManagementOverTls(primary)) {
+            // Attempting the scrape anyway would open a doomed connection to every Pod on every interval and
+            // then report a bare connection error, which says nothing about the actual cause.
+            throw new MetricsCollectionException(
+                    "The management interface is served over TLS because a keystore is configured in "
+                            + "spec.app.tls, and metrics collection only supports plain HTTP.");
+        }
+
+        var pods = findApplicationPods(client, primary);
+        if (pods.isEmpty()) {
+            throw new MetricsCollectionException("No running Apicurio Registry application Pod was found.");
+        }
+
+        var bodies = new ArrayList<String>();
+        String lastFailure = null;
+        for (var pod : pods) {
+            try {
+                bodies.add(scrape(pod.getStatus().getPodIP()));
+            } catch (Exception ex) {
+                lastFailure = pod.getMetadata().getName() + ": " + describe(ex);
+                log.debug("Could not scrape metrics from Pod {}", pod.getMetadata().getName(), ex);
+            }
+        }
+        if (bodies.isEmpty()) {
+            throw new MetricsCollectionException(
+                    "Could not read metrics from any of the %d application Pod(s). Last failure was %s"
+                            .formatted(pods.size(), lastFailure));
+        }
+        return aggregate(bodies);
+    }
+
+    /**
+     * Whether the operand serves its management interface over TLS.
+     * <p>
+     * Configuring a keystore switches the whole Quarkus TLS registry over, and the management interface
+     * follows the main HTTP server. Setting {@code spec.app.tls.insecureRequests} does not hold it back: an
+     * instance configured that way was observed listening on {@code http://0.0.0.0:8080},
+     * {@code https://0.0.0.0:8443} and {@code https://0.0.0.0:9000} at the same time.
+     */
+    static boolean servesManagementOverTls(ApicurioRegistry3 primary) {
+        return ofNullable(primary)
+                .map(ApicurioRegistry3::getSpec)
+                .map(ApicurioRegistry3Spec::getApp)
+                .map(AppSpec::getTls)
+                .map(TLSSpec::getKeystoreSecretRef)
+                .isPresent();
+    }
+
+    private List<Pod> findApplicationPods(KubernetesClient client, ApicurioRegistry3 primary) {
+        var all = client.pods()
+                .inNamespace(primary.getMetadata().getNamespace())
+                .withLabels(Labels.getSelectorLabels(primary, COMPONENT_APP))
+                .list()
+                .getItems();
+
+        var running = all.stream()
+                .filter(pod -> pod.getStatus() != null
+                        && "Running".equals(pod.getStatus().getPhase())
+                        && !isBlank(pod.getStatus().getPodIP()))
+                .limit(MAX_SCRAPED_PODS)
+                .toList();
+
+        if (all.size() > running.size()) {
+            log.debug("Collecting metrics from {} of {} application Pod(s).", running.size(), all.size());
+        }
+        return running;
+    }
+
+    private String scrape(String podIP) throws Exception {
+        // A literal IPv6 address has to be bracketed before it can go into a URI.
+        var host = podIP.contains(":") ? "[" + podIP + "]" : podIP;
+        var uri = URI.create("http://%s:%d%s".formatted(host, MANAGEMENT_PORT, METRICS_PATH));
+        var request = HttpRequest.newBuilder(uri).GET().timeout(REQUEST_TIMEOUT).build();
+        var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 200) {
+            throw new MetricsCollectionException("unexpected status code " + response.statusCode());
+        }
+        return response.body();
+    }
+
+    static RegistryMetricsSnapshot aggregate(List<String> bodies) {
+        var requestsTotal = 0.0;
+        var serverErrorsTotal = 0.0;
+        var requestMetricSeen = false;
+        var poolUtilizationSum = 0.0;
+        var poolUtilizationPods = 0;
+        Long artifactCount = null;
+        Long artifactVersionCount = null;
+        Long kafkaConsumerLag = null;
+
+        for (var body : bodies) {
+            var samples = PrometheusTextParser.parse(body);
+            var podActive = 0.0;
+            var podAvailable = 0.0;
+            var podPoolSeen = false;
+
+            for (var sample : samples) {
+                if (!isFinite(sample.value())) {
+                    continue;
+                }
+                switch (sample.name()) {
+                    case REST_REQUESTS_COUNT -> {
+                        requestMetricSeen = true;
+                        requestsTotal += sample.value();
+                        if (isServerError(sample.label(TAG_STATUS_CODE_GROUP))) {
+                            serverErrorsTotal += sample.value();
+                        }
+                    }
+                    case POOL_ACTIVE_COUNT -> {
+                        podActive += sample.value();
+                        podPoolSeen = true;
+                    }
+                    case POOL_AVAILABLE_COUNT -> {
+                        podAvailable += sample.value();
+                        podPoolSeen = true;
+                    }
+                    // Every replica counts the same shared storage, so these are maxed rather than summed.
+                    // Summing would multiply the real figure by the replica count.
+                    case STORAGE_ARTIFACTS -> artifactCount = highest(artifactCount, sample.value());
+                    case STORAGE_ARTIFACT_VERSIONS ->
+                            artifactVersionCount = highest(artifactVersionCount, sample.value());
+                    case KAFKA_RECORDS_LAG_MAX ->
+                            kafkaConsumerLag = highest(kafkaConsumerLag, sample.value());
+                    default -> {
+                        // Not a metric the operator reports.
+                    }
+                }
+            }
+
+            if (podPoolSeen) {
+                var poolSize = podActive + podAvailable;
+                // A pool that has not opened a connection yet is idle, not saturated.
+                poolUtilizationSum += poolSize > 0 ? podActive / poolSize : 0.0;
+                poolUtilizationPods++;
+            }
+        }
+
+        return new RegistryMetricsSnapshot(
+                Instant.now(),
+                bodies.size(),
+                requestsTotal,
+                serverErrorsTotal,
+                requestMetricSeen,
+                poolUtilizationPods > 0 ? poolUtilizationSum / poolUtilizationPods : null,
+                artifactCount,
+                artifactVersionCount,
+                kafkaConsumerLag);
+    }
+
+
+    /**
+     * Keeps the larger of the two, treating a negative sample as zero.
+     */
+    private static Long highest(Long current, double value) {
+        var candidate = (long) Math.max(0, value);
+        return current == null ? candidate : Math.max(current, candidate);
+    }
+    private static boolean isFinite(double value) {
+        return !Double.isNaN(value) && !Double.isInfinite(value);
+    }
+
+    private static String describe(Exception ex) {
+        return ex.getMessage() != null ? ex.getMessage() : ex.getClass().getSimpleName();
+    }
+}

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/MetricsManager.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/MetricsManager.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
@@ -39,11 +38,19 @@ import static java.util.Optional.ofNullable;
  * two collections and that requires state between reconciliations.
  * <p>
  * <strong>On reconciliation loops.</strong> The reconciler patches the status on every pass, and the operator
- * does not use server-side apply for the primary resource, so a status that changes on every pass would
- * rewrite the resource, trigger a watch event, and reconcile again without end. Two things prevent that.
- * Collection only happens once per scrape interval, and in between the previously published status object is
- * reused verbatim so the patch is a no-op. When collection does happen, the reported values are rounded and
- * {@code lastCollected} is only moved when the rounded summary actually changed.
+ * does not use server-side apply for the primary resource, so a status that changed on every pass would
+ * rewrite the resource and trigger another reconciliation. What stops that here is the scrape interval:
+ * collection happens at most once per interval, and in between the previously published status object is
+ * reused verbatim. The non-SSA status patch is an RFC 6902 diff, so an unchanged status produces an empty
+ * patch and no write at all.
+ * <p>
+ * A successful collection does move {@code lastCollected}, which writes and therefore fires a watch event.
+ * The reconciliation that event triggers falls inside the interval, reuses the published status, and writes
+ * nothing, so it settles after one extra pass instead of looping. That costs one additional reconciliation
+ * per interval, which is the price of {@code lastCollected} meaning what its name says. Reporting the last
+ * change instead would leave the field frozen on an idle registry, where every value is legitimately
+ * stable, and an operator could not then tell a healthy quiet deployment from one the operator stopped
+ * collecting from an hour ago.
  */
 public class MetricsManager {
 
@@ -160,6 +167,7 @@ public class MetricsManager {
         summary.setArtifactCount(snapshot.artifactCount());
         summary.setArtifactVersionCount(snapshot.artifactVersionCount());
         summary.setKafkaConsumerLag(snapshot.kafkaConsumerLag());
+        summary.setScrapedPods(snapshot.scrapedPods());
 
         var rates = deriveRates(snapshot);
         if (rates != null) {
@@ -176,33 +184,49 @@ public class MetricsManager {
 
     /**
      * Turn two consecutive counter readings into a rate, or return null when the pair cannot be trusted.
+     * <p>
+     * Counters are only comparable when both readings cover exactly the same Pods, which is why the set is
+     * compared and not just its size. A scrape that lost one Pod and gained another covers the same number
+     * of Pods, and the difference between the two sums would then be reported as traffic that never
+     * happened. The deltas are also checked per Pod, because one Pod resetting its counters can otherwise be
+     * masked by another Pod's traffic once the two are summed.
      */
     private Rates deriveRates(RegistryMetricsSnapshot snapshot) {
-        if (previousSnapshot == null || !snapshot.requestMetricSeen() || !previousSnapshot.requestMetricSeen()) {
+        if (previousSnapshot == null || !snapshot.requestMetricSeen()) {
             return null;
         }
-        if (snapshot.scrapedPods() != previousSnapshot.scrapedPods()) {
-            // The set of Pods changed, so the summed counters are not comparable.
+        var current = snapshot.requestCounters();
+        var previous = previousSnapshot.requestCounters();
+        if (!current.keySet().equals(previous.keySet())) {
             return null;
         }
         var seconds = Duration.between(previousSnapshot.timestamp(), snapshot.timestamp()).toMillis() / 1000.0;
-        var requests = snapshot.requestsTotal() - previousSnapshot.requestsTotal();
-        var errors = snapshot.serverErrorsTotal() - previousSnapshot.serverErrorsTotal();
-        if (seconds <= 0 || requests < 0 || errors < 0) {
-            // A negative delta means a Pod restarted and reset its counters.
+        if (seconds <= 0) {
             return null;
+        }
+        var requests = 0.0;
+        var errors = 0.0;
+        for (var pod : current.entrySet()) {
+            var before = previous.get(pod.getKey());
+            var requestDelta = pod.getValue().requests() - before.requests();
+            var errorDelta = pod.getValue().serverErrors() - before.serverErrors();
+            if (requestDelta < 0 || errorDelta < 0) {
+                // A negative delta means this Pod restarted and reset its counters.
+                return null;
+            }
+            requests += requestDelta;
+            errors += errorDelta;
         }
         return new Rates(requests / seconds, requests > 0 ? errors / requests : 0.0);
     }
 
     /**
-     * Store the summary, moving the timestamp only when the reported numbers actually changed.
+     * Store the summary and the time it was collected.
      */
     private void publish(MetricsSummary summary, Instant now) {
-        var unchanged = published != null && Objects.equals(published.getSummary(), summary);
         var status = new MetricsStatus();
         status.setSummary(summary);
-        status.setLastCollected(unchanged ? published.getLastCollected() : now);
+        status.setLastCollected(now);
         published = status;
     }
 
@@ -231,7 +255,7 @@ public class MetricsManager {
         if (summary.getConnectionPoolUtilization() != null
                 && summary.getConnectionPoolUtilization() >= poolThreshold) {
             found.add(new Breach(REASON_CONNECTION_POOL_SATURATED,
-                    "Database connection pool utilization is %.1f%%, at or above the configured threshold of %.1f%%."
+                    "Database connection pool utilization on at least one application Pod is %.1f%%, at or above the configured threshold of %.1f%%."
                             .formatted(summary.getConnectionPoolUtilization() * 100, poolThreshold * 100)));
         }
 

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/MetricsManager.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/MetricsManager.java
@@ -1,0 +1,368 @@
+package io.apicurio.registry.operator.metrics;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3Spec;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3Status;
+import io.apicurio.registry.operator.api.v1.spec.AppSpec;
+import io.apicurio.registry.operator.api.v1.spec.MetricsSpec;
+import io.apicurio.registry.operator.api.v1.status.MetricsStatus;
+import io.apicurio.registry.operator.api.v1.status.MetricsSummary;
+import io.apicurio.registry.operator.status.MetricsUnavailableConditionManager;
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.api.model.EventBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import static java.util.Optional.ofNullable;
+
+/**
+ * Collects operand metrics for a single Apicurio Registry instance and turns them into status fields and
+ * Kubernetes Events.
+ * <p>
+ * Instances are kept per custom resource, mirroring
+ * {@link io.apicurio.registry.operator.status.StatusManager}, because rates can only be derived by comparing
+ * two collections and that requires state between reconciliations.
+ * <p>
+ * <strong>On reconciliation loops.</strong> The reconciler patches the status on every pass, and the operator
+ * does not use server-side apply for the primary resource, so a status that changes on every pass would
+ * rewrite the resource, trigger a watch event, and reconcile again without end. Two things prevent that.
+ * Collection only happens once per scrape interval, and in between the previously published status object is
+ * reused verbatim so the patch is a no-op. When collection does happen, the reported values are rounded and
+ * {@code lastCollected} is only moved when the rounded summary actually changed.
+ */
+public class MetricsManager {
+
+    private static final Logger log = LoggerFactory.getLogger(MetricsManager.class);
+
+    private static final Map<ResourceID, MetricsManager> instances = new ConcurrentHashMap<>();
+
+    static final Duration DEFAULT_SCRAPE_INTERVAL = Duration.ofSeconds(60);
+
+    static final Duration MIN_SCRAPE_INTERVAL = Duration.ofSeconds(10);
+
+    public static final double DEFAULT_POOL_UTILIZATION_THRESHOLD = 0.8;
+
+    public static final double DEFAULT_ERROR_RATE_THRESHOLD = 0.1;
+
+    public static final long DEFAULT_KAFKA_CONSUMER_LAG_THRESHOLD = 1000L;
+
+    /**
+     * How long to wait before repeating an Event for a breach that is still ongoing.
+     */
+    static final Duration EVENT_REPEAT_INTERVAL = Duration.ofMinutes(10);
+
+    public static final String REASON_CONNECTION_POOL_SATURATED = "ConnectionPoolSaturated";
+
+    public static final String REASON_HIGH_ERROR_RATE = "HighErrorRate";
+
+    public static final String REASON_KAFKA_CONSUMER_LAG = "KafkaConsumerLagHigh";
+
+    private static final DateTimeFormatter EVENT_TIMESTAMP =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneOffset.UTC);
+
+    public static MetricsManager get(ApicurioRegistry3 primary) {
+        // We're assuming no concurrent reconciliations per primary resource instance.
+        return instances.computeIfAbsent(ResourceID.fromResource(primary), ignored -> new MetricsManager());
+    }
+
+    public static void clean(ApicurioRegistry3 primary) {
+        instances.remove(ResourceID.fromResource(primary));
+    }
+
+    private final MetricsCollector collector;
+
+    private final Map<String, Instant> lastEventAt = new HashMap<>();
+
+    private RegistryMetricsSnapshot previousSnapshot;
+
+    private MetricsStatus published;
+
+    private Instant lastAttempt;
+
+    private String currentFailure;
+
+    private final Supplier<Instant> clock;
+
+    MetricsManager() {
+        this(new MetricsCollector(), Instant::now);
+    }
+
+    MetricsManager(MetricsCollector collector, Supplier<Instant> clock) {
+        this.collector = collector;
+        this.clock = clock;
+    }
+
+    /**
+     * Collect metrics if the scrape interval has elapsed, then evaluate thresholds.
+     * <p>
+     * Never throws. A registry that cannot be reached is reported through the condition manager and leaves
+     * the previously reported summary in place.
+     */
+    public synchronized void collect(ApicurioRegistry3 primary, KubernetesClient client,
+                                     MetricsUnavailableConditionManager conditionManager) {
+        var now = clock.get();
+        if (lastAttempt != null && Duration.between(lastAttempt, now).compareTo(collectionDue(primary)) < 0) {
+            // Inside the interval. Reusing the published status keeps the resulting patch a no-op. The
+            // condition still has to be re-asserted, because the condition manager is reset after every pass.
+            reportFailure(conditionManager);
+            return;
+        }
+        lastAttempt = now;
+
+        RegistryMetricsSnapshot snapshot;
+        try {
+            snapshot = collector.collect(client, primary);
+        } catch (MetricsCollectionException ex) {
+            log.debug("Could not collect metrics for {}", ResourceID.fromResource(primary), ex);
+            currentFailure = ex.getMessage();
+            reportFailure(conditionManager);
+            return;
+        }
+        currentFailure = null;
+
+        var summary = summarize(snapshot);
+        publish(summary, now);
+        previousSnapshot = snapshot;
+        evaluateThresholds(primary, client, summary, now);
+    }
+
+    /**
+     * Copy the most recently published metrics onto the status being built.
+     */
+    public synchronized void applyStatus(ApicurioRegistry3Status status) {
+        status.setMetrics(published);
+    }
+
+    private void reportFailure(MetricsUnavailableConditionManager conditionManager) {
+        if (currentFailure != null) {
+            conditionManager.recordFailure(currentFailure);
+        }
+    }
+
+    private MetricsSummary summarize(RegistryMetricsSnapshot snapshot) {
+        var summary = new MetricsSummary();
+        summary.setConnectionPoolUtilization(round(snapshot.poolUtilization(), 3));
+        summary.setArtifactCount(snapshot.artifactCount());
+        summary.setArtifactVersionCount(snapshot.artifactVersionCount());
+        summary.setKafkaConsumerLag(snapshot.kafkaConsumerLag());
+
+        var rates = deriveRates(snapshot);
+        if (rates != null) {
+            summary.setRequestRate(round(rates.requestRate(), 2));
+            summary.setErrorRate(round(rates.errorRate(), 4));
+        } else if (published != null && published.getSummary() != null) {
+            // First collection after startup, or an interval we had to discard. Keep the last known rates
+            // rather than reporting nothing at all.
+            summary.setRequestRate(published.getSummary().getRequestRate());
+            summary.setErrorRate(published.getSummary().getErrorRate());
+        }
+        return summary;
+    }
+
+    /**
+     * Turn two consecutive counter readings into a rate, or return null when the pair cannot be trusted.
+     */
+    private Rates deriveRates(RegistryMetricsSnapshot snapshot) {
+        if (previousSnapshot == null || !snapshot.requestMetricSeen() || !previousSnapshot.requestMetricSeen()) {
+            return null;
+        }
+        if (snapshot.scrapedPods() != previousSnapshot.scrapedPods()) {
+            // The set of Pods changed, so the summed counters are not comparable.
+            return null;
+        }
+        var seconds = Duration.between(previousSnapshot.timestamp(), snapshot.timestamp()).toMillis() / 1000.0;
+        var requests = snapshot.requestsTotal() - previousSnapshot.requestsTotal();
+        var errors = snapshot.serverErrorsTotal() - previousSnapshot.serverErrorsTotal();
+        if (seconds <= 0 || requests < 0 || errors < 0) {
+            // A negative delta means a Pod restarted and reset its counters.
+            return null;
+        }
+        return new Rates(requests / seconds, requests > 0 ? errors / requests : 0.0);
+    }
+
+    /**
+     * Store the summary, moving the timestamp only when the reported numbers actually changed.
+     */
+    private void publish(MetricsSummary summary, Instant now) {
+        var unchanged = published != null && Objects.equals(published.getSummary(), summary);
+        var status = new MetricsStatus();
+        status.setSummary(summary);
+        status.setLastCollected(unchanged ? published.getLastCollected() : now);
+        published = status;
+    }
+
+    private void evaluateThresholds(ApicurioRegistry3 primary, KubernetesClient client, MetricsSummary summary,
+                                    Instant now) {
+        for (var breach : breaches(primary, summary)) {
+            if (!shouldReport(breach.reason(), now)) {
+                continue;
+            }
+            if (emit(primary, client, now, breach)) {
+                recordReported(breach.reason(), now);
+            }
+        }
+    }
+
+    /**
+     * Which configured thresholds the given summary crosses. Kept free of any API calls so that the rule
+     * itself can be exercised without a cluster.
+     */
+    static List<Breach> breaches(ApicurioRegistry3 primary, MetricsSummary summary) {
+        var spec = metricsSpec(primary);
+        var found = new ArrayList<Breach>();
+
+        double poolThreshold = spec.map(MetricsSpec::getConnectionPoolUtilizationThreshold)
+                .orElse(DEFAULT_POOL_UTILIZATION_THRESHOLD);
+        if (summary.getConnectionPoolUtilization() != null
+                && summary.getConnectionPoolUtilization() >= poolThreshold) {
+            found.add(new Breach(REASON_CONNECTION_POOL_SATURATED,
+                    "Database connection pool utilization is %.1f%%, at or above the configured threshold of %.1f%%."
+                            .formatted(summary.getConnectionPoolUtilization() * 100, poolThreshold * 100)));
+        }
+
+        double errorThreshold = spec.map(MetricsSpec::getErrorRateThreshold).orElse(DEFAULT_ERROR_RATE_THRESHOLD);
+        if (summary.getErrorRate() != null && summary.getErrorRate() >= errorThreshold) {
+            found.add(new Breach(REASON_HIGH_ERROR_RATE,
+                    "%.1f%% of REST API requests were answered with a 5xx status, at or above the configured threshold of %.1f%%."
+                            .formatted(summary.getErrorRate() * 100, errorThreshold * 100)));
+        }
+
+        long lagThreshold = spec.map(MetricsSpec::getKafkaConsumerLagThreshold)
+                .orElse(DEFAULT_KAFKA_CONSUMER_LAG_THRESHOLD);
+        if (summary.getKafkaConsumerLag() != null && summary.getKafkaConsumerLag() >= lagThreshold) {
+            found.add(new Breach(REASON_KAFKA_CONSUMER_LAG,
+                    "KafkaSQL consumer lag is %d records, at or above the configured threshold of %d."
+                            .formatted(summary.getKafkaConsumerLag(), lagThreshold)));
+        }
+        return found;
+    }
+
+    /**
+     * Whether a breach that is still ongoing may be reported again yet. Without this, a saturated pool would
+     * produce one Event per scrape interval.
+     */
+    boolean shouldReport(String reason, Instant now) {
+        var previous = lastEventAt.get(reason);
+        return previous == null || Duration.between(previous, now).compareTo(EVENT_REPEAT_INTERVAL) >= 0;
+    }
+
+    void recordReported(String reason, Instant now) {
+        lastEventAt.put(reason, now);
+    }
+
+    /**
+     * @return true when the Event was accepted by the API server
+     */
+    private boolean emit(ApicurioRegistry3 primary, KubernetesClient client, Instant now, Breach breach) {
+        var reason = breach.reason();
+        var namespace = primary.getMetadata().getNamespace();
+        try {
+            client.v1().events().inNamespace(namespace).resource(buildEvent(primary, now, breach)).create();
+            return true;
+        } catch (Exception ex) {
+            // Reporting is best effort. Failing to record an Event must not fail reconciliation, and not
+            // marking it as reported means the next collection will try again.
+            log.warn("Could not emit {} Event for {}: {}", reason, ResourceID.fromResource(primary),
+                    ex.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Builds the Event reporting a breach. Separate from sending it so that the shape can be checked against
+     * a real API server without having to reach the operand.
+     */
+    public static Event buildEvent(ApicurioRegistry3 primary, Instant now, Breach breach) {
+        var namespace = primary.getMetadata().getNamespace();
+        var timestamp = EVENT_TIMESTAMP.format(now);
+        return new EventBuilder()
+                .withNewMetadata()
+                .withNamespace(namespace)
+                .withGenerateName(primary.getMetadata().getName() + "-metrics-")
+                .endMetadata()
+                .withType("Warning")
+                .withReason(breach.reason())
+                .withMessage(breach.message())
+                .withFirstTimestamp(timestamp)
+                .withLastTimestamp(timestamp)
+                .withCount(1)
+                .withNewInvolvedObject()
+                .withApiVersion(primary.getApiVersion())
+                .withKind(primary.getKind())
+                .withName(primary.getMetadata().getName())
+                .withNamespace(namespace)
+                .withUid(primary.getMetadata().getUid())
+                .endInvolvedObject()
+                .withNewSource()
+                .withComponent("apicurio-registry-operator")
+                .endSource()
+                .build();
+    }
+
+    /**
+     * A threshold that the reported summary crosses, and the wording used to report it.
+     */
+    public record Breach(String reason, String message) {
+    }
+
+    public static boolean isEnabled(ApicurioRegistry3 primary) {
+        return metricsSpec(primary).map(MetricsSpec::getEnabled).orElse(false);
+    }
+
+    public static Duration scrapeInterval(ApicurioRegistry3 primary) {
+        var configured = metricsSpec(primary)
+                .map(MetricsSpec::getScrapeIntervalSeconds)
+                .filter(seconds -> seconds > 0)
+                .map(Duration::ofSeconds)
+                .orElse(DEFAULT_SCRAPE_INTERVAL);
+        // A very short interval would scrape the operand more often than it is useful, and would keep the
+        // reconciler busy for no benefit.
+        return configured.compareTo(MIN_SCRAPE_INTERVAL) < 0 ? MIN_SCRAPE_INTERVAL : configured;
+    }
+
+    /**
+     * How much time must pass before another collection is allowed.
+     * <p>
+     * This is slightly shorter than the scrape interval on purpose. Reconciliation is rescheduled one
+     * interval ahead, so a wake-up that lands a few milliseconds early would otherwise be turned away and
+     * the next chance would not come until a further full interval had passed, quietly halving the sampling
+     * rate.
+     */
+    private static Duration collectionDue(ApicurioRegistry3 primary) {
+        var interval = scrapeInterval(primary);
+        return interval.minus(interval.dividedBy(10));
+    }
+
+    private static Optional<MetricsSpec> metricsSpec(ApicurioRegistry3 primary) {
+        return ofNullable(primary)
+                .map(ApicurioRegistry3::getSpec)
+                .map(ApicurioRegistry3Spec::getApp)
+                .map(AppSpec::getMetrics);
+    }
+
+    private static Double round(Double value, int decimals) {
+        if (value == null) {
+            return null;
+        }
+        var factor = Math.pow(10, decimals);
+        return Math.round(value * factor) / factor;
+    }
+
+    private record Rates(double requestRate, double errorRate) {
+    }
+}

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/PrometheusTextParser.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/PrometheusTextParser.java
@@ -1,0 +1,177 @@
+package io.apicurio.registry.operator.metrics;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Minimal reader for the Prometheus text exposition format.
+ * <p>
+ * The operator only needs a handful of samples, so this deliberately does not build a full metric family
+ * model. Malformed lines are skipped rather than failing the whole scrape, because a single unexpected line
+ * should not cost us every other metric on the endpoint.
+ */
+public final class PrometheusTextParser {
+
+    private PrometheusTextParser() {
+    }
+
+    public static List<MetricSample> parse(String body) {
+        var samples = new ArrayList<MetricSample>();
+        if (body == null) {
+            return samples;
+        }
+        for (var rawLine : body.split("\n")) {
+            var line = rawLine.strip();
+            if (line.isEmpty() || line.charAt(0) == '#') {
+                continue;
+            }
+            var sample = parseLine(line);
+            if (sample != null) {
+                samples.add(sample);
+            }
+        }
+        return samples;
+    }
+
+    private static MetricSample parseLine(String line) {
+        String name;
+        Map<String, String> labels;
+        String remainder;
+
+        var openBrace = line.indexOf('{');
+        if (openBrace < 0) {
+            var space = line.indexOf(' ');
+            if (space <= 0) {
+                return null;
+            }
+            name = line.substring(0, space);
+            labels = Map.of();
+            remainder = line.substring(space + 1).strip();
+        } else {
+            var closeBrace = findClosingBrace(line, openBrace);
+            if (closeBrace < 0) {
+                return null;
+            }
+            name = line.substring(0, openBrace).strip();
+            labels = parseLabels(line.substring(openBrace + 1, closeBrace));
+            remainder = line.substring(closeBrace + 1).strip();
+        }
+
+        if (name.isEmpty() || remainder.isEmpty()) {
+            return null;
+        }
+        // The remainder is the value, optionally followed by a timestamp we do not use.
+        var space = remainder.indexOf(' ');
+        var valueToken = space < 0 ? remainder : remainder.substring(0, space);
+        var value = parseValue(valueToken);
+        return value == null ? null : new MetricSample(name, labels, value);
+    }
+
+    /**
+     * Label values are quoted and may contain braces, so the closing brace has to be found outside of quotes.
+     */
+    private static int findClosingBrace(String line, int openBrace) {
+        var inQuotes = false;
+        var escaped = false;
+        for (var i = openBrace + 1; i < line.length(); i++) {
+            var c = line.charAt(i);
+            if (escaped) {
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else if (c == '"') {
+                inQuotes = !inQuotes;
+            } else if (c == '}' && !inQuotes) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static Map<String, String> parseLabels(String raw) {
+        var labels = new LinkedHashMap<String, String>();
+        for (var pair : splitOutsideQuotes(raw)) {
+            var equals = pair.indexOf('=');
+            if (equals <= 0) {
+                continue;
+            }
+            var key = pair.substring(0, equals).strip();
+            var value = pair.substring(equals + 1).strip();
+            if (value.length() >= 2 && value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"') {
+                value = unescape(value.substring(1, value.length() - 1));
+            }
+            if (!key.isEmpty()) {
+                labels.put(key, value);
+            }
+        }
+        return labels;
+    }
+
+    private static List<String> splitOutsideQuotes(String raw) {
+        var parts = new ArrayList<String>();
+        var current = new StringBuilder();
+        var inQuotes = false;
+        var escaped = false;
+        for (var i = 0; i < raw.length(); i++) {
+            var c = raw.charAt(i);
+            if (escaped) {
+                escaped = false;
+                current.append(c);
+            } else if (c == '\\') {
+                escaped = true;
+                current.append(c);
+            } else if (c == '"') {
+                inQuotes = !inQuotes;
+                current.append(c);
+            } else if (c == ',' && !inQuotes) {
+                parts.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(c);
+            }
+        }
+        if (!current.isEmpty()) {
+            parts.add(current.toString());
+        }
+        return parts;
+    }
+
+    private static String unescape(String value) {
+        var out = new StringBuilder(value.length());
+        var escaped = false;
+        for (var i = 0; i < value.length(); i++) {
+            var c = value.charAt(i);
+            if (escaped) {
+                out.append(switch (c) {
+                    case 'n' -> '\n';
+                    case '"' -> '"';
+                    case '\\' -> '\\';
+                    default -> c;
+                });
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else {
+                out.append(c);
+            }
+        }
+        return out.toString();
+    }
+
+    private static Double parseValue(String token) {
+        return switch (token) {
+            case "NaN" -> Double.NaN;
+            case "+Inf", "Inf" -> Double.POSITIVE_INFINITY;
+            case "-Inf" -> Double.NEGATIVE_INFINITY;
+            default -> {
+                try {
+                    yield Double.parseDouble(token);
+                } catch (NumberFormatException ex) {
+                    yield null;
+                }
+            }
+        };
+    }
+}

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/RegistryMetricNames.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/RegistryMetricNames.java
@@ -1,0 +1,77 @@
+package io.apicurio.registry.operator.metrics;
+
+/**
+ * Names of the operand metrics that the operator reads.
+ * <p>
+ * These are the Prometheus names, i.e. the Micrometer meter names with dots replaced by underscores and,
+ * for timers, the base unit appended. They are collected here so that a change in the operand only requires
+ * a change in one place.
+ */
+public final class RegistryMetricNames {
+
+    /**
+     * Counter component of the {@code rest.requests} timer registered by the Registry REST metrics filter.
+     * Carries the {@link #TAG_STATUS_CODE_GROUP} tag.
+     */
+    public static final String REST_REQUESTS_COUNT = "rest_requests_seconds_count";
+
+    /**
+     * Response status code group, e.g. {@code 2xx} or {@code 5xx}.
+     */
+    public static final String TAG_STATUS_CODE_GROUP = "status_code_group";
+
+    /**
+     * Status code group covering server-side failures.
+     */
+    public static final String STATUS_CODE_GROUP_SERVER_ERROR = "5xx";
+
+    /**
+     * Whether a value of the {@link #TAG_STATUS_CODE_GROUP} tag denotes a server-side failure.
+     * <p>
+     * The Registry normally reports whole groups such as {@code 5xx}, but
+     * {@code apicurio.metrics.rest.explicit-status-codes-list} promotes individual status codes to a group of
+     * their own. It defaults to {@code 401}, and an operator who added a 5xx code to it would otherwise see
+     * those responses silently drop out of the reported error rate.
+     */
+    public static boolean isServerError(String statusCodeGroup) {
+        if (statusCodeGroup == null || statusCodeGroup.isEmpty() || statusCodeGroup.charAt(0) != '5') {
+            return false;
+        }
+        if (STATUS_CODE_GROUP_SERVER_ERROR.equals(statusCodeGroup)) {
+            return true;
+        }
+        if (statusCodeGroup.length() != 3) {
+            return false;
+        }
+        return Character.isDigit(statusCodeGroup.charAt(1)) && Character.isDigit(statusCodeGroup.charAt(2));
+    }
+
+    /**
+     * Number of database connections currently handed out by the Agroal pool.
+     */
+    public static final String POOL_ACTIVE_COUNT = "agroal_active_count";
+
+    /**
+     * Number of database connections currently idle in the Agroal pool.
+     */
+    public static final String POOL_AVAILABLE_COUNT = "agroal_available_count";
+
+    /**
+     * Number of artifacts currently held in storage.
+     */
+    public static final String STORAGE_ARTIFACTS = "storage_artifacts";
+
+    /**
+     * Number of artifact versions currently held in storage.
+     */
+    public static final String STORAGE_ARTIFACT_VERSIONS = "storage_artifact_versions";
+
+    /**
+     * Highest consumer lag, in records, across the partitions assigned to the KafkaSQL journal consumer.
+     * Present only when KafkaSQL storage is in use.
+     */
+    public static final String KAFKA_RECORDS_LAG_MAX = "kafka_consumer_fetch_manager_records_lag_max";
+
+    private RegistryMetricNames() {
+    }
+}

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/RegistryMetricsSnapshot.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/RegistryMetricsSnapshot.java
@@ -1,0 +1,32 @@
+package io.apicurio.registry.operator.metrics;
+
+import java.time.Instant;
+
+/**
+ * Raw metric values aggregated across the Apicurio Registry application Pods at a single point in time.
+ * <p>
+ * Counters are kept raw so that two snapshots can be differenced into a rate. Gauges are already aggregated,
+ * because averaging or maximizing them later would not be meaningful.
+ *
+ * @param timestamp           when the scrape completed
+ * @param scrapedPods         how many Pods answered
+ * @param requestsTotal       cumulative REST API request count, summed across Pods
+ * @param serverErrorsTotal   cumulative count of requests answered with a 5xx status, summed across Pods
+ * @param requestMetricSeen   whether any Pod exposed the request counter at all
+ * @param poolUtilization     mean fraction of in-use database connections, null when not exposed
+ * @param artifactCount       number of artifacts in storage, null when not exposed
+ * @param artifactVersionCount number of artifact versions in storage, null when not exposed
+ * @param kafkaConsumerLag    highest consumer lag reported by any Pod, null when not exposed
+ */
+public record RegistryMetricsSnapshot(
+        Instant timestamp,
+        int scrapedPods,
+        double requestsTotal,
+        double serverErrorsTotal,
+        boolean requestMetricSeen,
+        Double poolUtilization,
+        Long artifactCount,
+        Long artifactVersionCount,
+        Long kafkaConsumerLag
+) {
+}

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/RegistryMetricsSnapshot.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/metrics/RegistryMetricsSnapshot.java
@@ -1,32 +1,50 @@
 package io.apicurio.registry.operator.metrics;
 
 import java.time.Instant;
+import java.util.Map;
 
 /**
- * Raw metric values aggregated across the Apicurio Registry application Pods at a single point in time.
+ * Raw metric values collected from the Apicurio Registry application Pods at a single point in time.
  * <p>
- * Counters are kept raw so that two snapshots can be differenced into a rate. Gauges are already aggregated,
- * because averaging or maximizing them later would not be meaningful.
+ * Request counters are kept per Pod rather than pre-summed, because a rate can only be derived from two
+ * readings that cover the same set of Pods. Summing first loses the information needed to tell that apart: a
+ * scrape that lost one Pod and gained another covers the same number of Pods, and the difference between the
+ * two sums would then be reported as traffic. Gauges are already aggregated, because averaging or maximizing
+ * them later would not be meaningful.
  *
- * @param timestamp           when the scrape completed
- * @param scrapedPods         how many Pods answered
- * @param requestsTotal       cumulative REST API request count, summed across Pods
- * @param serverErrorsTotal   cumulative count of requests answered with a 5xx status, summed across Pods
- * @param requestMetricSeen   whether any Pod exposed the request counter at all
- * @param poolUtilization     mean fraction of in-use database connections, null when not exposed
- * @param artifactCount       number of artifacts in storage, null when not exposed
+ * @param timestamp            when the scrape completed
+ * @param scrapedPods          how many Pods answered
+ * @param requestCounters      cumulative REST API request counters, keyed by Pod name. A Pod that did not
+ *                             expose the counter is absent.
+ * @param poolUtilization      highest fraction of in-use database connections on any Pod, null when not
+ *                             exposed
+ * @param artifactCount        number of artifacts in storage, null when not exposed
  * @param artifactVersionCount number of artifact versions in storage, null when not exposed
- * @param kafkaConsumerLag    highest consumer lag reported by any Pod, null when not exposed
+ * @param kafkaConsumerLag     highest consumer lag reported by any Pod, null when not exposed
  */
 public record RegistryMetricsSnapshot(
         Instant timestamp,
         int scrapedPods,
-        double requestsTotal,
-        double serverErrorsTotal,
-        boolean requestMetricSeen,
+        Map<String, RequestCounters> requestCounters,
         Double poolUtilization,
         Long artifactCount,
         Long artifactVersionCount,
         Long kafkaConsumerLag
 ) {
+
+    /**
+     * Whether any Pod exposed the request counter at all.
+     */
+    public boolean requestMetricSeen() {
+        return !requestCounters.isEmpty();
+    }
+
+    /**
+     * The cumulative request counters read from a single Pod.
+     *
+     * @param requests     all REST API requests, across every status code group
+     * @param serverErrors the subset answered with a server error status
+     */
+    public record RequestCounters(double requests, double serverErrors) {
+    }
 }

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/status/MetricsUnavailableConditionManager.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/status/MetricsUnavailableConditionManager.java
@@ -1,0 +1,59 @@
+package io.apicurio.registry.operator.status;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.status.Condition;
+import io.apicurio.registry.operator.api.v1.status.ConditionStatus;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+
+import static io.apicurio.registry.operator.api.v1.status.ConditionConstants.TYPE_METRICS_UNAVAILABLE;
+
+/**
+ * Manages the condition that reports a failure to collect operand metrics.
+ * <p>
+ * Being unable to reach the operand is not an operator error, so it is reported separately and never fails
+ * reconciliation. The condition is hidden while collection is working, and also while metrics collection is
+ * disabled.
+ */
+public class MetricsUnavailableConditionManager extends AbstractConditionManager {
+
+    private static final String REASON_AVAILABLE = "MetricsAvailable";
+
+    private static final String REASON_COLLECTION_FAILED = "CollectionFailed";
+
+    private String failure;
+
+    MetricsUnavailableConditionManager() {
+        resetCondition();
+    }
+
+    @Override
+    void resetCondition() {
+        current = new Condition();
+        current.setType(TYPE_METRICS_UNAVAILABLE);
+        failure = null;
+    }
+
+    /**
+     * Record that the most recent collection attempt did not succeed.
+     * <p>
+     * This has to be called on every reconciliation while the failure persists, not only on the
+     * reconciliation that first observed it, otherwise the condition would disappear and reappear between
+     * scrape intervals.
+     */
+    public synchronized void recordFailure(String message) {
+        this.failure = message;
+    }
+
+    @Override
+    void updateCondition(ApicurioRegistry3 primary, Context<ApicurioRegistry3> context) {
+        if (failure != null) {
+            current.setStatus(ConditionStatus.TRUE);
+            current.setReason(REASON_COLLECTION_FAILED);
+            current.setMessage("Could not collect metrics from the Apicurio Registry application: " + failure);
+        } else {
+            current.setStatus(ConditionStatus.FALSE);
+            current.setReason(REASON_AVAILABLE);
+            current.setMessage("Metrics were collected successfully.");
+        }
+    }
+}

--- a/operator/controller/src/main/java/io/apicurio/registry/operator/status/StatusManager.java
+++ b/operator/controller/src/main/java/io/apicurio/registry/operator/status/StatusManager.java
@@ -3,6 +3,7 @@ package io.apicurio.registry.operator.status;
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
 import io.apicurio.registry.operator.api.v1.ApicurioRegistry3Status;
 import io.apicurio.registry.operator.api.v1.status.ConditionStatus;
+import io.apicurio.registry.operator.metrics.MetricsManager;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import org.slf4j.Logger;
@@ -40,6 +41,7 @@ public class StatusManager {
         conditionManagers = List.of(
                 new OperatorErrorConditionManager(),
                 new ValidationErrorConditionManager(),
+                new MetricsUnavailableConditionManager(),
                 new ReadyConditionManager()
         );
     }
@@ -69,6 +71,11 @@ public class StatusManager {
         }
 
         status.setObservedGeneration(primary.getMetadata().getGeneration());
+        // Metrics are collected by the reconciler before this point, when the feature is enabled. Skipping
+        // the call when it is disabled leaves the field null, which removes it from the resource.
+        if (MetricsManager.isEnabled(primary)) {
+            MetricsManager.get(primary).applyStatus(status);
+        }
 
         primary.setStatus(status);
         return primary;

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/feat/PrometheusRuleManagerTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/feat/PrometheusRuleManagerTest.java
@@ -44,6 +44,36 @@ public class PrometheusRuleManagerTest {
         assertThat(expr(rules, "ApicurioRegistryHighErrorRate")).endsWith(">= 0.1");
     }
 
+    /**
+     * The rule is owned by the custom resource that asked for it, so deleting the Registry takes the rule
+     * with it even when the operator is not running at the time. A rule left behind keeps alerting for a
+     * deployment that no longer exists.
+     */
+    @Test
+    public void testTheRuleIsOwnedByTheCustomResource() {
+        var registry = registry(new MetricsSpec());
+        registry.getMetadata().setUid("4b1d0000-0000-0000-0000-00000000cafe");
+        registry.setApiVersion("registry.apicur.io/v1");
+        registry.setKind("ApicurioRegistry3");
+
+        assertThat(PrometheusRuleManager.ownerReferences(registry)).singleElement().satisfies(owner -> {
+            assertThat(owner.getUid()).isEqualTo("4b1d0000-0000-0000-0000-00000000cafe");
+            assertThat(owner.getName()).isEqualTo("rules");
+            assertThat(owner.getKind()).isEqualTo("ApicurioRegistry3");
+            assertThat(owner.getApiVersion()).isEqualTo("registry.apicur.io/v1");
+            assertThat(owner.getController()).isTrue();
+        });
+    }
+
+    /**
+     * The API server rejects an owner reference without a UID, so a resource that does not have one yet must
+     * produce no reference at all rather than an invalid one.
+     */
+    @Test
+    public void testNoOwnerReferenceWithoutAUid() {
+        assertThat(PrometheusRuleManager.ownerReferences(registry(new MetricsSpec()))).isEmpty();
+    }
+
     private static String expr(java.util.List<java.util.Map<String, Object>> rules, String alert) {
         return rules.stream().filter(r -> alert.equals(r.get("alert"))).findFirst().orElseThrow()
                 .get("expr").toString();

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/feat/PrometheusRuleManagerTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/feat/PrometheusRuleManagerTest.java
@@ -1,0 +1,58 @@
+package io.apicurio.registry.operator.feat;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.spec.MetricsSpec;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PrometheusRuleManagerTest {
+
+    @Test
+    public void testDisabledUnlessAskedFor() {
+        assertThat(PrometheusRuleManager.isEnabled(registry(null))).isFalse();
+
+        var metrics = new MetricsSpec();
+        metrics.setEnabled(true);
+        assertThat(PrometheusRuleManager.isEnabled(registry(metrics))).isFalse();
+
+        metrics.setPrometheusRuleEnabled(true);
+        assertThat(PrometheusRuleManager.isEnabled(registry(metrics))).isTrue();
+    }
+
+    /**
+     * The generated alerts must carry the thresholds configured on the CR, otherwise Prometheus and the
+     * operator would disagree about when something is wrong.
+     */
+    @Test
+    public void testRulesCarryTheConfiguredThresholds() {
+        var metrics = new MetricsSpec();
+        metrics.setEnabled(true);
+        metrics.setPrometheusRuleEnabled(true);
+        metrics.setConnectionPoolUtilizationThreshold(0.6);
+        metrics.setKafkaConsumerLagThreshold(250L);
+
+        var rules = PrometheusRuleManager.buildRules(registry(metrics), "my-namespace");
+
+        assertThat(rules).hasSize(3);
+        assertThat(rules).allSatisfy(rule -> assertThat(rule.get("expr").toString())
+                .contains("namespace=\"my-namespace\""));
+        assertThat(expr(rules, "ApicurioRegistryConnectionPoolSaturated")).endsWith(">= 0.6");
+        assertThat(expr(rules, "ApicurioRegistryKafkaConsumerLagHigh")).endsWith(">= 250");
+        // Not configured, so the default applies.
+        assertThat(expr(rules, "ApicurioRegistryHighErrorRate")).endsWith(">= 0.1");
+    }
+
+    private static String expr(java.util.List<java.util.Map<String, Object>> rules, String alert) {
+        return rules.stream().filter(r -> alert.equals(r.get("alert"))).findFirst().orElseThrow()
+                .get("expr").toString();
+    }
+
+    private static ApicurioRegistry3 registry(MetricsSpec metrics) {
+        var registry = new ApicurioRegistry3();
+        registry.setMetadata(new ObjectMetaBuilder().withName("rules").withNamespace("test").build());
+        registry.withSpec().withApp().setMetrics(metrics);
+        return registry;
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/MetricsStatusITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/MetricsStatusITTest.java
@@ -1,0 +1,139 @@
+package io.apicurio.registry.operator.it;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.spec.MetricsSpec;
+import io.apicurio.registry.operator.metrics.MetricsManager;
+import io.apicurio.registry.operator.resource.ResourceFactory;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+
+import static io.apicurio.registry.operator.Tags.FEATURE;
+import static io.apicurio.registry.operator.Tags.FEATURE_A;
+import static io.apicurio.registry.operator.api.v1.status.ConditionConstants.TYPE_METRICS_UNAVAILABLE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Collection reads the application Pods over the cluster network, so the tests that need it only work when
+ * the operator itself runs in the cluster. With a local deployment the operator sits outside, where a Pod IP
+ * is not routable, and neither would a Service ClusterIP be.
+ */
+@QuarkusTest
+@Tag(FEATURE)
+@Tag(FEATURE_A)
+public class MetricsStatusITTest extends ITBase {
+
+    private static final Logger log = LoggerFactory.getLogger(MetricsStatusITTest.class);
+
+    @Test
+    @DisabledIf("io.apicurio.registry.operator.it.ITBase#isLocalDeployment")
+    void testMetricsAreReportedWhenEnabled() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+
+        var metrics = new MetricsSpec();
+        metrics.setEnabled(true);
+        metrics.setScrapeIntervalSeconds(10);
+        registry.getSpec().getApp().setMetrics(metrics);
+
+        client.resource(registry).create();
+
+        checkDeploymentExists(registry, ResourceFactory.COMPONENT_APP, 1);
+
+        await().atMost(MEDIUM_DURATION).ignoreExceptions().untilAsserted(() -> {
+            var status = client.resource(registry).get().getStatus();
+            assertThat(status).isNotNull();
+            assertThat(status.getMetrics()).isNotNull();
+            // A timestamp means the operator reached the management interface and parsed a response.
+            assertThat(status.getMetrics().getLastCollected()).isNotNull();
+            assertThat(status.getMetrics().getSummary()).isNotNull();
+            // Reaching the endpoint means the failure condition must not be present.
+            assertThat(status.getConditions())
+                    .noneMatch(condition -> TYPE_METRICS_UNAVAILABLE.equals(condition.getType()));
+        });
+    }
+
+    /**
+     * The reported timestamp tracks the last change in the numbers, not the last collection attempt. If it
+     * moved on every pass, each status patch would trigger another reconciliation.
+     */
+    @Test
+    @DisabledIf("io.apicurio.registry.operator.it.ITBase#isLocalDeployment")
+    void testLastCollectedDoesNotMoveWhileTheRegistryIsIdle() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+
+        var metrics = new MetricsSpec();
+        metrics.setEnabled(true);
+        metrics.setScrapeIntervalSeconds(10);
+        registry.getSpec().getApp().setMetrics(metrics);
+
+        client.resource(registry).create();
+
+        checkDeploymentExists(registry, ResourceFactory.COMPONENT_APP, 1);
+
+        await().atMost(MEDIUM_DURATION).ignoreExceptions().untilAsserted(() -> assertThat(
+                client.resource(registry).get().getStatus().getMetrics().getLastCollected()).isNotNull());
+
+        // An idle registry serves no API requests, so every scrape in this window yields the same numbers.
+        var first = client.resource(registry).get().getStatus().getMetrics().getLastCollected();
+        await().pollDelay(SHORT_DURATION).atMost(MEDIUM_DURATION).ignoreExceptions()
+                .untilAsserted(() -> assertThat(client.resource(registry).get()).isNotNull());
+        var later = client.resource(registry).get().getStatus().getMetrics().getLastCollected();
+
+        log.info("lastCollected across several scrape intervals: {} then {}", first, later);
+        assertThat(later).isEqualTo(first);
+    }
+
+    /**
+     * The Event is sent to the API server, not to the operand, so unlike collection this works with a local
+     * operator too. Without it the shape of the Event would never be checked against a real API server, and a
+     * rejected Event only produces a log warning.
+     */
+    @Test
+    void testABreachEventIsAcceptedByTheApiServer() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+        var created = client.resource(registry).create();
+
+        var breach = new MetricsManager.Breach(MetricsManager.REASON_HIGH_ERROR_RATE,
+                "12.0% of REST API requests were answered with a 5xx status.");
+        var event = MetricsManager.buildEvent(created, Instant.now(), breach);
+
+        client.v1().events().inNamespace(namespace).resource(event).create();
+
+        await().atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
+            var stored = client.v1().events().inNamespace(namespace).list().getItems().stream()
+                    .filter(e -> MetricsManager.REASON_HIGH_ERROR_RATE.equals(e.getReason()))
+                    .findFirst();
+            assertThat(stored).isPresent();
+            assertThat(stored.get().getType()).isEqualTo("Warning");
+            // An Event whose involvedObject does not resolve would not show up under kubectl describe.
+            assertThat(stored.get().getInvolvedObject().getName())
+                    .isEqualTo(created.getMetadata().getName());
+            assertThat(stored.get().getInvolvedObject().getUid()).isEqualTo(created.getMetadata().getUid());
+        });
+    }
+
+    @Test
+    void testMetricsAreAbsentByDefault() {
+        var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
+                ApicurioRegistry3.class);
+
+        client.resource(registry).create();
+
+        checkDeploymentExists(registry, ResourceFactory.COMPONENT_APP, 1);
+
+        await().atMost(SHORT_DURATION).ignoreExceptions().untilAsserted(() -> {
+            var status = client.resource(registry).get().getStatus();
+            assertThat(status).isNotNull();
+            assertThat(status.getMetrics()).isNull();
+        });
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/MetricsStatusITTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/MetricsStatusITTest.java
@@ -60,12 +60,15 @@ public class MetricsStatusITTest extends ITBase {
     }
 
     /**
-     * The reported timestamp tracks the last change in the numbers, not the last collection attempt. If it
-     * moved on every pass, each status patch would trigger another reconciliation.
+     * An idle registry serves no API requests and stores nothing new, so every scrape in this window yields
+     * the same numbers. The timestamp still has to advance, because it reports when the operator last read
+     * the operand rather than when the numbers last changed. That distinction is the only thing separating a
+     * healthy quiet deployment from one the operator stopped collecting from an hour ago, and it belongs in
+     * an integration test because it is the reconciliation loop that has to keep driving it.
      */
     @Test
     @DisabledIf("io.apicurio.registry.operator.it.ITBase#isLocalDeployment")
-    void testLastCollectedDoesNotMoveWhileTheRegistryIsIdle() {
+    void testLastCollectedAdvancesWhileTheRegistryIsIdle() {
         var registry = ResourceFactory.deserialize("/k8s/examples/simple.apicurioregistry3.yaml",
                 ApicurioRegistry3.class);
 
@@ -81,14 +84,17 @@ public class MetricsStatusITTest extends ITBase {
         await().atMost(MEDIUM_DURATION).ignoreExceptions().untilAsserted(() -> assertThat(
                 client.resource(registry).get().getStatus().getMetrics().getLastCollected()).isNotNull());
 
-        // An idle registry serves no API requests, so every scrape in this window yields the same numbers.
-        var first = client.resource(registry).get().getStatus().getMetrics().getLastCollected();
-        await().pollDelay(SHORT_DURATION).atMost(MEDIUM_DURATION).ignoreExceptions()
-                .untilAsserted(() -> assertThat(client.resource(registry).get()).isNotNull());
-        var later = client.resource(registry).get().getStatus().getMetrics().getLastCollected();
+        var reported = client.resource(registry).get().getStatus().getMetrics();
+        var first = reported.getLastCollected();
+        var summary = reported.getSummary();
 
-        log.info("lastCollected across several scrape intervals: {} then {}", first, later);
-        assertThat(later).isEqualTo(first);
+        await().atMost(MEDIUM_DURATION).ignoreExceptions().untilAsserted(() -> {
+            var later = client.resource(registry).get().getStatus().getMetrics();
+            log.info("lastCollected was {}, now {}", first, later.getLastCollected());
+            assertThat(later.getLastCollected()).isAfter(first);
+            // The numbers did not have to change for the timestamp to move.
+            assertThat(later.getSummary()).isEqualTo(summary);
+        });
     }
 
     /**

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/metrics/MetricsCollectorTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/metrics/MetricsCollectorTest.java
@@ -8,11 +8,11 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.within;
 
 public class MetricsCollectorTest {
 
@@ -37,27 +37,53 @@ public class MetricsCollectorTest {
 
     @Test
     public void testAggregatesAcrossPods() {
-        var snapshot = MetricsCollector.aggregate(List.of(POD_A, POD_B));
+        var snapshot = MetricsCollector.aggregate(bodies("pod-a", POD_A, "pod-b", POD_B));
 
         assertThat(snapshot.scrapedPods()).isEqualTo(2);
-        assertThat(snapshot.requestsTotal()).isEqualTo(155.0);
-        assertThat(snapshot.serverErrorsTotal()).isEqualTo(5.0);
-        // Pod A is at 8/10, Pod B at 2/10.
-        assertThat(snapshot.poolUtilization()).isCloseTo(0.5, within(0.0001));
         assertThat(snapshot.kafkaConsumerLag()).isEqualTo(700L);
         // Every replica counts the same shared storage, so these are maxed and not summed.
         assertThat(snapshot.artifactCount()).isEqualTo(40L);
         assertThat(snapshot.artifactVersionCount()).isEqualTo(120L);
     }
 
+    /**
+     * Request counters stay attributed to the Pod they came from. Summing them here would make a scrape that
+     * covered a different set of Pods indistinguishable from one that covered the same set, and the operator
+     * derives rates by differencing these.
+     */
+    @Test
+    public void testRequestCountersAreKeptPerPod() {
+        var snapshot = MetricsCollector.aggregate(bodies("pod-a", POD_A, "pod-b", POD_B));
+
+        assertThat(snapshot.requestMetricSeen()).isTrue();
+        assertThat(snapshot.requestCounters()).containsOnlyKeys("pod-a", "pod-b");
+        assertThat(snapshot.requestCounters().get("pod-a").requests()).isEqualTo(105.0);
+        assertThat(snapshot.requestCounters().get("pod-a").serverErrors()).isEqualTo(5.0);
+        assertThat(snapshot.requestCounters().get("pod-b").requests()).isEqualTo(50.0);
+        assertThat(snapshot.requestCounters().get("pod-b").serverErrors()).isEqualTo(0.0);
+    }
+
+    /**
+     * A replica whose pool is exhausted is already queueing or failing requests. Averaging across replicas
+     * would let it hide behind idle ones, which is the case the threshold exists to catch.
+     */
+    @Test
+    public void testPoolUtilizationReportsTheWorstPodRatherThanTheAverage() {
+        // Pod A is at 8/10 and Pod B at 2/10, which would average to 0.5.
+        var snapshot = MetricsCollector.aggregate(bodies("pod-a", POD_A, "pod-b", POD_B));
+
+        assertThat(snapshot.poolUtilization()).isEqualTo(0.8);
+    }
+
     @Test
     public void testAbsentMetricsAreReportedAsAbsentRatherThanZero() {
-        var snapshot = MetricsCollector.aggregate(List.of("""
+        var snapshot = MetricsCollector.aggregate(bodies("pod-a", """
                 some_unrelated_metric 1
                 kafka_consumer_fetch_manager_records_lag_max NaN
                 """));
 
         assertThat(snapshot.requestMetricSeen()).isFalse();
+        assertThat(snapshot.requestCounters()).isEmpty();
         assertThat(snapshot.poolUtilization()).isNull();
         assertThat(snapshot.artifactCount()).isNull();
         // Non-finite samples are skipped rather than turned into a bogus value.
@@ -70,14 +96,14 @@ public class MetricsCollectorTest {
      */
     @Test
     public void testExplicitServerErrorCodesAreCounted() {
-        var snapshot = MetricsCollector.aggregate(List.of("""
+        var snapshot = MetricsCollector.aggregate(bodies("pod-a", """
                 rest_requests_seconds_count{status_code_group="2xx"} 90
                 rest_requests_seconds_count{status_code_group="503"} 10
                 rest_requests_seconds_count{status_code_group="401"} 5
                 """));
 
-        assertThat(snapshot.requestsTotal()).isEqualTo(105.0);
-        assertThat(snapshot.serverErrorsTotal()).isEqualTo(10.0);
+        assertThat(snapshot.requestCounters().get("pod-a").requests()).isEqualTo(105.0);
+        assertThat(snapshot.requestCounters().get("pod-a").serverErrors()).isEqualTo(10.0);
     }
 
     /**
@@ -91,11 +117,11 @@ public class MetricsCollectorTest {
             body = new String(in.readAllBytes(), StandardCharsets.UTF_8);
         }
 
-        var snapshot = MetricsCollector.aggregate(List.of(body));
+        var snapshot = MetricsCollector.aggregate(bodies("pod-a", body));
 
         // 7 successful and 3 not-found requests, counted once each across all label combinations.
-        assertThat(snapshot.requestsTotal()).isEqualTo(10.0);
-        assertThat(snapshot.serverErrorsTotal()).isEqualTo(0.0);
+        assertThat(snapshot.requestCounters().get("pod-a").requests()).isEqualTo(10.0);
+        assertThat(snapshot.requestCounters().get("pod-a").serverErrors()).isEqualTo(0.0);
         // The pool had opened 20 connections and none were checked out.
         assertThat(snapshot.poolUtilization()).isEqualTo(0.0);
         // Captured from a released image, which predates the gauges this change adds to the app module.
@@ -122,6 +148,19 @@ public class MetricsCollectorTest {
         assertThatThrownBy(() -> new MetricsCollector().collect(null, registryWithTls(tls)))
                 .isInstanceOf(MetricsCollectionException.class)
                 .hasMessageContaining("spec.app.tls");
+    }
+
+    private static Map<String, String> bodies(String name, String body) {
+        var bodies = new LinkedHashMap<String, String>();
+        bodies.put(name, body);
+        return bodies;
+    }
+
+    private static Map<String, String> bodies(String firstName, String firstBody, String secondName,
+                                              String secondBody) {
+        var bodies = bodies(firstName, firstBody);
+        bodies.put(secondName, secondBody);
+        return bodies;
     }
 
     private static ApicurioRegistry3 registryWithTls(TLSSpec tls) {

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/metrics/MetricsCollectorTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/metrics/MetricsCollectorTest.java
@@ -1,0 +1,133 @@
+package io.apicurio.registry.operator.metrics;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.spec.InsecureRequests;
+import io.apicurio.registry.operator.api.v1.spec.SecretKeyRef;
+import io.apicurio.registry.operator.api.v1.spec.TLSSpec;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
+public class MetricsCollectorTest {
+
+    private static final String POD_A = """
+            rest_requests_seconds_count{status_code_group="2xx"} 100
+            rest_requests_seconds_count{status_code_group="5xx"} 5
+            agroal_active_count 8
+            agroal_available_count 2
+            storage_artifacts 40
+            storage_artifact_versions 120
+            kafka_consumer_fetch_manager_records_lag_max 300
+            """;
+
+    private static final String POD_B = """
+            rest_requests_seconds_count{status_code_group="2xx"} 50
+            agroal_active_count 2
+            agroal_available_count 8
+            storage_artifacts 40
+            storage_artifact_versions 120
+            kafka_consumer_fetch_manager_records_lag_max 700
+            """;
+
+    @Test
+    public void testAggregatesAcrossPods() {
+        var snapshot = MetricsCollector.aggregate(List.of(POD_A, POD_B));
+
+        assertThat(snapshot.scrapedPods()).isEqualTo(2);
+        assertThat(snapshot.requestsTotal()).isEqualTo(155.0);
+        assertThat(snapshot.serverErrorsTotal()).isEqualTo(5.0);
+        // Pod A is at 8/10, Pod B at 2/10.
+        assertThat(snapshot.poolUtilization()).isCloseTo(0.5, within(0.0001));
+        assertThat(snapshot.kafkaConsumerLag()).isEqualTo(700L);
+        // Every replica counts the same shared storage, so these are maxed and not summed.
+        assertThat(snapshot.artifactCount()).isEqualTo(40L);
+        assertThat(snapshot.artifactVersionCount()).isEqualTo(120L);
+    }
+
+    @Test
+    public void testAbsentMetricsAreReportedAsAbsentRatherThanZero() {
+        var snapshot = MetricsCollector.aggregate(List.of("""
+                some_unrelated_metric 1
+                kafka_consumer_fetch_manager_records_lag_max NaN
+                """));
+
+        assertThat(snapshot.requestMetricSeen()).isFalse();
+        assertThat(snapshot.poolUtilization()).isNull();
+        assertThat(snapshot.artifactCount()).isNull();
+        // Non-finite samples are skipped rather than turned into a bogus value.
+        assertThat(snapshot.kafkaConsumerLag()).isNull();
+    }
+
+    /**
+     * Registry promotes individual status codes to their own group when they appear in
+     * apicurio.metrics.rest.explicit-status-codes-list, so matching only "5xx" would miss them.
+     */
+    @Test
+    public void testExplicitServerErrorCodesAreCounted() {
+        var snapshot = MetricsCollector.aggregate(List.of("""
+                rest_requests_seconds_count{status_code_group="2xx"} 90
+                rest_requests_seconds_count{status_code_group="503"} 10
+                rest_requests_seconds_count{status_code_group="401"} 5
+                """));
+
+        assertThat(snapshot.requestsTotal()).isEqualTo(105.0);
+        assertThat(snapshot.serverErrorsTotal()).isEqualTo(10.0);
+    }
+
+    /**
+     * Parses output captured from a real Registry rather than a hand-written approximation, so a change in
+     * how the operand names or labels these metrics is caught here.
+     */
+    @Test
+    public void testOutputCapturedFromARealRegistry() throws Exception {
+        String body;
+        try (var in = getClass().getResourceAsStream("/metrics/registry-sql-metrics.txt")) {
+            body = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+
+        var snapshot = MetricsCollector.aggregate(List.of(body));
+
+        // 7 successful and 3 not-found requests, counted once each across all label combinations.
+        assertThat(snapshot.requestsTotal()).isEqualTo(10.0);
+        assertThat(snapshot.serverErrorsTotal()).isEqualTo(0.0);
+        // The pool had opened 20 connections and none were checked out.
+        assertThat(snapshot.poolUtilization()).isEqualTo(0.0);
+        // Captured from a released image, which predates the gauges this change adds to the app module.
+        assertThat(snapshot.kafkaConsumerLag()).isNull();
+        assertThat(snapshot.artifactCount()).isNull();
+    }
+
+    /**
+     * Configuring a keystore moves the Quarkus management interface to HTTPS, so the plain HTTP scrape cannot
+     * work. Allowing insecure requests does not bring it back, that only affects the API port.
+     */
+    @Test
+    public void testTlsInstanceIsSkippedWithAnExplanation() {
+        assertThat(MetricsCollector.servesManagementOverTls(registryWithTls(null))).isFalse();
+
+        var tls = new TLSSpec();
+        tls.setTruststoreSecretRef(new SecretKeyRef());
+        assertThat(MetricsCollector.servesManagementOverTls(registryWithTls(tls))).isFalse();
+
+        tls.setKeystoreSecretRef(new SecretKeyRef());
+        tls.setInsecureRequests(InsecureRequests.ENABLED);
+        assertThat(MetricsCollector.servesManagementOverTls(registryWithTls(tls))).isTrue();
+
+        assertThatThrownBy(() -> new MetricsCollector().collect(null, registryWithTls(tls)))
+                .isInstanceOf(MetricsCollectionException.class)
+                .hasMessageContaining("spec.app.tls");
+    }
+
+    private static ApicurioRegistry3 registryWithTls(TLSSpec tls) {
+        var registry = new ApicurioRegistry3();
+        registry.setMetadata(new ObjectMetaBuilder().withName("tls-test").withNamespace("test").build());
+        registry.withSpec().withApp().setTls(tls);
+        return registry;
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/metrics/MetricsManagerTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/metrics/MetricsManagerTest.java
@@ -5,6 +5,7 @@ import io.apicurio.registry.operator.api.v1.ApicurioRegistry3Status;
 import io.apicurio.registry.operator.api.v1.spec.MetricsSpec;
 import io.apicurio.registry.operator.api.v1.status.MetricsStatus;
 import io.apicurio.registry.operator.api.v1.status.MetricsSummary;
+import io.apicurio.registry.operator.metrics.RegistryMetricsSnapshot.RequestCounters;
 import io.apicurio.registry.operator.status.MetricsUnavailableConditionManager;
 import io.apicurio.registry.operator.status.StatusManager;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
@@ -16,6 +17,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.LinkedHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,34 +67,50 @@ public class MetricsManagerTest {
     }
 
     /**
-     * The reconciler patches the status on every pass. If the reported metrics changed on every pass, that
-     * patch would rewrite the resource, produce a watch event, and reconcile again without end.
+     * The reconciler patches the status on every pass. Inside the scrape interval nothing is collected and
+     * the previously published status is reused unchanged, so the patch is empty and nothing is written.
+     * That is what stops a reconciliation from feeding itself.
      */
     @Test
-    public void testStatusDoesNotChangeWhenTheNumbersDoNot() {
+    public void testStatusIsReusedInsideTheScrapeInterval() {
         collector.enqueue(snapshot(T0, 100, 0));
         collect();
         var afterFirst = currentStatus();
         assertThat(afterFirst.getLastCollected()).isEqualTo(T0);
 
-        // Inside the interval nothing is collected and the same status is reported.
         advance(Duration.ofSeconds(30));
         collect();
-        assertThat(currentStatus()).isEqualTo(afterFirst);
 
-        // A second collection produces rates for the first time, so the summary legitimately changes.
-        advance(Duration.ofSeconds(30));
+        assertThat(collector.calls).isEqualTo(1);
+        assertThat(currentStatus()).isEqualTo(afterFirst);
+    }
+
+    /**
+     * lastCollected reports when the operator last managed to read the operand, not when the numbers last
+     * changed. An idle registry serves no requests and stores nothing new, so it reports the same values
+     * every interval, and a timestamp that froze there would be indistinguishable from one that froze
+     * because collection had stopped.
+     */
+    @Test
+    public void testLastCollectedAdvancesEvenWhenTheNumbersAreUnchanged() {
+        collector.enqueue(snapshot(T0, 100, 0));
+        collect();
+        assertThat(currentStatus().getLastCollected()).isEqualTo(T0);
+
+        advance(Duration.ofSeconds(60));
         collector.enqueue(snapshot(clock.get(), 160, 0));
         collect();
         var afterSecond = currentStatus();
         assertThat(afterSecond.getLastCollected()).isEqualTo(T0.plusSeconds(60));
         assertThat(afterSecond.getSummary().getRequestRate()).isEqualTo(1.0);
 
-        // A third collection yields the same numbers, so the timestamp must not move.
+        // Identical traffic over an identical interval, so every reported number is the same.
         advance(Duration.ofSeconds(60));
         collector.enqueue(snapshot(clock.get(), 220, 0));
         collect();
-        assertThat(currentStatus()).isEqualTo(afterSecond);
+
+        assertThat(currentStatus().getSummary()).isEqualTo(afterSecond.getSummary());
+        assertThat(currentStatus().getLastCollected()).isEqualTo(T0.plusSeconds(120));
     }
 
     @Test
@@ -129,7 +147,56 @@ public class MetricsManagerTest {
         assertThat(currentStatus().getSummary().getRequestRate()).isEqualTo(2.0);
 
         advance(Duration.ofSeconds(60));
-        collector.enqueue(new RegistryMetricsSnapshot(clock.get(), 2, 4000, 0, true, 0.5, 12L, 34L, 100L));
+        collector.enqueue(snapshot(clock.get(), counters("pod-a", 4000, 0), counters("pod-b", 100, 0)));
+        collect();
+        assertThat(currentStatus().getSummary().getRequestRate()).isEqualTo(2.0);
+    }
+
+    /**
+     * A scrape that loses one Pod and gains another covers the same number of Pods but not the same Pods, so
+     * a count alone cannot tell the two apart. Differencing the sums anyway would report the gap between two
+     * populations as traffic, which inflates the request rate and can invent an error rate large enough to
+     * raise a Warning Event.
+     */
+    @Test
+    public void testRatesAreDiscardedWhenThePodSetChangesWithoutChangingSize() {
+        collector.enqueue(snapshot(T0, counters("pod-a", 1000, 0), counters("pod-b", 1000, 0)));
+        collect();
+
+        advance(Duration.ofSeconds(60));
+        collector.enqueue(snapshot(clock.get(), counters("pod-a", 1060, 0), counters("pod-b", 1060, 0)));
+        collect();
+        assertThat(currentStatus().getSummary().getRequestRate()).isEqualTo(2.0);
+        assertThat(currentStatus().getSummary().getErrorRate()).isEqualTo(0.0);
+
+        // pod-b dropped out and pod-c answered instead. Still two Pods, but not the same two.
+        advance(Duration.ofSeconds(60));
+        collector.enqueue(snapshot(clock.get(), counters("pod-a", 1120, 0), counters("pod-c", 9000, 900)));
+        collect();
+
+        // The last trustworthy rates are kept rather than the 150/s and 15% the raw sums would imply.
+        assertThat(currentStatus().getSummary().getRequestRate()).isEqualTo(2.0);
+        assertThat(currentStatus().getSummary().getErrorRate()).isEqualTo(0.0);
+    }
+
+    /**
+     * One Pod restarting is otherwise masked by another Pod serving traffic, because the two only have to
+     * net out positive for the summed delta to look like a plausible rate.
+     */
+    @Test
+    public void testARestartIsDetectedEvenWhenTheSummedDeltaStaysPositive() {
+        collector.enqueue(snapshot(T0, counters("pod-a", 1000, 0), counters("pod-b", 1000, 0)));
+        collect();
+
+        advance(Duration.ofSeconds(60));
+        collector.enqueue(snapshot(clock.get(), counters("pod-a", 1060, 0), counters("pod-b", 1060, 0)));
+        collect();
+        assertThat(currentStatus().getSummary().getRequestRate()).isEqualTo(2.0);
+
+        // pod-b restarted back to 10, losing 1050, while pod-a served 2000 more. The summed delta is still
+        // positive, so checking only the total would accept it and report a rate of nearly 16/s.
+        advance(Duration.ofSeconds(60));
+        collector.enqueue(snapshot(clock.get(), counters("pod-a", 3060, 0), counters("pod-b", 10, 0)));
         collect();
         assertThat(currentStatus().getSummary().getRequestRate()).isEqualTo(2.0);
     }
@@ -205,7 +272,22 @@ public class MetricsManagerTest {
     }
 
     private static RegistryMetricsSnapshot snapshot(Instant timestamp, double requests, double errors) {
-        return new RegistryMetricsSnapshot(timestamp, 1, requests, errors, true, 0.5, 12L, 34L, 100L);
+        return snapshot(timestamp, counters("pod-a", requests, errors));
+    }
+
+    private static RegistryMetricsSnapshot snapshot(Instant timestamp, PodCounters... pods) {
+        var counters = new LinkedHashMap<String, RequestCounters>();
+        for (var pod : pods) {
+            counters.put(pod.name(), pod.counters());
+        }
+        return new RegistryMetricsSnapshot(timestamp, counters.size(), counters, 0.5, 12L, 34L, 100L);
+    }
+
+    private static PodCounters counters(String name, double requests, double errors) {
+        return new PodCounters(name, new RequestCounters(requests, errors));
+    }
+
+    private record PodCounters(String name, RequestCounters counters) {
     }
 
     private static ApicurioRegistry3 registry(String name) {

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/metrics/MetricsManagerTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/metrics/MetricsManagerTest.java
@@ -1,0 +1,246 @@
+package io.apicurio.registry.operator.metrics;
+
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3;
+import io.apicurio.registry.operator.api.v1.ApicurioRegistry3Status;
+import io.apicurio.registry.operator.api.v1.spec.MetricsSpec;
+import io.apicurio.registry.operator.api.v1.status.MetricsStatus;
+import io.apicurio.registry.operator.api.v1.status.MetricsSummary;
+import io.apicurio.registry.operator.status.MetricsUnavailableConditionManager;
+import io.apicurio.registry.operator.status.StatusManager;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MetricsManagerTest {
+
+    private static final Instant T0 = Instant.parse("2026-08-27T10:00:00Z");
+
+    private final AtomicReference<Instant> clock = new AtomicReference<>(T0);
+
+    private StubCollector collector;
+
+    private MetricsManager manager;
+
+    private ApicurioRegistry3 primary;
+
+    private MetricsUnavailableConditionManager conditionManager;
+
+    @BeforeEach
+    public void setUp() {
+        clock.set(T0);
+        collector = new StubCollector();
+        manager = new MetricsManager(collector, clock::get);
+        primary = registry("metrics-manager-test-" + System.nanoTime());
+        conditionManager = StatusManager.get(primary)
+                .getConditionManager(MetricsUnavailableConditionManager.class);
+    }
+
+    /**
+     * Reconciliation is rescheduled one interval ahead, so a wake-up that lands slightly early must still be
+     * allowed to collect. Otherwise the next chance is a further full interval away and the sampling rate
+     * quietly halves.
+     */
+    @Test
+    public void testCollectionRespectsTheScrapeInterval() {
+        collector.enqueue(snapshot(T0, 100, 0));
+        collect();
+
+        advance(Duration.ofSeconds(30));
+        collect();
+        assertThat(collector.calls).isEqualTo(1);
+
+        advance(Duration.ofSeconds(27));
+        collector.enqueue(snapshot(clock.get(), 200, 0));
+        collect();
+        assertThat(collector.calls).isEqualTo(2);
+    }
+
+    /**
+     * The reconciler patches the status on every pass. If the reported metrics changed on every pass, that
+     * patch would rewrite the resource, produce a watch event, and reconcile again without end.
+     */
+    @Test
+    public void testStatusDoesNotChangeWhenTheNumbersDoNot() {
+        collector.enqueue(snapshot(T0, 100, 0));
+        collect();
+        var afterFirst = currentStatus();
+        assertThat(afterFirst.getLastCollected()).isEqualTo(T0);
+
+        // Inside the interval nothing is collected and the same status is reported.
+        advance(Duration.ofSeconds(30));
+        collect();
+        assertThat(currentStatus()).isEqualTo(afterFirst);
+
+        // A second collection produces rates for the first time, so the summary legitimately changes.
+        advance(Duration.ofSeconds(30));
+        collector.enqueue(snapshot(clock.get(), 160, 0));
+        collect();
+        var afterSecond = currentStatus();
+        assertThat(afterSecond.getLastCollected()).isEqualTo(T0.plusSeconds(60));
+        assertThat(afterSecond.getSummary().getRequestRate()).isEqualTo(1.0);
+
+        // A third collection yields the same numbers, so the timestamp must not move.
+        advance(Duration.ofSeconds(60));
+        collector.enqueue(snapshot(clock.get(), 220, 0));
+        collect();
+        assertThat(currentStatus()).isEqualTo(afterSecond);
+    }
+
+    @Test
+    public void testRatesAreDerivedFromConsecutiveCollections() {
+        collector.enqueue(snapshot(T0, 1000, 10));
+        collect();
+        assertThat(currentStatus().getSummary().getRequestRate()).isNull();
+
+        advance(Duration.ofSeconds(60));
+        collector.enqueue(snapshot(clock.get(), 1120, 16));
+        collect();
+
+        var summary = currentStatus().getSummary();
+        assertThat(summary.getRequestRate()).isEqualTo(2.0);
+        assertThat(summary.getErrorRate()).isEqualTo(0.05);
+    }
+
+    /**
+     * A restarted Pod resets its counters and a rescaled Deployment changes what the sum covers. Neither
+     * delta is a rate, so the last known values are kept instead.
+     */
+    @Test
+    public void testUntrustworthyDeltasAreDiscarded() {
+        collector.enqueue(snapshot(T0, 1000, 0));
+        collect();
+        advance(Duration.ofSeconds(60));
+        collector.enqueue(snapshot(clock.get(), 1120, 0));
+        collect();
+        assertThat(currentStatus().getSummary().getRequestRate()).isEqualTo(2.0);
+
+        advance(Duration.ofSeconds(60));
+        collector.enqueue(snapshot(clock.get(), 5, 0));
+        collect();
+        assertThat(currentStatus().getSummary().getRequestRate()).isEqualTo(2.0);
+
+        advance(Duration.ofSeconds(60));
+        collector.enqueue(new RegistryMetricsSnapshot(clock.get(), 2, 4000, 0, true, 0.5, 12L, 34L, 100L));
+        collect();
+        assertThat(currentStatus().getSummary().getRequestRate()).isEqualTo(2.0);
+    }
+
+    @Test
+    public void testThresholdsAreCrossedAtTheirConfiguredValue() {
+        var summary = new MetricsSummary();
+        summary.setConnectionPoolUtilization(0.79);
+        summary.setErrorRate(0.09);
+        summary.setKafkaConsumerLag(999L);
+        // Just below each default, so nothing is reported.
+        assertThat(MetricsManager.breaches(primary, summary)).isEmpty();
+
+        // Exactly at the default is a breach, not just above it.
+        summary.setConnectionPoolUtilization(0.8);
+        summary.setErrorRate(0.1);
+        summary.setKafkaConsumerLag(1000L);
+        assertThat(MetricsManager.breaches(primary, summary)).map(MetricsManager.Breach::reason)
+                .containsExactlyInAnyOrder(MetricsManager.REASON_CONNECTION_POOL_SATURATED,
+                        MetricsManager.REASON_HIGH_ERROR_RATE, MetricsManager.REASON_KAFKA_CONSUMER_LAG);
+
+        // A configured threshold replaces the default.
+        primary.getSpec().getApp().getMetrics().setConnectionPoolUtilizationThreshold(0.95);
+        assertThat(MetricsManager.breaches(primary, summary)).map(MetricsManager.Breach::reason)
+                .doesNotContain(MetricsManager.REASON_CONNECTION_POOL_SATURATED);
+
+        // An absent value cannot breach anything.
+        assertThat(MetricsManager.breaches(primary, new MetricsSummary())).isEmpty();
+    }
+
+    /**
+     * A breach that persists would otherwise produce one Event per scrape interval and bury everything else
+     * in kubectl describe.
+     */
+    @Test
+    public void testAnOngoingBreachIsNotReportedAgainWithinTheWindow() {
+        var reason = MetricsManager.REASON_HIGH_ERROR_RATE;
+
+        assertThat(manager.shouldReport(reason, T0)).isTrue();
+        manager.recordReported(reason, T0);
+
+        assertThat(manager.shouldReport(reason, T0.plusSeconds(60))).isFalse();
+        assertThat(manager.shouldReport(reason, T0.plus(MetricsManager.EVENT_REPEAT_INTERVAL))).isTrue();
+        // A different threshold is tracked separately.
+        assertThat(manager.shouldReport(MetricsManager.REASON_KAFKA_CONSUMER_LAG, T0)).isTrue();
+    }
+
+    @Test
+    public void testFailedCollectionKeepsTheLastKnownSummary() {
+        collector.enqueue(snapshot(T0, 100, 0));
+        collect();
+        var afterFirst = currentStatus();
+
+        advance(Duration.ofSeconds(60));
+        collector.enqueueFailure("connection refused");
+        collect();
+
+        assertThat(currentStatus()).isEqualTo(afterFirst);
+    }
+
+    private void collect() {
+        manager.collect(primary, null, conditionManager);
+    }
+
+    private void advance(Duration duration) {
+        clock.set(clock.get().plus(duration));
+    }
+
+    private MetricsStatus currentStatus() {
+        var status = new ApicurioRegistry3Status();
+        manager.applyStatus(status);
+        return status.getMetrics();
+    }
+
+    private static RegistryMetricsSnapshot snapshot(Instant timestamp, double requests, double errors) {
+        return new RegistryMetricsSnapshot(timestamp, 1, requests, errors, true, 0.5, 12L, 34L, 100L);
+    }
+
+    private static ApicurioRegistry3 registry(String name) {
+        var registry = new ApicurioRegistry3();
+        registry.setMetadata(new ObjectMetaBuilder().withName(name).withNamespace("test").build());
+        var metrics = new MetricsSpec();
+        metrics.setEnabled(true);
+        metrics.setScrapeIntervalSeconds(60);
+        registry.withSpec().withApp().setMetrics(metrics);
+        return registry;
+    }
+
+    private static class StubCollector extends MetricsCollector {
+
+        private final Deque<Object> results = new ArrayDeque<>();
+
+        private int calls;
+
+        void enqueue(RegistryMetricsSnapshot snapshot) {
+            results.add(snapshot);
+        }
+
+        void enqueueFailure(String message) {
+            results.add(new MetricsCollectionException(message));
+        }
+
+        @Override
+        public RegistryMetricsSnapshot collect(KubernetesClient client, ApicurioRegistry3 primary)
+                throws MetricsCollectionException {
+            calls++;
+            var next = results.poll();
+            if (next instanceof MetricsCollectionException ex) {
+                throw ex;
+            }
+            return (RegistryMetricsSnapshot) next;
+        }
+    }
+}

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/metrics/PrometheusTextParserTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/metrics/PrometheusTextParserTest.java
@@ -1,0 +1,61 @@
+package io.apicurio.registry.operator.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PrometheusTextParserTest {
+
+    @Test
+    public void testParsesSamples() {
+        var samples = PrometheusTextParser.parse("""
+                # HELP agroal_active_count Number of active connections
+                # TYPE agroal_active_count gauge
+
+                agroal_active_count 3.0
+                rest_requests_seconds_count{method="GET",status_code_group="5xx"} 12.0
+                some_metric 1.5 1699999999000
+                """);
+
+        assertThat(samples).hasSize(3);
+        assertThat(samples.get(0).name()).isEqualTo("agroal_active_count");
+        assertThat(samples.get(0).labels()).isEmpty();
+        assertThat(samples.get(0).value()).isEqualTo(3.0);
+        assertThat(samples.get(1).label("status_code_group")).isEqualTo("5xx");
+        // A trailing timestamp is not part of the value.
+        assertThat(samples.get(2).value()).isEqualTo(1.5);
+    }
+
+    /**
+     * Registry tags REST metrics with the unsubstituted path, which contains braces, and a label value may
+     * also contain commas and escaped quotes.
+     */
+    @Test
+    public void testParsesLabelValueContainingSeparators() {
+        var samples = PrometheusTextParser.parse(
+                "rest_requests_seconds_count{path=\"/apis/registry/v3/groups/{groupId}\",note=\"a,b \\\"c\\\"\"} 7\n");
+
+        assertThat(samples).hasSize(1);
+        assertThat(samples.get(0).label("path")).isEqualTo("/apis/registry/v3/groups/{groupId}");
+        assertThat(samples.get(0).label("note")).isEqualTo("a,b \"c\"");
+    }
+
+    /**
+     * One unexpected line should not cost us every other metric on the endpoint.
+     */
+    @Test
+    public void testSkipsWhatItCannotRead() {
+        var samples = PrometheusTextParser.parse("""
+                no_value_at_all
+                broken{unclosed="label" 1
+                not_a_number abc
+                a_nan NaN
+                good_metric 42
+                """);
+
+        assertThat(samples).hasSize(2);
+        assertThat(samples.get(0).value()).isNaN();
+        assertThat(samples.get(1).name()).isEqualTo("good_metric");
+        assertThat(PrometheusTextParser.parse(null)).isEmpty();
+    }
+}

--- a/operator/controller/src/test/resources/metrics/registry-sql-metrics.txt
+++ b/operator/controller/src/test/resources/metrics/registry-sql-metrics.txt
@@ -1,0 +1,25 @@
+# TYPE agroal_active_count gauge
+# HELP agroal_active_count Number of active connections. These connections are in use and not available to be acquired.
+# TYPE agroal_max_used_count gauge
+# HELP agroal_max_used_count Maximum number of connections active simultaneously.
+# TYPE rest_requests_seconds_max gauge
+# HELP rest_requests_seconds_max Timing and results of REST endpoints calls
+# TYPE rest_requests_seconds histogram
+# HELP rest_requests_seconds Timing and results of REST endpoints calls
+# TYPE agroal_available_count gauge
+# HELP agroal_available_count Number of idle connections in the pool, available to be acquired.
+# NOTE: captured from quay.io/apicurio/apicurio-registry:latest-snapshot, SQL storage, after 7 successful
+# and 3 not-found API requests. Predates the storage and Kafka gauges added in this change, which is why
+# neither appears here.
+agroal_active_count{datasource="h2"} 0.0
+agroal_max_used_count{datasource="h2"} 20.0
+rest_requests_seconds_count{method="(unspecified)",path="(unspecified)",status_code_group="5xx"} 0.0
+rest_requests_seconds_count{method="(unspecified)",path="(unspecified)",status_code_group="401"} 0.0
+rest_requests_seconds_count{method="(unspecified)",path="(unspecified)",status_code_group="2xx"} 0.0
+rest_requests_seconds_count{method="(unspecified)",path="(unspecified)",status_code_group="1xx"} 0.0
+rest_requests_seconds_count{method="(unspecified)",path="(unspecified)",status_code_group="4xx"} 0.0
+rest_requests_seconds_count{method="(unspecified)",path="(unspecified)",status_code_group="3xx"} 0.0
+rest_requests_seconds_count{method="GET",path="/apis/registry/v3/groups/{groupId}/artifacts/{artifactId}",status_code_group="4xx"} 3.0
+rest_requests_seconds_count{method="GET",path="/apis/registry/v3/groups/{groupId}/artifacts",status_code_group="2xx"} 7.0
+agroal_awaiting_count{datasource="h2"} 0.0
+agroal_available_count{datasource="h2"} 20.0

--- a/operator/docs/modules/ROOT/examples/apicurioregistry3_metrics_cr.yaml
+++ b/operator/docs/modules/ROOT/examples/apicurioregistry3_metrics_cr.yaml
@@ -1,0 +1,23 @@
+apiVersion: registry.apicur.io/v1
+kind: ApicurioRegistry3
+metadata:
+  name: registry-with-metrics
+spec:
+  app:
+    ingress:
+      host: registry.apps.cluster.example
+    # Operator-side metrics collection
+    metrics:
+      # Disabled by default. When enabled, the Operator scrapes each application Pod.
+      enabled: true
+      # How often to collect. Values below 10 are raised to 10.
+      scrapeIntervalSeconds: 60
+      # Warn when 80% of the database connection pool is in use.
+      connectionPoolUtilizationThreshold: 0.8
+      # Warn when 10% of REST API requests are answered with a 5xx status.
+      errorRateThreshold: 0.1
+      # Warn when the KafkaSQL consumer falls this many records behind.
+      kafkaConsumerLagThreshold: 1000
+  ui:
+    ingress:
+      host: registry-ui.apps.cluster.example

--- a/operator/docs/modules/ROOT/examples/apicurioregistry3_metrics_cr.yaml
+++ b/operator/docs/modules/ROOT/examples/apicurioregistry3_metrics_cr.yaml
@@ -10,7 +10,7 @@ spec:
     metrics:
       # Disabled by default. When enabled, the Operator scrapes each application Pod.
       enabled: true
-      # How often to collect. Values below 10 are raised to 10.
+      # How often to collect. Minimum 10.
       scrapeIntervalSeconds: 60
       # Warn when 80% of the database connection pool is in use.
       connectionPoolUtilizationThreshold: 0.8

--- a/operator/docs/modules/ROOT/pages/assembly-registry-maintenance.adoc
+++ b/operator/docs/modules/ROOT/pages/assembly-registry-maintenance.adoc
@@ -22,6 +22,7 @@ This chapter explains how to configure and manage your {registry} deployment:
 //include::partial$ref-liveness-and-readiness.adoc[leveloffset=+1]
 include::partial$ref-registry-pod-template-spec.adoc[leveloffset=+1]
 include::partial$proc-registry-observability-otel.adoc[leveloffset=+1]
+include::partial$proc-registry-operator-metrics.adoc[leveloffset=+1]
 //include::partial$proc-registry-https-in-cluster.adoc[leveloffset=+1]
 //include::partial$proc-registry-https-outside-cluster.adoc[leveloffset=+1]
 //include::partial$proc-registry-sql-backup.adoc[leveloffset=+1]

--- a/operator/docs/modules/ROOT/partials/proc-registry-operator-metrics.adoc
+++ b/operator/docs/modules/ROOT/partials/proc-registry-operator-metrics.adoc
@@ -54,7 +54,7 @@ kubectl describe apicurioregistry3 registry-with-metrics
 | `spec.app.metrics.scrapeIntervalSeconds`
 | integer
 | `60`
-| How often the {operator} collects metrics, in seconds. Values below 10 are raised to 10.
+| How often the {operator} collects metrics, in seconds. Minimum 10; the CRD rejects anything lower.
 
 | `spec.app.metrics.connectionPoolUtilizationThreshold`
 | number
@@ -91,7 +91,9 @@ The {operator} contacts each {registry} application Pod on its management interf
 | Share of the requests in that interval that were answered with a 5xx status.
 
 | `status.metrics.summary.connectionPoolUtilization`
-| In-use database connections as a fraction of the current pool, averaged across Pods.
+| In-use database connections as a fraction of the current pool, on whichever Pod is using the most of
+its pool. Reported as the highest rather than the average so that one exhausted replica is not hidden
+behind idle ones.
 
 | `status.metrics.summary.artifactCount`
 | Number of artifacts in storage. Every replica counts the same shared storage, so this is the highest value seen rather than a sum.
@@ -102,12 +104,21 @@ The {operator} contacts each {registry} application Pod on its management interf
 | `status.metrics.summary.kafkaConsumerLag`
 | Highest consumer lag reported by any Pod. Present only with KafkaSQL storage.
 
+| `status.metrics.summary.scrapedPods`
+| How many application Pods the values above were read from. At most 10 Pods are read per collection, so on a larger deployment, or when a Pod cannot be reached, the totals cover only the Pods that answered.
+
 | `status.metrics.lastCollected`
-| The last time the reported summary changed. It deliberately does not move on every collection, because rewriting the resource when nothing has changed would trigger another reconciliation.
+| The time of the last successful collection. A failed collection does not move it, so a timestamp that has stopped advancing means the Operator can no longer read the Pods, and the `MetricsUnavailable` condition says why.
 |===
 
 A field is omitted when the underlying metric is not exposed, rather than reported as zero.
 Rates need two collections, so they appear one interval after the feature is enabled.
+
+`artifactCount` and `artifactVersionCount` come from gauges that {registry} does not publish by default,
+because each refresh of them costs an aggregate count over the whole dataset, which is not cheap on a large
+registry. To have the Operator report them, set `apicurio.metrics.storage-usage.enabled` to `true` on the
+{registry} deployment, for example through `spec.app.env`. Until then the two fields are simply absent, and
+the rest of the summary is unaffected.
 
 .Emitted Events
 Events are of type `Warning` and repeat at most once every 10 minutes while the breach continues.
@@ -117,7 +128,7 @@ Events are of type `Warning` and repeat at most once every 10 minutes while the 
 | Reason | Meaning
 
 | `ConnectionPoolSaturated`
-| Database connection pool use reached `connectionPoolUtilizationThreshold`.
+| Database connection pool use on at least one Pod reached `connectionPoolUtilizationThreshold`.
 
 | `HighErrorRate`
 | The share of 5xx responses reached `errorRateThreshold`.

--- a/operator/docs/modules/ROOT/partials/proc-registry-operator-metrics.adoc
+++ b/operator/docs/modules/ROOT/partials/proc-registry-operator-metrics.adoc
@@ -1,0 +1,140 @@
+[#registry-operator-metrics]
+= Reporting {registry} metrics in the custom resource
+
+[role="_abstract"]
+You can configure the {operator} to read the {registry} metrics endpoint and report a summary in the `status` section of the `ApicurioRegistry3` custom resource.
+This gives cluster administrators a view of request rate, error rate, database connection pool use, stored artifact counts and KafkaSQL consumer lag through `kubectl` alone, without installing a separate monitoring stack.
+
+The {operator} also emits {platform} Events when a value crosses a threshold, so that `kubectl describe` surfaces problems next to the rest of the deployment history.
+
+This feature is disabled by default.
+
+.Prerequisites
+* You have already installed {registry} using the {operator}.
+
+.Procedure
+. Configure the `ApicurioRegistry3` CR with the `spec.app.metrics` section:
++
+[source,yaml]
+----
+include::ROOT:example$apicurioregistry3_metrics_cr.yaml[]
+----
+
+. Apply the CR to your cluster:
++
+[source,shell]
+----
+kubectl apply -f apicurioregistry3_metrics_cr.yaml
+----
+
+. Read the reported values:
++
+[source,shell]
+----
+kubectl get apicurioregistry3 registry-with-metrics -o jsonpath='{.status.metrics}'
+----
+
+. Read any Events that were emitted for this deployment:
++
+[source,shell]
+----
+kubectl describe apicurioregistry3 registry-with-metrics
+----
+
+.Metrics configuration options
+[%header,cols="3,2,2,4"]
+|===
+| Configuration option | Type | Default | Description
+
+| `spec.app.metrics.enabled`
+| boolean
+| `false`
+| Enable operator-side collection of {registry} metrics.
+
+| `spec.app.metrics.scrapeIntervalSeconds`
+| integer
+| `60`
+| How often the {operator} collects metrics, in seconds. Values below 10 are raised to 10.
+
+| `spec.app.metrics.connectionPoolUtilizationThreshold`
+| number
+| `0.8`
+| Emit a `ConnectionPoolSaturated` Event when the fraction of in-use database connections reaches this value.
+
+| `spec.app.metrics.errorRateThreshold`
+| number
+| `0.1`
+| Emit a `HighErrorRate` Event when the fraction of REST API requests answered with a 5xx status reaches this value.
+
+| `spec.app.metrics.kafkaConsumerLagThreshold`
+| integer
+| `1000`
+| Emit a `KafkaConsumerLagHigh` Event when the KafkaSQL consumer lag reaches this number of records.
+
+| `spec.app.metrics.prometheusRuleEnabled`
+| boolean
+| `false`
+| Generate a `PrometheusRule` carrying the same thresholds, so a cluster running the Prometheus Operator raises the same alerts through its own alerting path. See the note below.
+|===
+
+.Reported values
+The {operator} contacts each {registry} application Pod on its management interface, port 9000, path `/metrics`, and aggregates what it finds.
+
+[%header,cols="3,4"]
+|===
+| Status field | How it is derived
+
+| `status.metrics.summary.requestRate`
+| Change in the REST API request counter since the previous collection, divided by the elapsed time, summed across Pods.
+
+| `status.metrics.summary.errorRate`
+| Share of the requests in that interval that were answered with a 5xx status.
+
+| `status.metrics.summary.connectionPoolUtilization`
+| In-use database connections as a fraction of the current pool, averaged across Pods.
+
+| `status.metrics.summary.artifactCount`
+| Number of artifacts in storage. Every replica counts the same shared storage, so this is the highest value seen rather than a sum.
+
+| `status.metrics.summary.artifactVersionCount`
+| Number of artifact versions in storage, taken the same way.
+
+| `status.metrics.summary.kafkaConsumerLag`
+| Highest consumer lag reported by any Pod. Present only with KafkaSQL storage.
+
+| `status.metrics.lastCollected`
+| The last time the reported summary changed. It deliberately does not move on every collection, because rewriting the resource when nothing has changed would trigger another reconciliation.
+|===
+
+A field is omitted when the underlying metric is not exposed, rather than reported as zero.
+Rates need two collections, so they appear one interval after the feature is enabled.
+
+.Emitted Events
+Events are of type `Warning` and repeat at most once every 10 minutes while the breach continues.
+
+[%header,cols="2,4"]
+|===
+| Reason | Meaning
+
+| `ConnectionPoolSaturated`
+| Database connection pool use reached `connectionPoolUtilizationThreshold`.
+
+| `HighErrorRate`
+| The share of 5xx responses reached `errorRateThreshold`.
+
+| `KafkaConsumerLagHigh`
+| KafkaSQL consumer lag reached `kafkaConsumerLagThreshold`.
+|===
+
+
+.Alerting through the Prometheus Operator
+Setting `spec.app.metrics.prometheusRuleEnabled` makes the {operator} generate a `PrometheusRule` named
+`<cr-name>-app-metrics`, with one alert per threshold, matching the Events above.
+It is only created when the Prometheus Operator CRDs are present on the cluster, and it is removed again when
+the option is turned off.
+
+The rules are evaluated over metrics Prometheus has already collected. Generating them does not arrange that
+collection, so until something scrapes {registry}, for example a `ServiceMonitor`, the rules never fire.
+.Limitations
+* Metrics collection only supports plain HTTP. Configuring `spec.app.tls.keystoreSecretRef` moves the Quarkus management interface to HTTPS, so those deployments are skipped and the CR reports a `MetricsUnavailable` condition explaining why. Setting `insecureRequests` does not change this, it only affects the API port. Collection failures never fail reconciliation and never discard the last known summary.
+* At most 10 Pods are contacted per collection.

--- a/operator/docs/modules/ROOT/partials/ref-registry-cr-spec.adoc
+++ b/operator/docs/modules/ROOT/partials/ref-registry-cr-spec.adoc
@@ -108,6 +108,13 @@ spec:
       endpoint: <string>
       protocol: <string>
       traceSamplingRatio: <double>
+    metrics:
+      enabled: <bool>
+      scrapeIntervalSeconds: <int>
+      prometheusRuleEnabled: <bool>
+      connectionPoolUtilizationThreshold: <double>
+      errorRateThreshold: <double>
+      kafkaConsumerLagThreshold: <int>
     env: <k8s.io/api/core/v1 []EnvVar>
     ingress:
       enabled: <bool>
@@ -238,6 +245,13 @@ spec:
       endpoint: <string>
       protocol: <string>
       traceSamplingRatio: <double>
+    metrics:
+      enabled: <bool>
+      scrapeIntervalSeconds: <int>
+      prometheusRuleEnabled: <bool>
+      connectionPoolUtilizationThreshold: <double>
+      errorRateThreshold: <double>
+      kafkaConsumerLagThreshold: <int>
     env: <k8s.io/api/core/v1 []EnvVar>
     ingress:
       enabled: <bool>
@@ -634,6 +648,41 @@ endif::[]
 | double
 | _empty_
 | Sampling ratio for traces (0.0-1.0). When set, uses `parentbased_traceidratio` sampler.
+
+| `app/metrics`
+| -
+| -
+| Operator-side metrics collection configuration.
+
+| `app/metrics/enabled`
+| bool
+| `false`
+| Enable operator-side collection of {registry} metrics. When enabled, the Operator scrapes the management interface of each application Pod and reports a summary in `status.metrics`.
+
+| `app/metrics/scrapeIntervalSeconds`
+| int
+| `60`
+| How often the Operator collects metrics, in seconds. Values below 10 are raised to 10.
+
+| `app/metrics/prometheusRuleEnabled`
+| bool
+| `false`
+| Generate a PrometheusRule carrying the same thresholds. Requires the Prometheus Operator CRDs, and something already scraping {registry}.
+
+| `app/metrics/connectionPoolUtilizationThreshold`
+| double
+| `0.8`
+| Emit a `ConnectionPoolSaturated` Event when the fraction of in-use database connections reaches this value.
+
+| `app/metrics/errorRateThreshold`
+| double
+| `0.1`
+| Emit a `HighErrorRate` Event when the fraction of REST API requests answered with a 5xx status reaches this value.
+
+| `app/metrics/kafkaConsumerLagThreshold`
+| int
+| `1000`
+| Emit a `KafkaConsumerLagHigh` Event when the KafkaSQL consumer lag reaches this number of records.
 
 | `app/env`
 | k8s.io/api/core/v1 []EnvVar

--- a/operator/docs/modules/ROOT/partials/ref-registry-cr-spec.adoc
+++ b/operator/docs/modules/ROOT/partials/ref-registry-cr-spec.adoc
@@ -662,7 +662,7 @@ endif::[]
 | `app/metrics/scrapeIntervalSeconds`
 | int
 | `60`
-| How often the Operator collects metrics, in seconds. Values below 10 are raised to 10.
+| How often the Operator collects metrics, in seconds. Minimum 10; the CRD rejects anything lower.
 
 | `app/metrics/prometheusRuleEnabled`
 | bool
@@ -672,7 +672,7 @@ endif::[]
 | `app/metrics/connectionPoolUtilizationThreshold`
 | double
 | `0.8`
-| Emit a `ConnectionPoolSaturated` Event when the fraction of in-use database connections reaches this value.
+| Emit a `ConnectionPoolSaturated` Event when the fraction of in-use database connections on any one application Pod reaches this value.
 
 | `app/metrics/errorRateThreshold`
 | double

--- a/operator/docs/modules/ROOT/partials/ref-registry-cr-status.adoc
+++ b/operator/docs/modules/ROOT/partials/ref-registry-cr-status.adoc
@@ -26,6 +26,7 @@ status:
       requestRate: <double>
       errorRate: <double>
       connectionPoolUtilization: <double>
+      scrapedPods: <int>
       artifactCount: <int>
       artifactVersionCount: <int>
       kafkaConsumerLag: <int>
@@ -90,7 +91,7 @@ status:
 
 | `metrics/lastCollected`
 | string
-| The last time the reported summary changed. This is not the time of the last collection attempt.
+| The time of the last successful collection. A failed collection does not move it, so a timestamp that has stopped advancing means the Operator can no longer read the application Pods.
 
 | `metrics/summary/requestRate`
 | double
@@ -102,7 +103,11 @@ status:
 
 | `metrics/summary/connectionPoolUtilization`
 | double
-| Fraction of the database connection pool in use, averaged across all application Pods, between 0.0 and 1.0.
+| Highest fraction of the database connection pool in use on any one application Pod, between 0.0 and 1.0.
+
+| `metrics/summary/scrapedPods`
+| int
+| How many application Pods the reported values were read from. At most 10 Pods are read per collection, so on a larger deployment, or when a Pod cannot be reached, the totals cover only the Pods that answered.
 
 | `metrics/summary/artifactCount`
 | int

--- a/operator/docs/modules/ROOT/partials/ref-registry-cr-status.adoc
+++ b/operator/docs/modules/ROOT/partials/ref-registry-cr-status.adoc
@@ -20,6 +20,15 @@ status:
   - kind: <string>
     namespace: <string>
     name: <string>
+  metrics:
+    lastCollected: <string, RFC-3339 timestamp>
+    summary:
+      requestRate: <double>
+      errorRate: <double>
+      connectionPoolUtilization: <double>
+      artifactCount: <int>
+      artifactVersionCount: <int>
+      kafkaConsumerLag: <int>
 ----
 
 .ApicurioRegistry3 CR status fields
@@ -74,4 +83,36 @@ status:
 | `managedResources/name`
 | string
 | Resource name.
+
+| `metrics`
+| -
+| Metrics collected by the Operator from the {registry} application Pods. Present only when `spec.app.metrics.enabled` is `true`.
+
+| `metrics/lastCollected`
+| string
+| The last time the reported summary changed. This is not the time of the last collection attempt.
+
+| `metrics/summary/requestRate`
+| double
+| REST API requests per second, averaged over the interval between the last two collections, summed across all application Pods.
+
+| `metrics/summary/errorRate`
+| double
+| Fraction of REST API requests answered with a 5xx status, between 0.0 and 1.0.
+
+| `metrics/summary/connectionPoolUtilization`
+| double
+| Fraction of the database connection pool in use, averaged across all application Pods, between 0.0 and 1.0.
+
+| `metrics/summary/artifactCount`
+| int
+| Number of artifacts in storage. Every replica counts the same shared storage, so the highest value seen is reported rather than a sum.
+
+| `metrics/summary/artifactVersionCount`
+| int
+| Number of artifact versions in storage, taken the same way.
+
+| `metrics/summary/kafkaConsumerLag`
+| int
+| Highest KafkaSQL consumer lag, in records, reported by any application Pod. Present only when KafkaSQL storage is used.
 |===

--- a/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/ApicurioRegistry3Status.java
+++ b/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/ApicurioRegistry3Status.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.JsonDeserializer.None;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.apicurio.registry.operator.api.v1.status.Condition;
+import io.apicurio.registry.operator.api.v1.status.MetricsStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -18,13 +19,14 @@ import lombok.ToString;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static com.fasterxml.jackson.annotation.Nulls.SKIP;
 import static lombok.AccessLevel.PRIVATE;
 
 @JsonInclude(NON_NULL)
-@JsonPropertyOrder({"conditions"})
+@JsonPropertyOrder({"conditions", "metrics"})
 @JsonDeserialize(using = None.class)
 @NoArgsConstructor
 @AllArgsConstructor(access = PRIVATE)
@@ -54,6 +56,15 @@ public class ApicurioRegistry3Status {
     private List<Condition> conditions = new ArrayList<>();
 
     /**
+     * Metrics collected by the operator from the Apicurio Registry application Pods.
+     */
+    @JsonProperty("metrics")
+    @JsonPropertyDescription("""
+            Metrics collected by the operator from the Apicurio Registry application Pods.""")
+    @JsonSetter(nulls = SKIP)
+    private MetricsStatus metrics;
+
+    /**
      * Check that the statuses are semantically equivalent (i.e. ignoring observedGeneration, condition order, timestamps, etc.).
      */
     public static boolean isEquivalent(ApicurioRegistry3Status left, ApicurioRegistry3Status right) {
@@ -81,6 +92,6 @@ public class ApicurioRegistry3Status {
                 return false;
             }
         }
-        return true;
+        return Objects.equals(left.metrics, right.metrics);
     }
 }

--- a/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/spec/AppSpec.java
+++ b/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/spec/AppSpec.java
@@ -85,6 +85,18 @@ public class AppSpec extends ComponentSpec {
     private OTelSpec otel;
 
     /**
+     * Configure operator-side collection of Apicurio Registry metrics.
+     */
+    @JsonProperty("metrics")
+    @JsonPropertyDescription("""
+            Configure operator-side collection of Apicurio Registry metrics.
+            When enabled, the operator scrapes the management interface of each application Pod and reports
+            a summary in `status.metrics`.
+            """)
+    @JsonSetter(nulls = SKIP)
+    private MetricsSpec metrics;
+
+    /**
      * Configure Elasticsearch-based search indexing for Apicurio Registry.
      */
     @JsonProperty("searchIndex")

--- a/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/spec/MetricsSpec.java
+++ b/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/spec/MetricsSpec.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.generator.annotation.Max;
+import io.fabric8.generator.annotation.Min;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -49,23 +51,26 @@ public class MetricsSpec {
     private Boolean enabled;
 
     /**
-     * How often the operator collects metrics, in seconds. Default is 60.
+     * How often the operator collects metrics, in seconds. Minimum 10, default 60.
      */
     @JsonProperty("scrapeIntervalSeconds")
     @JsonPropertyDescription("""
-            How often the operator collects metrics, in seconds. Default is 60.""")
+            How often the operator collects metrics, in seconds. Minimum 10, default 60.""")
     @JsonSetter(nulls = Nulls.SKIP)
+    @Min(10)
     private Integer scrapeIntervalSeconds;
 
     /**
-     * Emit a Kubernetes Event when the fraction of in-use database connections reaches this value.
-     * Value between 0.0 and 1.0. Default is 0.8.
+     * Emit a Kubernetes Event when the fraction of in-use database connections on any one application Pod
+     * reaches this value. Value between 0.0 and 1.0. Default is 0.8.
      */
     @JsonProperty("connectionPoolUtilizationThreshold")
     @JsonPropertyDescription("""
-            Emit a Kubernetes Event when the fraction of in-use database connections reaches this value.
-            Value between 0.0 and 1.0. Default is 0.8.""")
+            Emit a Kubernetes Event when the fraction of in-use database connections on any one application
+            Pod reaches this value. Value between 0.0 and 1.0. Default is 0.8.""")
     @JsonSetter(nulls = Nulls.SKIP)
+    @Min(0)
+    @Max(1)
     private Double connectionPoolUtilizationThreshold;
 
     /**
@@ -77,6 +82,8 @@ public class MetricsSpec {
             Emit a Kubernetes Event when the fraction of REST API requests answered with a 5xx status
             reaches this value. Value between 0.0 and 1.0. Default is 0.1.""")
     @JsonSetter(nulls = Nulls.SKIP)
+    @Min(0)
+    @Max(1)
     private Double errorRateThreshold;
 
     /**
@@ -88,6 +95,7 @@ public class MetricsSpec {
             Emit a Kubernetes Event when the KafkaSQL consumer lag reaches this number of records.
             Only applies when KafkaSQL storage is used. Default is 1000.""")
     @JsonSetter(nulls = Nulls.SKIP)
+    @Min(0)
     private Long kafkaConsumerLagThreshold;
 
     /**

--- a/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/spec/MetricsSpec.java
+++ b/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/spec/MetricsSpec.java
@@ -1,0 +1,104 @@
+package io.apicurio.registry.operator.api.v1.spec;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static lombok.AccessLevel.PRIVATE;
+
+/**
+ * Configuration for operator-side collection of Apicurio Registry metrics.
+ */
+@JsonDeserialize(using = JsonDeserializer.None.class)
+@JsonInclude(NON_NULL)
+@JsonPropertyOrder({"enabled", "scrapeIntervalSeconds", "prometheusRuleEnabled", "connectionPoolUtilizationThreshold",
+        "errorRateThreshold", "kafkaConsumerLagThreshold"})
+@NoArgsConstructor
+@AllArgsConstructor(access = PRIVATE)
+@SuperBuilder(toBuilder = true)
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+public class MetricsSpec {
+
+    /**
+     * Enable operator-side collection of Apicurio Registry metrics.
+     * When enabled, the operator periodically scrapes the management interface of each application Pod
+     * and reports a summary in `status.metrics`. Default is false.
+     */
+    @JsonProperty("enabled")
+    @JsonPropertyDescription("""
+            Enable operator-side collection of Apicurio Registry metrics.
+            When enabled, the operator periodically scrapes the management interface of each application Pod
+            and reports a summary in `status.metrics`. Default is false.""")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Boolean enabled;
+
+    /**
+     * How often the operator collects metrics, in seconds. Default is 60.
+     */
+    @JsonProperty("scrapeIntervalSeconds")
+    @JsonPropertyDescription("""
+            How often the operator collects metrics, in seconds. Default is 60.""")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Integer scrapeIntervalSeconds;
+
+    /**
+     * Emit a Kubernetes Event when the fraction of in-use database connections reaches this value.
+     * Value between 0.0 and 1.0. Default is 0.8.
+     */
+    @JsonProperty("connectionPoolUtilizationThreshold")
+    @JsonPropertyDescription("""
+            Emit a Kubernetes Event when the fraction of in-use database connections reaches this value.
+            Value between 0.0 and 1.0. Default is 0.8.""")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Double connectionPoolUtilizationThreshold;
+
+    /**
+     * Emit a Kubernetes Event when the fraction of REST API requests answered with a 5xx status
+     * reaches this value. Value between 0.0 and 1.0. Default is 0.1.
+     */
+    @JsonProperty("errorRateThreshold")
+    @JsonPropertyDescription("""
+            Emit a Kubernetes Event when the fraction of REST API requests answered with a 5xx status
+            reaches this value. Value between 0.0 and 1.0. Default is 0.1.""")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Double errorRateThreshold;
+
+    /**
+     * Emit a Kubernetes Event when the KafkaSQL consumer lag reaches this number of records.
+     * Only applies when KafkaSQL storage is used. Default is 1000.
+     */
+    @JsonProperty("kafkaConsumerLagThreshold")
+    @JsonPropertyDescription("""
+            Emit a Kubernetes Event when the KafkaSQL consumer lag reaches this number of records.
+            Only applies when KafkaSQL storage is used. Default is 1000.""")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Long kafkaConsumerLagThreshold;
+
+    /**
+     * Generate a PrometheusRule carrying the same thresholds, for clusters running the Prometheus Operator.
+     */
+    @JsonProperty("prometheusRuleEnabled")
+    @JsonPropertyDescription("""
+            Generate a PrometheusRule carrying the same thresholds, so that a cluster running the Prometheus
+            Operator raises the same alerts through its own alerting path. Requires the Prometheus Operator
+            CRDs, and something already scraping Apicurio Registry. Default is false.""")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Boolean prometheusRuleEnabled;
+
+}

--- a/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/status/ConditionConstants.java
+++ b/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/status/ConditionConstants.java
@@ -5,6 +5,7 @@ public final class ConditionConstants {
     public static final String TYPE_OPERATOR_ERROR = "OperatorError";
     public static final String TYPE_VALIDATION_ERROR = "ValidationError";
     public static final String TYPE_READY = "Ready";
+    public static final String TYPE_METRICS_UNAVAILABLE = "MetricsUnavailable";
 
     private ConditionConstants() {
     }

--- a/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/status/MetricsStatus.java
+++ b/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/status/MetricsStatus.java
@@ -1,0 +1,67 @@
+package io.apicurio.registry.operator.api.v1.status;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.JsonDeserializer.None;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.crd.generator.annotation.SchemaFrom;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.time.Instant;
+
+import static lombok.AccessLevel.PRIVATE;
+
+/**
+ * Metrics collected by the operator from the Apicurio Registry application Pods.
+ * <p>
+ * Present only when `spec.app.metrics.enabled` is true.
+ */
+@JsonInclude(Include.NON_NULL)
+@JsonPropertyOrder({"lastCollected", "summary"})
+@JsonDeserialize(using = None.class)
+@NoArgsConstructor
+@AllArgsConstructor(access = PRIVATE)
+@SuperBuilder(toBuilder = true)
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+public class MetricsStatus {
+
+    /**
+     * The last time the reported summary changed.
+     * <p>
+     * This is deliberately not the time of the last collection attempt. Refreshing it on every attempt
+     * would rewrite the resource on every reconciliation, which would in turn trigger another
+     * reconciliation.
+     */
+    @JsonProperty("lastCollected")
+    @JsonPropertyDescription("""
+            The last time the reported summary changed. This is not the time of the last collection attempt.""")
+    @JsonSetter(nulls = Nulls.SKIP)
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+    @SchemaFrom(type = String.class)
+    private Instant lastCollected;
+
+    /**
+     * Aggregated metric values across all application Pods.
+     */
+    @JsonProperty("summary")
+    @JsonPropertyDescription("""
+            Aggregated metric values across all application Pods.""")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private MetricsSummary summary;
+
+}

--- a/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/status/MetricsStatus.java
+++ b/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/status/MetricsStatus.java
@@ -41,15 +41,15 @@ import static lombok.AccessLevel.PRIVATE;
 public class MetricsStatus {
 
     /**
-     * The last time the reported summary changed.
+     * The time of the last successful collection.
      * <p>
-     * This is deliberately not the time of the last collection attempt. Refreshing it on every attempt
-     * would rewrite the resource on every reconciliation, which would in turn trigger another
-     * reconciliation.
+     * A failed collection does not move this, so a timestamp that has stopped advancing means the operator
+     * can no longer read the operand. The accompanying MetricsUnavailable condition says why.
      */
     @JsonProperty("lastCollected")
     @JsonPropertyDescription("""
-            The last time the reported summary changed. This is not the time of the last collection attempt.""")
+            The time of the last successful collection. A failed collection does not move it, so a timestamp
+            that has stopped advancing means the operator can no longer read the application Pods.""")
     @JsonSetter(nulls = Nulls.SKIP)
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
     @SchemaFrom(type = String.class)

--- a/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/status/MetricsSummary.java
+++ b/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/status/MetricsSummary.java
@@ -1,0 +1,103 @@
+package io.apicurio.registry.operator.api.v1.status;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.JsonDeserializer.None;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import static lombok.AccessLevel.PRIVATE;
+
+/**
+ * Aggregated values collected from the management interface of the Apicurio Registry application Pods.
+ * <p>
+ * Every field is optional. A field is absent when the underlying metric is not exposed by the operand,
+ * which is preferable to reporting a misleading zero.
+ */
+@JsonInclude(Include.NON_NULL)
+@JsonPropertyOrder({"requestRate", "errorRate", "connectionPoolUtilization", "artifactCount",
+        "artifactVersionCount", "kafkaConsumerLag"})
+@JsonDeserialize(using = None.class)
+@NoArgsConstructor
+@AllArgsConstructor(access = PRIVATE)
+@SuperBuilder(toBuilder = true)
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+public class MetricsSummary {
+
+    /**
+     * REST API requests per second, averaged over the interval between the last two collections,
+     * summed across all application Pods.
+     */
+    @JsonProperty("requestRate")
+    @JsonPropertyDescription("""
+            REST API requests per second, averaged over the interval between the last two collections,
+            summed across all application Pods.""")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Double requestRate;
+
+    /**
+     * Fraction of REST API requests answered with a 5xx status, over the interval between the last two
+     * collections. Value between 0.0 and 1.0.
+     */
+    @JsonProperty("errorRate")
+    @JsonPropertyDescription("""
+            Fraction of REST API requests answered with a 5xx status, over the interval between the last two
+            collections. Value between 0.0 and 1.0.""")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Double errorRate;
+
+    /**
+     * Fraction of the database connection pool that is currently in use, averaged across all application
+     * Pods. Value between 0.0 and 1.0.
+     */
+    @JsonProperty("connectionPoolUtilization")
+    @JsonPropertyDescription("""
+            Fraction of the database connection pool that is currently in use, averaged across all application
+            Pods. Value between 0.0 and 1.0.""")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Double connectionPoolUtilization;
+
+    /**
+     * Number of artifacts currently held in storage.
+     */
+    @JsonProperty("artifactCount")
+    @JsonPropertyDescription("""
+            Number of artifacts currently held in storage.""")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Long artifactCount;
+
+    /**
+     * Number of artifact versions currently held in storage.
+     */
+    @JsonProperty("artifactVersionCount")
+    @JsonPropertyDescription("""
+            Number of artifact versions currently held in storage.""")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Long artifactVersionCount;
+
+    /**
+     * Highest KafkaSQL consumer lag, in records, reported by any application Pod.
+     * Only present when KafkaSQL storage is used.
+     */
+    @JsonProperty("kafkaConsumerLag")
+    @JsonPropertyDescription("""
+            Highest KafkaSQL consumer lag, in records, reported by any application Pod.
+            Only present when KafkaSQL storage is used.""")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Long kafkaConsumerLag;
+
+}

--- a/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/status/MetricsSummary.java
+++ b/operator/model/src/main/java/io/apicurio/registry/operator/api/v1/status/MetricsSummary.java
@@ -27,7 +27,7 @@ import static lombok.AccessLevel.PRIVATE;
  */
 @JsonInclude(Include.NON_NULL)
 @JsonPropertyOrder({"requestRate", "errorRate", "connectionPoolUtilization", "artifactCount",
-        "artifactVersionCount", "kafkaConsumerLag"})
+        "artifactVersionCount", "kafkaConsumerLag", "scrapedPods"})
 @JsonDeserialize(using = None.class)
 @NoArgsConstructor
 @AllArgsConstructor(access = PRIVATE)
@@ -61,13 +61,15 @@ public class MetricsSummary {
     private Double errorRate;
 
     /**
-     * Fraction of the database connection pool that is currently in use, averaged across all application
-     * Pods. Value between 0.0 and 1.0.
+     * Highest fraction of the database connection pool in use on any one application Pod. Reported as the
+     * highest rather than the average, because a replica whose pool is exhausted is already queueing or
+     * failing requests, and averaging would hide it behind idle replicas. Value between 0.0 and 1.0.
      */
     @JsonProperty("connectionPoolUtilization")
     @JsonPropertyDescription("""
-            Fraction of the database connection pool that is currently in use, averaged across all application
-            Pods. Value between 0.0 and 1.0.""")
+            Highest fraction of the database connection pool in use on any one application Pod. Reported as
+            the highest rather than the average, so that an exhausted replica is not hidden by idle ones.
+            Value between 0.0 and 1.0.""")
     @JsonSetter(nulls = Nulls.SKIP)
     private Double connectionPoolUtilization;
 
@@ -99,5 +101,21 @@ public class MetricsSummary {
             Only present when KafkaSQL storage is used.""")
     @JsonSetter(nulls = Nulls.SKIP)
     private Long kafkaConsumerLag;
+
+    /**
+     * How many application Pods these values were read from.
+     * <p>
+     * The operator reads at most 10 Pods per collection, so that one custom resource cannot turn a single
+     * reconciliation into an unbounded number of requests. Above that, and whenever a Pod cannot be reached,
+     * the totals here cover only the Pods that answered. This field says how many that was, so that
+     * `requestRate` is not read as the whole deployment when it is not.
+     */
+    @JsonProperty("scrapedPods")
+    @JsonPropertyDescription("""
+            How many application Pods these values were read from. The operator reads at most 10 Pods per
+            collection, so on a larger deployment, or when a Pod cannot be reached, the totals cover only
+            the Pods that answered.""")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Integer scrapedPods;
 
 }

--- a/operator/olm-tests/src/test/deploy/olmv1/cluster-role.yaml
+++ b/operator/olm-tests/src/test/deploy/olmv1/cluster-role.yaml
@@ -228,3 +228,16 @@ rules:
 # [1] We can't easily limit the permissions only to resources that are used to deploy the operator.
 #     OLM v1 adds hash-like suffixes to the resource names, but Kubernetes [does not support wildcards yet](https://github.com/kubernetes/kubernetes/issues/56582).
 #     We could try to figure out the hashes ahead of time, but it's complex and error-prone.
+
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch


### PR DESCRIPTION
Closes #8084
Part of #8078

## Summary

Adds an opt-in `spec.app.metrics` block. When enabled, the operator reads the Prometheus endpoint on each application Pod's management interface and reports request rate, error rate, connection pool use, stored artifact and version counts, KafkaSQL consumer lag, and how many Pods the values were read from, under `status.metrics`. A Warning Event is emitted when a value crosses a threshold, and a `PrometheusRule` carrying the same thresholds can optionally be generated. Everything is off by default, so existing deployments are unaffected.

**Scope note.** This also touches the app module, so `area/storage` and `area/observability` alongside `area/operator`. Two of the values the issue asks for were not on the Prometheus endpoint at all, and the operator cannot report what Registry does not publish. Artifact and version counts existed only as OpenTelemetry gauges, and KafkaSQL binds no Kafka client metrics, so a KafkaSQL deployment exposed no `kafka_*` series. Both were confirmed against a running registry. The additions are one `KafkaClientMetrics` binding and two gauges over counters `StorageMetricsStore` already caches. The gauges are off by default, because every storage limit defaults to disabled and returns before touching those counters: nothing loads them on a default deployment today, so registering the gauges would add an aggregate count over the whole dataset on every cache expiry rather than share an existing one. Set `apicurio.metrics.storage-usage.enabled=true` to have the artifact counts reported. Happy to split the app module changes into a separate PR if you would prefer to review them independently.

**New RBAC.** PrometheusRule generation needs `monitoring.coreos.com/prometheusrules`, added to the namespaced Role, the cluster Role and the OLM installer role.

**Decisions taken where the issue left it open.**

1. Off by default, so nothing changes for existing deployments.
2. Pods are read on their Pod IP. The Service publishes only the API ports, not the management port, so the metrics endpoint is not reachable through it.
3. `lastCollected` is the time of the last successful collection, not of the last change in the numbers. An idle registry reports the same values every interval, so tracking changes would leave the field frozen and give no way to tell a quiet deployment from one the operator had stopped collecting from.
4. Field names are as they appear in the CRD, and the thresholds are bounded there. Easy to change now, not after a release.

**Correction to the issue.** It specifies `/q/metrics` on 8080. The endpoint is `/metrics` on the management port, 9000, confirmed against a running registry.

**Not included.** Instances with TLS configured are skipped, because a keystore moves the Quarkus management interface to HTTPS. Supporting it means trusting the truststore the CR already references, which is worth its own change. The generated PrometheusRule is also inert until a ServiceMonitor exists (#8080), since its rules evaluate over metrics Prometheus has already scraped.

**Testing.** Two integration tests carry `@DisabledIf(ITBase#isLocalDeployment)`, because collection reads Pods over the cluster network and only works with a deployed operator. As CI is configured today it runs the operator suite with `deployment-type=local`, so those two never execute there; say the word if you would rather they did. The rest of the suite, including an integration test that posts a breach Event to the API server, runs in both modes.

**Third commit** is self-review follow-up, and changes reported numbers. Request counters are kept per Pod, because deriving rates from two sums guarded only on the Pod count meant a scrape that lost one Pod and gained another compared different populations and reported the gap as traffic. Connection pool utilization reports the highest value across Pods rather than the mean, so a saturated replica is not hidden by idle ones, which also matches how the generated PrometheusRule evaluates it.

## Checklist

- [x] Linked issue has maintainer approval
- [x] No overlapping open PRs for the same issue
- [x] Checked the [Tried & Rejected list](https://github.com/Apicurio/apicurio-registry/discussions/8364)
- [x] Tests added for new code paths
- [x] Tested locally: `./mvnw -pl controller -am -DskipOperatorTests=false verify` against a kind cluster
- [x] `./mvnw checkstyle:check -pl <module>` passes
- [x] All commits have DCO sign-off (`git commit -s`)
