### PR TITLE
feat: add re-augmentable (mutable-jar) container image variant for custom artifact type Java providers

### DIFF
--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -32,3 +32,20 @@ jobs:
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: 'trivy-results.sarif'
+
+      # The mutable variant additionally ships the Quarkus deployment jars (lib/deployment)
+      - name: Run Trivy vulnerability scanner (mutable image)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: quay.io/apicurio/apicurio-registry:latest-snapshot-mutable
+          format: 'sarif'
+          output: 'trivy-results-mutable.sarif'
+          severity: 'CRITICAL,HIGH'
+          vuln-type: 'os,library'
+          ignore-unfixed: true
+
+      - name: Upload Trivy scan results to GitHub Security tab (mutable image)
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: 'trivy-results-mutable.sarif'
+          category: 'trivy-mutable-image'

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -189,6 +189,21 @@ jobs:
               $TAGS \
               --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le ./distro/docker/target/docker
 
+      - name: Build and Push Multi-arch Application Images (mutable)
+        run: |
+          cd registry
+          TAGS="-t docker.io/apicurio/apicurio-registry:$RELEASE_VERSION-mutable"
+          TAGS="$TAGS -t docker.io/apicurio/apicurio-registry:$MINOR_TAG-mutable"
+          TAGS="$TAGS -t quay.io/apicurio/apicurio-registry:$RELEASE_VERSION-mutable"
+          TAGS="$TAGS -t quay.io/apicurio/apicurio-registry:$MINOR_TAG-mutable"
+          if [ "$IS_LATEST_RELEASE" = "true" ]; then
+            TAGS="$TAGS -t docker.io/apicurio/apicurio-registry:latest-mutable"
+            TAGS="$TAGS -t quay.io/apicurio/apicurio-registry:latest-mutable"
+          fi
+          docker buildx build --push -f ./distro/docker/target/docker/Dockerfile.mutable.jvm \
+              $TAGS \
+              --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le ./distro/docker/target/docker
+
       - name: Build and Push Multi-arch Console Plugin Images
         working-directory: registry/console-plugin
         run: |

--- a/.github/workflows/verify-publish.yaml
+++ b/.github/workflows/verify-publish.yaml
@@ -39,6 +39,23 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
+  publish-app-mutable-image:
+    name: Publish App Docker Image (mutable)
+    uses: ./.github/workflows/reusable-docker-build.yaml
+    with:
+      image-name: 'apicurio/apicurio-registry'
+      dockerfile: './distro/docker/target/docker/Dockerfile.mutable.jvm'
+      context: './distro/docker/target/docker'
+      tag: 'latest-snapshot-mutable'
+      maven-build: false
+      download-artifact: 'build-artifacts-${{ inputs.image-tag }}'
+      platforms: 'linux/amd64,linux/arm64'
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+
   publish-mcp-image:
     name: Publish MCP Server Docker Image
     uses: ./.github/workflows/reusable-docker-build.yaml

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -132,6 +132,16 @@ jobs:
             -t apicurio/apicurio-registry:${{ github.sha }} \
             ./distro/docker/target/docker
 
+      - name: Build Mutable Docker Image
+        run: |
+          docker build -f ./distro/docker/target/docker/Dockerfile.mutable.jvm \
+            -t apicurio/apicurio-registry:${{ github.sha }}-mutable \
+            ./distro/docker/target/docker
+
+      - name: Smoke Test Re-augmentation of the Mutable Docker Image
+        run: |
+          docker run --rm apicurio/apicurio-registry:${{ github.sha }}-mutable /deployments/build.sh --prune
+
       - name: Save Docker Image
         uses: apicurio/apicurio-github-actions/save-docker-image@ecae58cc1a9b5eeb810b90f8a9e15d2266a371d3 # v2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,22 +151,19 @@ locally is not required.
 
 ### Customizing Registry supported ArtifactTypes
 
-Apicurio Registry is a modular project and allows reuse of artifact types to extend and enhance functionality.
+The artifact types supported by a registry instance can be configured at deployment time, without
+changing the registry code, through a JSON file referenced by `apicurio.artifact-types.config-file`.
+Each custom type delegates its behaviour (content detection, validation, compatibility checking,
+canonicalization, ...) either to **webhooks** or to **Java classes** implementing the interfaces of
+`apicurio-registry-schema-util-common` (`ContentAccepter`, `ContentValidator`, `CompatibilityChecker`, ...).
 
-You can modify the currently supported artifact types and add new types by providing a higher priority implementation of `io.apicurio.registry.types.<my-type>.provider.ArtifactTypeUtilProviderImpl` to the dependency injection framework.
+Java providers are added to the container image by deriving from the `apicurio/apicurio-registry:VERSION-mutable`
+image (a re-augmentable Quarkus mutable-jar, produced with `-Dfull`), copying the jar into
+`/deployments/quarkus-app/providers/` and running `/deployments/build.sh`. See the
+["Configuring custom artifact types"](docs/modules/ROOT/pages/getting-started/assembly-custom-artifact-types.adoc)
+documentation and the [custom-artifact-types example](examples/custom-artifact-types/) for a complete walkthrough.
 
-In [this GitHub repository](https://github.com/andreaTP/apicurio-registry-with-bigquery-example), you can find an example where we add demo `BigQuery` support.
-
-The important parts are as follows:
-
- - Use [Apicurio Registry as a dependency](https://github.com/andreaTP/apicurio-registry-with-bigquery-example/blob/66c5d18d9c0b5e246597b79e5c5b82a54752a65d/pom.xml#L45-L49)
- - Provide a [higher priority `ArtifactTypeUtilProviderImpl`](https://github.com/andreaTP/apicurio-registry-with-bigquery-example/blob/66c5d18d9c0b5e246597b79e5c5b82a54752a65d/src/main/java/io/apicurio/registry/types/bigquery/provider/ArtifactTypeUtilProviderImpl.java#L30-L33)
- - [Update the provider list](https://github.com/andreaTP/apicurio-registry-with-bigquery-example/blob/66c5d18d9c0b5e246597b79e5c5b82a54752a65d/src/main/java/io/apicurio/registry/types/bigquery/provider/ArtifactTypeUtilProviderImpl.java#L48) in the constructor to include the additional artifact type
-
-**NOTES:**
-
-- When creating an artifact of a type that is not included in the default, you must _always_ specify the appropriate artifact type.
-- The registry UI will show the plain name of the additional type and won't have an appropriate icon to identify it.
+**NOTE:** The registry UI shows the plain name of a custom type and has no dedicated icon for it.
 
 ## Versioning & Release Cycle
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -147,7 +147,7 @@ modes, and detailed usage instructions.
 
 Run Apicurio Registry with Postgres:
 
- - Compile using `mvn clean install -DskipTests -Pprod -Ddocker`
+ - Compile using `mvn clean install -DskipTests -Pprod` (see `distro/docker/README.md` for building the image)
 
  - Then create a docker-compose file `test.yml`:
 ```yaml

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -564,6 +564,27 @@
               <goal>build</goal>
             </goals>
           </execution>
+          <!-- Second build producing a Quarkus "mutable-jar" (re-augmentable) distribution in
+               target/mutable/quarkus-app. It is the basis of the "-mutable" container image, which
+               lets deployers add Java providers for custom artifact types (jars dropped into
+               quarkus-app/providers) without rebuilding the registry. Enabled by -Dfull.
+               NOTE: do not set quarkus.package.output-directory here - plugin properties are recorded
+               in quarkus/build-system.properties and replayed at re-augmentation time. -->
+          <execution>
+            <id>build-mutable</id>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <skip>${apicurio.mutable-jar.skip}</skip>
+              <bootstrapId>mutable</bootstrapId>
+              <buildDir>${project.build.directory}/mutable</buildDir>
+              <properties>
+                <quarkus.package.jar.type>mutable-jar</quarkus.package.jar.type>
+                <quarkus.package.jar.user-providers-directory>providers</quarkus.package.jar.user-providers-directory>
+              </properties>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -619,6 +640,26 @@
               <attach>true</attach>
               <descriptors>
                 <descriptor>src/main/assembly/assembly.xml</descriptor>
+              </descriptors>
+              <archiverConfig>
+                <defaultDirectoryMode>0755</defaultDirectoryMode>
+              </archiverConfig>
+              <tarLongFileMode>${tar.long.file.mode}</tarLongFileMode>
+            </configuration>
+          </execution>
+          <!-- Tarball of the mutable-jar distribution (see build-mutable above); not attached/deployed -->
+          <execution>
+            <id>assembly-mutable</id>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <skipAssembly>${apicurio.mutable-jar.skip}</skipAssembly>
+              <finalName>${project.artifactId}-${project.version}</finalName>
+              <attach>false</attach>
+              <descriptors>
+                <descriptor>src/main/assembly/assembly-mutable.xml</descriptor>
               </descriptors>
               <archiverConfig>
                 <defaultDirectoryMode>0755</defaultDirectoryMode>

--- a/app/src/main/assembly/assembly-mutable.xml
+++ b/app/src/main/assembly/assembly-mutable.xml
@@ -1,0 +1,29 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>mutable</id>
+  <formats>
+    <format>tar.gz</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <!-- Quarkus mutable-jar layout. Kept nested under quarkus-app/ (the Quarkus default output
+         directory name) because re-augmentation resolves the providers directory relative to it. -->
+    <fileSet>
+      <directory>target/mutable/quarkus-app</directory>
+      <outputDirectory>/quarkus-app</outputDirectory>
+      <filtered>false</filtered>
+      <includes>
+        <include>**/*</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>target</directory>
+      <outputDirectory>/</outputDirectory>
+      <filtered>false</filtered>
+      <includes>
+        <include>meta</include>
+        <include>meta/*</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -95,7 +95,9 @@ quarkus.otel.instrument.kafka=true
 
 
 # Package
-quarkus.package.jar.type=fast-jar
+# The jar type is intentionally not set here: the default (fast-jar) is used by the main build,
+# while the "build-mutable" execution in pom.xml overrides it with mutable-jar (plugin properties
+# have a lower priority than application.properties, so an explicit value here would win).
 quarkus.index-dependency.jaxrs.group-id=jakarta.ws.rs
 quarkus.index-dependency.jaxrs.artifact-id=jakarta.ws.rs-api
 

--- a/distro/docker/README.md
+++ b/distro/docker/README.md
@@ -1,11 +1,25 @@
-This module builds the docker image for the `app` component, if activated by the `docker` property.
+This module prepares the Docker build context for the `app` component in `target/docker/`
+(the application tarball plus the filtered `Dockerfile.jvm` / `Dockerfile.mutable.jvm`).
+Maven does not run `docker build` itself; the images are built by CI (see
+`.github/workflows/verify-publish.yaml` and `release-images.yaml`) or manually:
 
-In case of an error while executing `docker` during the build, try:
+```bash
+# from the repository root; -Dfull is required for the mutable variant
+./mvnw clean install -DskipTests -Pprod -Dfull
 
-`sudo chmod a+rw /var/run/docker.sock`
+cd distro/docker/target/docker
 
-If you skip the docker execution, you can build the image manually:
+# standard image (Quarkus fast-jar)
+docker build -f Dockerfile.jvm -t apicurio/apicurio-registry:[project version] .
 
-`cd target/docker`
+# re-augmentable image (Quarkus mutable-jar), see docs "Custom artifact types"
+docker build -f Dockerfile.mutable.jvm -t apicurio/apicurio-registry:[project version]-mutable .
+```
 
-`docker build -f Dockerfile.jvm -t apicurio/apicurio-registry:[project version] .`
+The `-mutable` image additionally contains `lib/deployment` and `/deployments/build.sh`, which
+re-augments the application so that provider jars copied into `/deployments/quarkus-app/providers`
+(for example Java implementations of custom artifact types) become part of the application:
+
+```bash
+docker run --rm apicurio/apicurio-registry:[project version]-mutable /deployments/build.sh --prune
+```

--- a/distro/docker/pom.xml
+++ b/distro/docker/pom.xml
@@ -16,6 +16,8 @@
   <properties>
     <projectRoot>${project.basedir}/../..</projectRoot>
     <docker.app.file>app-files/apicurio-registry-app-${project.version}-all.tar.gz</docker.app.file>
+    <!-- Re-augmentable distribution, only produced with -Dfull (see Dockerfile.mutable.jvm) -->
+    <docker.app.file.mutable>app-files/apicurio-registry-app-${project.version}-mutable.tar.gz</docker.app.file.mutable>
   </properties>
 
   <dependencies>

--- a/distro/docker/src/main/docker/Dockerfile.mutable.jvm
+++ b/distro/docker/src/main/docker/Dockerfile.mutable.jvm
@@ -1,0 +1,31 @@
+# Re-augmentable ("mutable") variant of the Apicurio Registry image.
+#
+# Identical to Dockerfile.jvm except that the application is packaged as a Quarkus mutable-jar:
+# it additionally ships lib/deployment and can be re-augmented in a derived image to pick up
+# provider jars placed in /deployments/quarkus-app/providers (for example Java implementations
+# of custom artifact types). See /deployments/build.sh and the "Custom artifact types" docs.
+#
+#   FROM apicurio/apicurio-registry:VERSION-mutable
+#   COPY --chown=1001:0 my-provider.jar /deployments/quarkus-app/providers/
+#   RUN /deployments/build.sh --prune
+FROM registry.access.redhat.com/ubi10/openjdk-21-runtime@sha256:2056c5139666c5e52f01af5b80f0def423a94c3fe824321d74041c11e20c9b72
+
+ENV APP_URL="${docker.app.file.mutable}" \
+    JAVA_APP_JAR="quarkus-app/quarkus-run.jar" \
+    JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+
+ADD "$APP_URL" /deployments
+COPY build.sh /deployments/build.sh
+
+USER root
+
+# Set appropriate permissions and ownership (the providers directory must be writable by the
+# container user so that derived images can re-augment the application)
+RUN mkdir -p /deployments/quarkus-app/providers \
+    && chmod -R "ug=rwx" /deployments \
+    && chown -R 1001:0 /deployments
+
+# Set user for running the container, according to OpenShift best practices
+USER 1001
+
+EXPOSE 8080 8443 9000

--- a/distro/docker/src/main/docker/build.sh
+++ b/distro/docker/src/main/docker/build.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+#
+# Re-augments the Apicurio Registry application so that the jars found in
+# /deployments/quarkus-app/providers become part of the application (Quarkus mutable-jar
+# re-augmentation, the same mechanism as Keycloak's "kc.sh build").
+#
+# Usage (typically from a Dockerfile deriving from apicurio/apicurio-registry:VERSION-mutable):
+#   /deployments/build.sh [--prune]
+#
+#   --prune   remove lib/deployment afterwards. The application can then no longer be
+#             re-augmented, but the Quarkus deployment jars disappear from the image file system.
+#
+# NOTE: this file is filtered by Maven; do not use the ${...} syntax in it.
+set -eu
+
+APP_DIR=/deployments/quarkus-app
+PROVIDERS_DIR=$APP_DIR/providers
+DEPLOYMENT_DIR=$APP_DIR/lib/deployment
+PRUNE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --prune) PRUNE=true ;;
+    -h|--help) sed -n '2,13p' "$0"; exit 0 ;;
+    *) echo "Unknown option: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [ ! -d "$DEPLOYMENT_DIR" ]; then
+  echo "ERROR: $DEPLOYMENT_DIR is missing: this image has already been pruned and cannot be re-augmented." >&2
+  exit 1
+fi
+
+echo "Provider jars in $PROVIDERS_DIR:"
+if ls "$PROVIDERS_DIR"/*.jar >/dev/null 2>&1; then
+  ls -1 "$PROVIDERS_DIR"/*.jar
+else
+  echo "  (none)"
+fi
+
+# Quarkus rewrites every jar of the application during re-augmentation, even when unchanged.
+# Inside a container image build that would copy ~200 MB into the new layer, so the work is done
+# on a scratch copy and only the regenerated class-path index (quarkus/) is copied back.
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+cp -a "$APP_DIR" "$WORK_DIR/quarkus-app"
+
+echo "Re-augmenting the application..."
+# JAVA_OPTS_APPEND is honoured so that e.g. -Xmx can be tuned for the build step.
+# shellcheck disable=SC2086
+java ${JAVA_OPTS_APPEND:-} -Dquarkus.launch.rebuild=true -jar "$WORK_DIR/quarkus-app/quarkus-run.jar"
+
+rm -rf "$APP_DIR/quarkus"
+cp -a "$WORK_DIR/quarkus-app/quarkus" "$APP_DIR/quarkus"
+cp -a "$WORK_DIR/quarkus-app/quarkus-app-dependencies.txt" "$APP_DIR/quarkus-app-dependencies.txt" 2>/dev/null || true
+
+if [ "$PRUNE" = true ]; then
+  echo "Pruning $DEPLOYMENT_DIR ($(du -sh "$DEPLOYMENT_DIR" | cut -f1))"
+  rm -rf "$DEPLOYMENT_DIR"
+fi
+echo "Done."

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -22,6 +22,7 @@
 * Configuration
 ** xref:getting-started/assembly-configuring-registry-security.adoc[]
 ** xref:getting-started/assembly-configuring-the-registry.adoc[]
+** xref:getting-started/assembly-custom-artifact-types.adoc[]
 ** xref:getting-started/assembly-registry-events.adoc[]
 * Client applications
 ** xref:getting-started/assembly-managing-registry-artifacts-ui.adoc[]

--- a/docs/modules/ROOT/pages/getting-started/assembly-custom-artifact-types.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-custom-artifact-types.adoc
@@ -1,0 +1,183 @@
+include::{mod-loc}shared/all-attributes.adoc[]
+
+[id="custom-artifact-types_{context}"]
+= Configuring custom artifact types
+
+:_mod-docs-content-type: ASSEMBLY
+
+[role="_abstract"]
+In addition to the built-in artifact types, {registry} can be configured at deployment time with custom artifact types. The behavior of a custom type (content detection, validation, compatibility checking, canonicalization, dereferencing) is provided either by webhooks or by Java classes. This chapter describes the configuration file and how to add Java providers to the container image without rebuilding {registry}.
+
+// ref-custom-artifact-types-config
+[id="custom-artifact-types-config_{context}"]
+== Artifact type configuration file
+
+:_mod-docs-content-type: REFERENCE
+
+[role="_abstract"]
+The list of artifact types supported by a {registry} instance is read from a JSON file at startup. The file is configured with the `apicurio.artifact-types.config-file` property (environment variable `APICURIO_ARTIFACT_TYPES_CONFIG_FILE`). When the file does not exist, only the built-in artifact types are available.
+
+.Example configuration file
+[source,json]
+----
+{
+  "includeStandardArtifactTypes": true,
+  "artifactTypes": [
+    {
+      "artifactType": "MARKDOWN",
+      "name": "Markdown",
+      "description": "Markdown documents with a level-1 title and level-2 sections.",
+      "contentTypes": ["text/markdown", "text/plain"],
+      "contentAccepter": {
+        "type": "java",
+        "classname": "io.apicurio.registry.examples.customtypes.MarkdownContentAccepter"
+      },
+      "contentValidator": {
+        "type": "java",
+        "classname": "io.apicurio.registry.examples.customtypes.MarkdownContentValidator"
+      },
+      "compatibilityChecker": {
+        "type": "webhook",
+        "url": "https://markdown-service.example.com/compatibility",
+        "headers": { "Authorization": "Bearer YOUR_SECRET_TOKEN" }
+      }
+    }
+  ]
+}
+----
+
+.Top-level properties
+[cols="1,3"]
+|===
+|Property |Description
+
+|`includeStandardArtifactTypes`
+|Whether the built-in artifact types (AVRO, JSON, OPENAPI, ...) remain available. When `false`, only the types listed in `artifactTypes` are supported.
+
+|`artifactTypes`
+|The list of custom artifact types.
+|===
+
+.Artifact type properties
+[cols="1,3"]
+|===
+|Property |Description
+
+|`artifactType`
+|The identifier of the type, used in the REST API and the UI (for example `MARKDOWN`). Must be unique.
+
+|`name`, `description`
+|Display name and description of the type.
+
+|`contentTypes`
+|The content types (media types) accepted for this artifact type.
+
+|`contentAccepter`
+|Provider that decides whether a piece of content belongs to this type. Used to detect the artifact type when a client does not specify one.
+
+|`contentValidator`
+|Provider that backs the `VALIDITY` rule (`SYNTAX_ONLY` and `FULL` levels).
+
+|`compatibilityChecker`
+|Provider that backs the `COMPATIBILITY` rule (`BACKWARD`, `FORWARD`, `FULL` and their transitive variants).
+
+|`contentCanonicalizer`
+|Provider that produces the canonical form of the content, used to recognize equivalent content (for example canonical search and de-duplication).
+
+|`contentDereferencer`
+|Provider that inlines or rewrites references to other artifacts when content is retrieved with `references=DEREFERENCE` or `references=REWRITE`.
+
+|`referenceFinder`
+|Provider that finds external references in the content. Used by the Maven plug-in to register references automatically.
+|===
+
+Every provider property is optional. When a provider is not configured, the corresponding feature is a no-op for the type (for example, the artifact type is never auto-detected and every content is considered valid and compatible).
+
+.Provider types
+[cols="1,3"]
+|===
+|Provider |Description
+
+|`{"type": "java", "classname": "..."}`
+|A Java class implementing the corresponding interface of the `io.apicurio:apicurio-registry-schema-util-common` module (`io.apicurio.registry.content.ContentAccepter`, `io.apicurio.registry.rules.validity.ContentValidator`, `io.apicurio.registry.rules.compatibility.CompatibilityChecker`, `io.apicurio.registry.content.canon.ContentCanonicalizer`, `io.apicurio.registry.content.dereference.ContentDereferencer`, `io.apicurio.registry.content.refs.ReferenceFinder`). The class must have a public no-argument constructor and must be available on the class path of {registry}, see xref:custom-artifact-types-mutable-image_{context}[].
+
+|`{"type": "webhook", "url": "...", "headers": {...}}`
+|An HTTP endpoint that {registry} calls with a JSON request describing the operation (content, resolved references, rule level) and that returns a JSON response. The optional `headers` are sent with every request, for example for authentication. Webhooks work with the standard container image but add a network round trip to every operation.
+|===
+
+// proc-custom-artifact-types-mutable-image
+[id="custom-artifact-types-mutable-image_{context}"]
+== Adding Java providers with the mutable container image
+
+:_mod-docs-content-type: PROCEDURE
+
+[role="_abstract"]
+The standard {registry} container image is a Quarkus _fast-jar_: its class path is indexed when the image is built, so a jar copied into the image is not visible to the application. Every release is therefore also published as a `VERSION-mutable` image, a Quarkus _mutable-jar_ that can be _re-augmented_ to include additional jars. Build a derived image that copies your provider jar into the providers directory and runs the re-augmentation once, at image build time.
+
+.Prerequisites
+
+* A jar containing your provider classes, compiled against the `io.apicurio:apicurio-registry-schema-util-common` module of the same {registry} minor version. The jar must not bundle the {registry} or Quarkus classes; other dependencies must either be already present in the image or be copied into the providers directory as well.
+* An artifact type configuration file, see xref:custom-artifact-types-config_{context}[].
+
+.Procedure
+
+. Create a `Dockerfile` that derives from the mutable image:
++
+[source,dockerfile,subs="attributes+"]
+----
+FROM apicurio/apicurio-registry:{registry-docker-version}-mutable
+
+COPY --chown=1001:0 my-artifact-type.jar /deployments/quarkus-app/providers/
+COPY --chown=1001:0 artifact-types.json /deployments/artifact-types.json
+
+RUN /deployments/build.sh --prune
+
+ENV APICURIO_ARTIFACT_TYPES_CONFIG_FILE=/deployments/artifact-types.json
+----
++
+`/deployments/build.sh` re-augments the application with the jars found in `/deployments/quarkus-app/providers` and adds only the regenerated class-path index (a few MB) to the derived image. The `--prune` option removes the `lib/deployment` directory (the Quarkus deployment jars) from the file system of the derived image afterwards; omit it if you want to re-augment the derived image again later.
+
+. Build and run the image:
++
+[source,bash]
+----
+$ docker build -t my-registry .
+$ docker run -it -p 8080:8080 my-registry
+----
+
+. Verify that the custom type is available:
++
+[source,bash]
+----
+$ curl http://localhost:8080/apis/registry/v3/admin/config/artifactTypes
+----
+
+Re-augmentation takes about ten seconds and requires roughly 1 GB of memory during the image build (tune it with the `JAVA_OPTS_APPEND` environment variable). It must be repeated, by rebuilding the derived image, whenever the provider jars change. The startup time and runtime behavior of {registry} are not affected.
+
+.Trade-offs
+[cols="1,1,1"]
+|===
+| |Standard image |`-mutable` image
+
+|Packaging
+|Quarkus fast-jar (`/deployments`)
+|Quarkus mutable-jar (`/deployments/quarkus-app`)
+
+|Size
+|Reference
+|About 47 MB (150 jars) of additional files in `lib/deployment` (roughly 100 MB of image size with the current image layering). A derived image adds only a few MB; `build.sh --prune` removes the deployment jars from the file system but, as with any container image, does not shrink the layers inherited from the base image.
+
+|Java providers
+|Not supported (use webhooks)
+|Supported through `/deployments/build.sh`
+
+|Runtime behavior
+|Reference
+|Identical
+|===
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://github.com/Apicurio/apicurio-registry/tree/main/examples/custom-artifact-types[Custom artifact types example] (a complete `MARKDOWN` artifact type with Java providers)
+* link:https://quarkus.io/guides/reaugmentation[Quarkus re-augmentation guide]
+* xref:assembly-artifact-reference.adoc[]

--- a/docs/modules/ROOT/pages/getting-started/assembly-installing-registry-docker.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-installing-registry-docker.adoc
@@ -60,6 +60,8 @@ $ docker run -it -p 8080:8080 apicurio/apicurio-registry:VERSION
 ----
 +
 NOTE: All storage variants of {registry} 3.x now share the same container image of `apicurio/apicurio-registry`. This is in contrast to the separate container images used by {registry} 2.x. Choosing a storage variant is now a matter of configuring the single backend/server container image.
++
+NOTE: Every release is also published as `apicurio/apicurio-registry:VERSION-mutable`, a variant that can be extended with Java providers for custom artifact types without rebuilding {registry}. See xref:assembly-custom-artifact-types.adoc[].
 
 . Send a test request using the {registry} REST API. For example, enter the following `curl` command to create an Avro schema artifact for a share price application in the registry:
 +

--- a/examples/README.md
+++ b/examples/README.md
@@ -122,3 +122,11 @@ The demo includes a multi-agent workflow that processes customer complaints thro
 summarization, and translation agents - all using real HTTP communication.
 
 See the [a2a-real-world-integration](a2a-real-world-integration/) directory for details.
+
+## Custom Artifact Types (Java providers)
+
+Adds a custom `MARKDOWN` artifact type to the registry with Java implementations of the artifact
+type interfaces (content accepter, validator, compatibility checker, canonicalizer), configured
+through `apicurio.artifact-types.config-file`. The providers are loaded into the
+`apicurio/apicurio-registry:VERSION-mutable` container image by re-augmenting it, so no custom
+build of the registry is needed. See the [custom-artifact-types](custom-artifact-types/) directory for details.

--- a/examples/custom-artifact-types/Dockerfile
+++ b/examples/custom-artifact-types/Dockerfile
@@ -1,0 +1,16 @@
+# Apicurio Registry + the custom MARKDOWN artifact type.
+#
+# Derives from the re-augmentable ("-mutable") registry image: the provider jar is copied into
+# the providers directory and /deployments/build.sh re-augments the application so that the
+# classes become loadable. --prune drops lib/deployment afterwards (same size as the standard image).
+#
+# Build the jar first:  mvn package
+ARG REGISTRY_IMAGE=apicurio/apicurio-registry:latest-snapshot-mutable
+FROM ${REGISTRY_IMAGE}
+
+COPY --chown=1001:0 target/custom-artifact-types.jar /deployments/quarkus-app/providers/
+COPY --chown=1001:0 artifact-types.json /deployments/artifact-types.json
+
+RUN /deployments/build.sh --prune
+
+ENV APICURIO_ARTIFACT_TYPES_CONFIG_FILE=/deployments/artifact-types.json

--- a/examples/custom-artifact-types/README.md
+++ b/examples/custom-artifact-types/README.md
@@ -1,0 +1,109 @@
+# Custom Artifact Types (Java providers)
+
+This example adds a custom **`MARKDOWN`** artifact type to Apicurio Registry, implemented in
+Java and loaded into the registry container image **without rebuilding the registry**.
+
+Since Apicurio Registry 3.1 the set of artifact types can be configured with a JSON file
+(`apicurio.artifact-types.config-file`). Each type's behaviour (content acceptance, validation,
+compatibility checking, canonicalization, ...) is delegated either to a **webhook** or to a
+**Java class**. Java classes must be on the registry's class path, and because the registry is a
+Quarkus *fast-jar*, a jar cannot simply be copied into the image. The `-mutable` image variant
+solves this: it is a Quarkus *mutable-jar* that can be re-augmented with the jars found in
+`/deployments/quarkus-app/providers` by running `/deployments/build.sh` (the same mechanism
+Keycloak uses for its custom providers).
+
+## What is in here
+
+| File | Purpose |
+|---|---|
+| `src/main/java/.../Markdown*.java` | The providers: `MarkdownContentAccepter` (auto-detection), `MarkdownContentValidator` (`VALIDITY` rule), `MarkdownCompatibilityChecker` (`COMPATIBILITY` rule), `MarkdownContentCanonicalizer` (canonical content for de-duplication/search) |
+| `artifact-types.json` | Registers the `MARKDOWN` type and points at the classes above (`"type": "java"`) |
+| `Dockerfile` | `FROM apicurio/apicurio-registry:VERSION-mutable`, copies the jar into `providers/`, runs `build.sh --prune` |
+| `docker-compose.yml` | Registry (built from the Dockerfile) and the registry UI |
+| `samples/*.md` | Documents used by the walkthrough below |
+| `test.sh` | Runs the whole walkthrough end to end |
+
+The type itself is deliberately simple: a document must start with a level-1 heading (its
+title), level-2 headings are its sections, a new version is backward compatible when it keeps
+the title and all existing sections.
+
+## Quick start
+
+```bash
+./test.sh
+```
+
+or step by step:
+
+```bash
+mvn package                       # builds target/custom-artifact-types.jar (no dependencies)
+docker compose up --build         # builds the derived image and starts registry + UI
+```
+
+Use `REGISTRY_IMAGE=apicurio/apicurio-registry:3.4.0-mutable docker compose up --build` to pick a
+specific registry version (the default is `latest-snapshot-mutable`). The provider jar must be
+compiled against the same registry minor version (`apicurio-registry-schema-util-common`).
+
+## Walkthrough
+
+```bash
+API=http://localhost:8080/apis/registry/v3
+
+# MARKDOWN is now one of the artifact types
+curl -s $API/admin/config/artifactTypes | jq 'map(.name)'
+
+# Create an artifact WITHOUT specifying the type: the ContentAccepter detects MARKDOWN
+jq -n --rawfile c samples/getting-started.md \
+  '{artifactId:"orders-getting-started", firstVersion:{content:{content:$c, contentType:"text/markdown"}}}' \
+  | curl -s -X POST -H 'Content-Type: application/json' -d @- $API/groups/docs/artifacts | jq .artifact.artifactType
+
+# Enable validation on the artifact: a document without a title is rejected (HTTP 409)
+curl -s -X POST -H 'Content-Type: application/json' -d '{"ruleType":"VALIDITY","config":"FULL"}' \
+  $API/groups/docs/artifacts/orders-getting-started/rules
+jq -n --rawfile c samples/invalid-no-title.md '{content:{content:$c, contentType:"text/markdown"}}' \
+  | curl -s -X POST -H 'Content-Type: application/json' -d @- $API/groups/docs/artifacts/orders-getting-started/versions | jq .
+
+# Enable backward compatibility: removing a section is rejected (HTTP 400)
+curl -s -X POST -H 'Content-Type: application/json' -d '{"ruleType":"COMPATIBILITY","config":"BACKWARD"}' \
+  $API/groups/docs/artifacts/orders-getting-started/rules
+jq -n --rawfile c samples/getting-started-v2-removed-section.md '{content:{content:$c, contentType:"text/markdown"}}' \
+  | curl -s -X POST -H 'Content-Type: application/json' -d @- $API/groups/docs/artifacts/orders-getting-started/versions | jq .
+
+# Accepted: a section was added -> version 2
+jq -n --rawfile c samples/getting-started-v2.md '{content:{content:$c, contentType:"text/markdown"}}' \
+  | curl -s -X POST -H 'Content-Type: application/json' -d @- $API/groups/docs/artifacts/orders-getting-started/versions | jq .version
+```
+
+The UI at http://localhost:8888 shows the artifact with type `MARKDOWN` (custom types have no
+dedicated icon).
+
+## How the image is built
+
+```dockerfile
+FROM apicurio/apicurio-registry:VERSION-mutable
+COPY --chown=1001:0 target/custom-artifact-types.jar /deployments/quarkus-app/providers/
+COPY --chown=1001:0 artifact-types.json /deployments/artifact-types.json
+RUN /deployments/build.sh --prune
+ENV APICURIO_ARTIFACT_TYPES_CONFIG_FILE=/deployments/artifact-types.json
+```
+
+`build.sh` runs a Quarkus re-augmentation (`java -Dquarkus.launch.rebuild=true -jar quarkus-run.jar`)
+on a scratch copy of the application and copies back only the regenerated class-path index, so the
+derived image is only a few MB larger than the base image. It takes about 10 seconds and needs
+roughly 1 GB of memory at image build time, and must be re-run whenever the jars in `providers/`
+change. Runtime behaviour and startup time of the registry are unchanged. `--prune` removes
+`lib/deployment` (the Quarkus deployment jars, about 47 MB, which the `-mutable` image carries in
+addition to the standard image) from the file system of the derived image; the image can then
+not be re-augmented again.
+
+## Alternative: webhook providers
+
+If you prefer not to build a derived image, the same `artifact-types.json` can point at an HTTP
+service instead of Java classes, and the standard registry image can be used:
+
+```json
+"contentValidator": { "type": "webhook", "url": "http://markdown-service:8080/validate", "headers": {} }
+```
+
+The registry then POSTs the content to your service for each operation. See the "Custom artifact
+types" chapter of the documentation for the request/response payloads.

--- a/examples/custom-artifact-types/artifact-types.json
+++ b/examples/custom-artifact-types/artifact-types.json
@@ -1,0 +1,30 @@
+{
+  "includeStandardArtifactTypes": true,
+  "artifactTypes": [
+    {
+      "artifactType": "MARKDOWN",
+      "name": "Markdown",
+      "description": "Markdown documents with a level-1 title and level-2 sections.",
+      "contentTypes": [
+        "text/markdown",
+        "text/plain"
+      ],
+      "contentAccepter": {
+        "type": "java",
+        "classname": "io.apicurio.registry.examples.customtypes.MarkdownContentAccepter"
+      },
+      "contentValidator": {
+        "type": "java",
+        "classname": "io.apicurio.registry.examples.customtypes.MarkdownContentValidator"
+      },
+      "compatibilityChecker": {
+        "type": "java",
+        "classname": "io.apicurio.registry.examples.customtypes.MarkdownCompatibilityChecker"
+      },
+      "contentCanonicalizer": {
+        "type": "java",
+        "classname": "io.apicurio.registry.examples.customtypes.MarkdownContentCanonicalizer"
+      }
+    }
+  ]
+}

--- a/examples/custom-artifact-types/docker-compose.yml
+++ b/examples/custom-artifact-types/docker-compose.yml
@@ -1,0 +1,33 @@
+---
+services:
+  # Apicurio Registry with the custom MARKDOWN artifact type (see Dockerfile)
+  apicurio-registry:
+    build:
+      context: .
+      args:
+        REGISTRY_IMAGE: "${REGISTRY_IMAGE:-apicurio/apicurio-registry:latest-snapshot-mutable}"
+    image: apicurio-registry-custom-artifact-types:local
+    container_name: custom-artifact-types-registry
+    ports:
+      - "8080:8080"
+    environment:
+      QUARKUS_LOG_LEVEL: "INFO"
+      APICURIO_LOG_LEVEL: "DEBUG"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  # Apicurio Registry UI
+  apicurio-registry-ui:
+    image: quay.io/apicurio/apicurio-registry-ui:latest-snapshot
+    container_name: custom-artifact-types-registry-ui
+    ports:
+      - "8888:8080"
+    environment:
+      REGISTRY_API_URL: "http://localhost:8080/apis/registry/v3"
+    depends_on:
+      apicurio-registry:
+        condition: service_healthy

--- a/examples/custom-artifact-types/pom.xml
+++ b/examples/custom-artifact-types/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.apicurio</groupId>
+    <artifactId>apicurio-registry-examples</artifactId>
+    <version>3.3.3-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>apicurio-registry-examples-custom-artifact-types</artifactId>
+  <packaging>jar</packaging>
+  <name>Registry :: Examples :: Custom Artifact Types</name>
+  <description>Java providers for a custom MARKDOWN artifact type, loaded into the -mutable registry image</description>
+
+  <properties>
+    <projectRoot>${project.basedir}/../..</projectRoot>
+  </properties>
+
+  <dependencies>
+    <!-- The artifact type SPI. Provided at runtime by the registry itself, so the resulting jar
+         has no dependencies of its own and can be dropped into the registry's providers/ directory. -->
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-util-common</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <!-- Stable jar name, referenced by the Dockerfile -->
+    <finalName>custom-artifact-types</finalName>
+  </build>
+
+</project>

--- a/examples/custom-artifact-types/samples/getting-started-v2-removed-section.md
+++ b/examples/custom-artifact-types/samples/getting-started-v2-removed-section.md
@@ -1,0 +1,5 @@
+# Getting started with the Orders API
+
+## Creating an order
+
+`POST /orders` with the order payload. The response contains the generated order id.

--- a/examples/custom-artifact-types/samples/getting-started-v2.md
+++ b/examples/custom-artifact-types/samples/getting-started-v2.md
@@ -1,0 +1,13 @@
+# Getting started with the Orders API
+
+## Authentication
+
+Obtain a token from the identity provider and pass it as a bearer token.
+
+## Creating an order
+
+`POST /orders` with the order payload. The response contains the generated order id.
+
+## Cancelling an order
+
+`DELETE /orders/{id}` cancels an order that has not been shipped yet.

--- a/examples/custom-artifact-types/samples/getting-started.md
+++ b/examples/custom-artifact-types/samples/getting-started.md
@@ -1,0 +1,9 @@
+# Getting started with the Orders API
+
+## Authentication
+
+Obtain a token from the identity provider and pass it as a bearer token.
+
+## Creating an order
+
+`POST /orders` with the order payload. The response contains the generated order id.

--- a/examples/custom-artifact-types/samples/invalid-no-title.md
+++ b/examples/custom-artifact-types/samples/invalid-no-title.md
@@ -1,0 +1,5 @@
+This document has no level-1 heading, so it fails FULL validation.
+
+## Authentication
+
+Obtain a token from the identity provider and pass it as a bearer token.

--- a/examples/custom-artifact-types/src/main/java/io/apicurio/registry/examples/customtypes/Markdown.java
+++ b/examples/custom-artifact-types/src/main/java/io/apicurio/registry/examples/customtypes/Markdown.java
@@ -1,0 +1,55 @@
+package io.apicurio.registry.examples.customtypes;
+
+import io.apicurio.registry.content.TypedContent;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Tiny Markdown "model" shared by the MARKDOWN artifact type providers: a document has a title
+ * (the first level-1 heading) and a set of sections (level-2 headings).
+ */
+final class Markdown {
+
+    static final String CONTENT_TYPE = "text/markdown";
+
+    private Markdown() {
+    }
+
+    static String text(TypedContent content) {
+        return content.getContent().content();
+    }
+
+    /** Returns the text of the first {@code # } heading, or {@code null} when there is none. */
+    static String title(String markdown) {
+        for (String line : markdown.split("\n")) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            return trimmed.startsWith("# ") ? trimmed.substring(2).trim() : null;
+        }
+        return null;
+    }
+
+    /** Returns the texts of all {@code ## } headings, in document order. */
+    static Set<String> sections(String markdown) {
+        Set<String> sections = new LinkedHashSet<>();
+        for (String line : markdown.split("\n")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("## ")) {
+                sections.add(trimmed.substring(3).trim());
+            }
+        }
+        return sections;
+    }
+
+    /** Normalizes line endings and trailing whitespace so that equivalent documents hash alike. */
+    static String canonicalize(String markdown) {
+        StringBuilder out = new StringBuilder(markdown.length());
+        for (String line : markdown.replace("\r\n", "\n").replace('\r', '\n').split("\n", -1)) {
+            out.append(line.stripTrailing()).append('\n');
+        }
+        return out.toString().strip() + "\n";
+    }
+}

--- a/examples/custom-artifact-types/src/main/java/io/apicurio/registry/examples/customtypes/MarkdownCompatibilityChecker.java
+++ b/examples/custom-artifact-types/src/main/java/io/apicurio/registry/examples/customtypes/MarkdownCompatibilityChecker.java
@@ -1,0 +1,69 @@
+package io.apicurio.registry.examples.customtypes;
+
+import io.apicurio.registry.content.TypedContent;
+import io.apicurio.registry.rules.compatibility.CompatibilityChecker;
+import io.apicurio.registry.rules.compatibility.CompatibilityExecutionResult;
+import io.apicurio.registry.rules.compatibility.CompatibilityLevel;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Backs the COMPATIBILITY rule for the MARKDOWN artifact type. A new version is:
+ * <ul>
+ * <li>{@code BACKWARD} compatible when it keeps the title and all sections of the previous version
+ * (sections may be added);</li>
+ * <li>{@code FORWARD} compatible when it does not introduce new sections;</li>
+ * <li>{@code FULL} compatible when both hold.</li>
+ * </ul>
+ * The {@code *_TRANSITIVE} levels apply the same checks against every existing version.
+ */
+public class MarkdownCompatibilityChecker implements CompatibilityChecker {
+
+    @Override
+    public CompatibilityExecutionResult testCompatibility(CompatibilityLevel level,
+            List<TypedContent> existingArtifacts, TypedContent proposedArtifact,
+            Map<String, TypedContent> resolvedReferences) {
+        if (level == null || level == CompatibilityLevel.NONE || existingArtifacts == null
+                || existingArtifacts.isEmpty()) {
+            return CompatibilityExecutionResult.compatible();
+        }
+        boolean transitive = level.name().endsWith("_TRANSITIVE");
+        boolean backward = level.name().startsWith("BACKWARD") || level.name().startsWith("FULL");
+        boolean forward = level.name().startsWith("FORWARD") || level.name().startsWith("FULL");
+
+        List<TypedContent> toCompare = transitive ? existingArtifacts
+            : List.of(existingArtifacts.get(existingArtifacts.size() - 1));
+        String proposed = Markdown.text(proposedArtifact);
+        String proposedTitle = Markdown.title(proposed);
+        Set<String> proposedSections = Markdown.sections(proposed);
+
+        List<String> problems = new ArrayList<>();
+        for (TypedContent existingContent : toCompare) {
+            String existing = Markdown.text(existingContent);
+            if (!Objects.equals(Markdown.title(existing), proposedTitle)) {
+                problems.add("Title changed from \"" + Markdown.title(existing) + "\" to \"" + proposedTitle + "\".");
+            }
+            Set<String> existingSections = Markdown.sections(existing);
+            if (backward) {
+                for (String section : existingSections) {
+                    if (!proposedSections.contains(section)) {
+                        problems.add("Section \"" + section + "\" was removed.");
+                    }
+                }
+            }
+            if (forward) {
+                for (String section : proposedSections) {
+                    if (!existingSections.contains(section)) {
+                        problems.add("Section \"" + section + "\" was added.");
+                    }
+                }
+            }
+        }
+        return problems.isEmpty() ? CompatibilityExecutionResult.compatible()
+            : CompatibilityExecutionResult.incompatible(String.join(" ", problems));
+    }
+}

--- a/examples/custom-artifact-types/src/main/java/io/apicurio/registry/examples/customtypes/MarkdownContentAccepter.java
+++ b/examples/custom-artifact-types/src/main/java/io/apicurio/registry/examples/customtypes/MarkdownContentAccepter.java
@@ -1,0 +1,21 @@
+package io.apicurio.registry.examples.customtypes;
+
+import io.apicurio.registry.content.ContentAccepter;
+import io.apicurio.registry.content.TypedContent;
+
+import java.util.Map;
+
+/**
+ * Lets the registry auto-detect the MARKDOWN artifact type when a client does not specify one:
+ * the content type is {@code text/markdown}, or the document starts with a level-1 heading.
+ */
+public class MarkdownContentAccepter implements ContentAccepter {
+
+    @Override
+    public boolean acceptsContent(TypedContent content, Map<String, TypedContent> resolvedReferences) {
+        if (Markdown.CONTENT_TYPE.equalsIgnoreCase(content.getContentType())) {
+            return true;
+        }
+        return Markdown.title(Markdown.text(content)) != null;
+    }
+}

--- a/examples/custom-artifact-types/src/main/java/io/apicurio/registry/examples/customtypes/MarkdownContentCanonicalizer.java
+++ b/examples/custom-artifact-types/src/main/java/io/apicurio/registry/examples/customtypes/MarkdownContentCanonicalizer.java
@@ -1,0 +1,21 @@
+package io.apicurio.registry.examples.customtypes;
+
+import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.content.TypedContent;
+import io.apicurio.registry.content.canon.ContentCanonicalizer;
+
+import java.util.Map;
+
+/**
+ * Canonical form of a MARKDOWN document: LF line endings, no trailing whitespace, single trailing
+ * newline. The registry uses it to recognise equivalent content (for example when searching with
+ * {@code canonical=true}).
+ */
+public class MarkdownContentCanonicalizer implements ContentCanonicalizer {
+
+    @Override
+    public TypedContent canonicalize(TypedContent content, Map<String, TypedContent> resolvedReferences) {
+        String canonical = Markdown.canonicalize(Markdown.text(content));
+        return TypedContent.create(ContentHandle.create(canonical), Markdown.CONTENT_TYPE);
+    }
+}

--- a/examples/custom-artifact-types/src/main/java/io/apicurio/registry/examples/customtypes/MarkdownContentValidator.java
+++ b/examples/custom-artifact-types/src/main/java/io/apicurio/registry/examples/customtypes/MarkdownContentValidator.java
@@ -1,0 +1,50 @@
+package io.apicurio.registry.examples.customtypes;
+
+import io.apicurio.registry.content.TypedContent;
+import io.apicurio.registry.rest.v3.beans.ArtifactReference;
+import io.apicurio.registry.rules.validity.ContentValidator;
+import io.apicurio.registry.rules.validity.ValidityLevel;
+import io.apicurio.registry.rules.violation.RuleViolation;
+import io.apicurio.registry.rules.violation.RuleViolationException;
+import io.apicurio.registry.types.RuleType;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Backs the VALIDITY rule for the MARKDOWN artifact type.
+ * <ul>
+ * <li>{@code SYNTAX_ONLY}: the document must not be blank.</li>
+ * <li>{@code FULL}: additionally, the document must start with a level-1 heading (its title).</li>
+ * </ul>
+ */
+public class MarkdownContentValidator implements ContentValidator {
+
+    @Override
+    public void validate(ValidityLevel level, TypedContent content, Map<String, TypedContent> resolvedReferences)
+            throws RuleViolationException {
+        if (level == null || level == ValidityLevel.NONE) {
+            return;
+        }
+        String markdown = Markdown.text(content);
+        Set<RuleViolation> violations = new LinkedHashSet<>();
+        if (markdown == null || markdown.isBlank()) {
+            violations.add(new RuleViolation("Markdown document is empty.", null));
+        } else if (level == ValidityLevel.FULL && Markdown.title(markdown) == null) {
+            violations.add(new RuleViolation("Markdown document must start with a level-1 heading (\"# Title\").",
+                    "line 1"));
+        }
+        if (!violations.isEmpty()) {
+            throw new RuleViolationException("Markdown validation failed.", RuleType.VALIDITY, level.name(),
+                    violations);
+        }
+    }
+
+    @Override
+    public void validateReferences(TypedContent content, List<ArtifactReference> references)
+            throws RuleViolationException {
+        // Markdown documents do not reference other registry artifacts.
+    }
+}

--- a/examples/custom-artifact-types/test.sh
+++ b/examples/custom-artifact-types/test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Builds the provider jar and the derived registry image, then exercises the MARKDOWN artifact
+# type through the REST API. Requires Maven, Docker (compose), curl and jq.
+#
+#   ./test.sh                                                        # latest-snapshot-mutable base image
+#   REGISTRY_IMAGE=apicurio/apicurio-registry:3.4.0-mutable ./test.sh
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# Use the default (docker driver) builder so that a locally built base image is visible;
+# set BUILDX_BUILDER yourself to use a different one.
+export BUILDX_BUILDER="${BUILDX_BUILDER:-default}"
+
+API="http://localhost:8080/apis/registry/v3"
+GROUP="docs"
+ARTIFACT="orders-getting-started"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"; docker compose down -v >/dev/null 2>&1 || true' EXIT
+
+pass() { printf '  \033[32mPASS\033[0m %s\n' "$*"; }
+fail() { printf '  \033[31mFAIL\033[0m %s\n' "$*"; docker compose logs apicurio-registry | tail -50; exit 1; }
+
+# request METHOD PATH [JSON-BODY] -> sets STATUS and BODY
+request() {
+  local method="$1" path="$2" data="${3:-}"
+  if [ -n "$data" ]; then
+    STATUS="$(curl -sS -o "$TMP" -w '%{http_code}' -X "$method" -H 'Content-Type: application/json' \
+      --data-binary "$data" "$API$path")"
+  else
+    STATUS="$(curl -sS -o "$TMP" -w '%{http_code}' -X "$method" "$API$path")"
+  fi
+  BODY="$(cat "$TMP")"
+}
+expect() { [ "$STATUS" = "$1" ] || fail "$2 -> expected HTTP $1, got $STATUS: $BODY"; }
+# rule violations are reported as HTTP 400 (compatibility) or 409 (validity / conflicts)
+expect_violation() {
+  case "$STATUS" in 400|409) ;; *) fail "$1 -> expected a rule violation (HTTP 400/409), got $STATUS: $BODY" ;; esac
+  [ -z "$2" ] || echo "$BODY" | grep -q "$2" || fail "$1 -> violation does not mention '$2': $BODY"
+}
+create_artifact_body() { jq -n --rawfile c "$1" --arg id "$ARTIFACT" \
+  '{artifactId: $id, firstVersion: {content: {content: $c, contentType: "text/markdown"}}}'; }
+create_version_body() { jq -n --rawfile c "$1" '{content: {content: $c, contentType: "text/markdown"}}'; }
+violations() { echo "$BODY" | jq -r '[.causes[]?.description] | join(" | ")' 2>/dev/null || echo "$BODY"; }
+
+echo "Building the provider jar..."
+mvn -q package -DskipTests
+
+echo "Building and starting the registry (${REGISTRY_IMAGE:-apicurio/apicurio-registry:latest-snapshot-mutable})..."
+docker compose up -d --build --wait apicurio-registry
+for _ in $(seq 1 60); do curl -sf "$API/system/info" >/dev/null && break; sleep 2; done
+curl -sf "$API/system/info" >/dev/null || fail "registry not reachable"
+
+echo "1. MARKDOWN is a registered artifact type"
+request GET /admin/config/artifactTypes
+expect 200 "list artifact types"
+echo "$BODY" | jq -e 'map(.name) | index("MARKDOWN")' >/dev/null || fail "MARKDOWN not in: $BODY"
+pass "$(echo "$BODY" | jq -c 'map(.name)')"
+
+echo "2. Artifact type is auto-detected (no artifactType in the request)"
+request POST "/groups/$GROUP/artifacts" "$(create_artifact_body samples/getting-started.md)"
+expect 200 "create artifact"
+[ "$(echo "$BODY" | jq -r .artifact.artifactType)" = "MARKDOWN" ] || fail "unexpected type: $BODY"
+pass "artifactType=MARKDOWN, version $(echo "$BODY" | jq -r .version.version)"
+
+echo "3. Enable the VALIDITY=FULL rule; a document without a title is rejected (ContentValidator)"
+request POST "/groups/$GROUP/artifacts/$ARTIFACT/rules" '{"ruleType":"VALIDITY","config":"FULL"}'
+expect 204 "validity rule"
+request POST "/groups/$GROUP/artifacts/$ARTIFACT/versions" "$(create_version_body samples/invalid-no-title.md)"
+expect_violation "invalid document" "level-1 heading"
+pass "$(violations)"
+
+echo "4. Enable the COMPATIBILITY=BACKWARD rule; removing a section is rejected (CompatibilityChecker)"
+request POST "/groups/$GROUP/artifacts/$ARTIFACT/rules" '{"ruleType":"COMPATIBILITY","config":"BACKWARD"}'
+expect 204 "compatibility rule"
+request POST "/groups/$GROUP/artifacts/$ARTIFACT/versions" "$(create_version_body samples/getting-started-v2-removed-section.md)"
+expect_violation "incompatible document" "was removed"
+pass "$(violations)"
+
+echo "5. Adding a section is accepted as version 2"
+request POST "/groups/$GROUP/artifacts/$ARTIFACT/versions" "$(create_version_body samples/getting-started-v2.md)"
+expect 200 "compatible document"
+pass "version $(echo "$BODY" | jq -r .version)"
+
+echo "6. Content with different whitespace matches version 1 when compared canonically (ContentCanonicalizer)"
+sed 's/$/   /' samples/getting-started.md | tr -d '\r' > "$TMP.md"
+request POST "/groups/$GROUP/artifacts?ifExists=FIND_OR_CREATE_VERSION&canonical=true" "$(create_artifact_body "$TMP.md")"
+rm -f "$TMP.md"
+expect 200 "find or create version"
+V="$(echo "$BODY" | jq -r .version.version)"
+[ "$V" = "1" ] || fail "expected the canonical lookup to resolve to version 1, got $V: $BODY"
+pass "resolved to version $V"
+
+echo
+echo "All checks passed. UI: http://localhost:8888 (run 'docker compose down' to stop)."
+trap 'rm -f "$TMP"' EXIT

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -63,6 +63,7 @@
     <module>camel-quarkus-kafka</module>
     <module>a2a-real-world-integration</module>
     <module>odcs-data-contracts</module>
+    <module>custom-artifact-types</module>
   </modules>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,10 @@
 
     <tar.long.file.mode>posix</tar.long.file.mode>
 
+    <!-- Re-augmentable (Quarkus mutable-jar) variant of the app distribution, used by the
+         "-mutable" container image. Skipped by default, enabled by -Dfull. -->
+    <apicurio.mutable-jar.skip>true</apicurio.mutable-jar.skip>
+
     <projectRoot>${project.basedir}</projectRoot>
 
     <!--
@@ -1422,6 +1426,10 @@
           <name>full</name>
         </property>
       </activation>
+      <properties>
+        <!-- Also build the re-augmentable app distribution (see app/pom.xml, build-mutable) -->
+        <apicurio.mutable-jar.skip>false</apicurio.mutable-jar.skip>
+      </properties>
       <modules>
         <!-- Include non-essential modules so -Dfull is a true superset -->
         <module>cli</module>


### PR DESCRIPTION
## Summary

Currently you need to rebuild custom artifact type providers **in** the Apicurio Registry build to make them available on the "fastjar".
Adding a "mutable-jar" container distribution we enable users downstream to run only the Quarkus "re-augmentation" without the need of a full Maven re-build.

Closes #9902

## Checklist

- [ ] Linked issue has maintainer approval (#9902)
- [ ] No overlapping open PRs for the same issue
- [ ] Checked the [Tried & Rejected list](https://github.com/Apicurio/apicurio-registry/discussions/8364)
- [ ] Tests added for new code paths
- [ ] Tested locally: `./mvnw test -pl <module> -am -Dlocal`
- [ ] `./mvnw checkstyle:check -pl <module>` passes
- [x] All commits have DCO sign-off (`git commit -s`)

<!-- If your PR is still in progress, open it as a Draft. CI will not run
     until the PR is marked ready for review and accepted by a maintainer. -->

