### PR TITLE
docs: make GitHub Private Vulnerability Reporting the primary security channel

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,21 +2,36 @@
 
 ## Reporting a Vulnerability
 
-Security is important for us.
-Security vulnerabilities or suspected security vulnerabilities should be reported to Apicurio Registry maintainers privately, to minimize attacks against current users before they are fixed.
-Reported vulnerabilities will be investigated and patched on the next patch (or minor) release as soon as possible.
+Security is important to us. Security vulnerabilities or suspected security vulnerabilities
+should be reported to the Apicurio Registry maintainers **privately**, so we can fix them
+before they are disclosed publicly and minimize the risk to current users.
 
-**IMPORTANT: Please do not file public issues on GitHub for security vulnerabilities**
+**Please do not open public GitHub issues for security vulnerabilities.**
 
-To report a vulnerability or a security-related issue, please email [cncf-apicurio-registry-security@lists.cncf.io](mailto:cncf-apicurio-registry-security@lists.cncf.io) with the details of the vulnerability.
-(Note: The mailing list address was corrected from `cncf-apicurio-registery-security` to `cncf-apicurio-registry-security`.)
-Do not report non-security-impacting issues through this channel.
-Use [GitHub issues](https://github.com/Apicurio/apicurio-registry/issues) instead.
+There are two private reporting channels:
+
+1. **Preferred — GitHub Private Vulnerability Reporting.** On the
+   [Security tab](https://github.com/Apicurio/apicurio-registry/security/advisories), click
+   **"Report a vulnerability."** This opens a private advisory visible only to the
+   maintainers and you, and keeps the whole coordination — investigation, fix, CVE, and the
+   published advisory — in one place.
+2. **Alternative — email.** If you prefer email or don't have a GitHub account, write to
+   [cncf-apicurio-registry-security@lists.cncf.io](mailto:cncf-apicurio-registry-security@lists.cncf.io)
+   with the details.
+
+Please include as much detail as you can — affected version(s), configuration, and a
+minimal reproducer if possible. We follow coordinated disclosure, will keep you updated as
+we investigate, and are glad to credit you unless you'd prefer otherwise.
+
+For non-security issues, please use
+[GitHub issues](https://github.com/Apicurio/apicurio-registry/issues) instead.
 
 ## Supported Versions
 
-Depending on the severity of the CVE or other vulnerability, the project provides the fix either as a patch release of the current minor release or in the next minor release.
+Depending on the severity of the vulnerability, the project provides the fix either as a
+patch release of the current minor release or in the next minor release.
 
 ## Published Security Advisories
 
-Published security advisories are available on the [GitHub Security Advisories page](https://github.com/Apicurio/apicurio-registry/security/advisories).
+Published security advisories are available on the
+[GitHub Security Advisories page](https://github.com/Apicurio/apicurio-registry/security/advisories).


### PR DESCRIPTION
## What

Updates `SECURITY.md` to make **GitHub Private Vulnerability Reporting (PVR)** the preferred private reporting channel, with the CNCF security mailing list kept as the secondary channel.

## Why

PVR keeps the whole coordination flow — private report, discussion, fix, CVE request, and the published advisory — in one place on the repo, and gives reporters a first-class private path that doesn't depend on email. Private vulnerability reporting is now enabled on this repository, so the "Report a vulnerability" button on the Security tab is available.

## Changes

- Present two clearly ordered private channels: **1)** GitHub *Report a vulnerability* (preferred), **2)** `cncf-apicurio-registry-security@lists.cncf.io` (alternative).
- Ask reporters for affected versions, configuration, and a minimal reproducer; note that we follow coordinated disclosure and offer credit.
- Minor wording/formatting cleanup; removed a transient address-correction note.