### PR TITLE
fix(rest): clamp limit on the MCP compatible tools endpoint

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -792,11 +792,16 @@ public class WellKnownResourceImpl implements WellKnownResource {
         return true;
     }
 
+    /**
+     * Applies the requested pagination window to the compatible tools. The limit is clamped to the
+     * same maximum page size as the other well-known search endpoints, which also keeps
+     * {@code fromIndex + safeLimit} from overflowing when a very large limit is requested.
+     */
     private McpCompatibleToolsResults buildPaginatedCompatibleResults(List<McpToolSearchResult> compatibleTools,
             Integer offset, Integer limit) {
         int total = compatibleTools.size();
         int safeOffset = Math.max(0, offset);
-        int safeLimit = Math.max(1, limit);
+        int safeLimit = Math.max(1, Math.min(limit, 500));
         int fromIndex = Math.min(safeOffset, total);
         int toIndex = Math.min(fromIndex + safeLimit, total);
         List<McpToolSearchResult> page = compatibleTools.subList(fromIndex, toIndex);

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/mcptools/WellKnownMcpToolsTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/mcptools/WellKnownMcpToolsTest.java
@@ -426,6 +426,35 @@ public class WellKnownMcpToolsTest extends AbstractResourceTestBase {
             }
             """;
 
+    private static final String LARGE_LIMIT_SOURCE_TOOL = """
+            {
+                "name": "large_limit_source",
+                "title": "Large Limit Source Tool",
+                "description": "Produces unique large-limit output property",
+                "inputSchema": { "type": "object" },
+                "outputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "unique_large_limit_field": { "type": "string" }
+                    }
+                }
+            }
+            """;
+
+    private static final String LARGE_LIMIT_COMPATIBLE_TOOL = """
+            {
+                "name": "large_limit_compat",
+                "title": "Large Limit Compatible Tool",
+                "description": "Consumes unique large-limit output property",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "unique_large_limit_field": { "type": "string" }
+                    }
+                }
+            }
+            """;
+
     @Test
     public void testFindCompatibleToolsSuccess() throws Exception {
         String groupId = TestUtils.generateGroupId();
@@ -531,6 +560,42 @@ public class WellKnownMcpToolsTest extends AbstractResourceTestBase {
                 .statusCode(200)
                 .body("count", equalTo(2))
                 .body("tools", hasSize(0));
+    }
+
+    @Test
+    public void testFindCompatibleToolsLargeLimit() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String sourceId = "large-limit-source";
+
+        createMcpTool(groupId, sourceId, LARGE_LIMIT_SOURCE_TOOL);
+        createMcpTool(groupId, "large-limit-compat-1", LARGE_LIMIT_COMPATIBLE_TOOL);
+        createMcpTool(groupId, "large-limit-compat-2", LARGE_LIMIT_COMPATIBLE_TOOL);
+
+        // A limit larger than the maximum page size is clamped rather than applied literally,
+        // for every offset within the result set and for the offset just past its end.
+        assertCompatibleToolsPage(groupId, sourceId, 0, Integer.MAX_VALUE, 2);
+        assertCompatibleToolsPage(groupId, sourceId, 1, Integer.MAX_VALUE, 1);
+        assertCompatibleToolsPage(groupId, sourceId, 2, Integer.MAX_VALUE, 0);
+    }
+
+    /**
+     * Asserts that a compatible-tools request succeeds and returns the expected page. The total
+     * count stays at the two compatible tools created by the caller, independent of the window.
+     */
+    private void assertCompatibleToolsPage(String groupId, String sourceId, int offset, int limit,
+            int expectedToolsOnPage) {
+        givenAtRoot()
+                .when()
+                .contentType(CT_JSON)
+                .pathParam("groupId", groupId)
+                .pathParam("artifactId", sourceId)
+                .queryParam("offset", offset)
+                .queryParam("limit", limit)
+                .get("/.well-known/mcp-tools/{groupId}/{artifactId}/compatible")
+                .then()
+                .statusCode(200)
+                .body("count", equalTo(2))
+                .body("tools", hasSize(expectedToolsOnPage));
     }
 
     private void createMcpTool(String groupId, String artifactId, String content) throws Exception {


### PR DESCRIPTION
Closes #9908

## Summary

The MCP compatible tools endpoint (`GET /.well-known/mcp-tools/{groupId}/{artifactId}/compatible`) returns 500 when it is called with a large `limit` and an `offset` of 1 or more.

`buildPaginatedCompatibleResults` clamps the offset but not the limit:

```java
int safeLimit = Math.max(1, limit);
int fromIndex = Math.min(safeOffset, total);
int toIndex = Math.min(fromIndex + safeLimit, total);
List<McpToolSearchResult> page = compatibleTools.subList(fromIndex, toIndex);
```

`fromIndex + safeLimit` overflows to a negative value, so `subList` gets a negative end index and throws `IllegalArgumentException`. That exception is not registered in `HttpStatusCodeMap`, so `getCode` walks the superclass chain, finds no match and falls back to 500. `isIgnored` is backed by the same map, so the error is also reported to `ResponseErrorLivenessCheck`.

This PR clamps the limit to the same maximum page size the other well-known search endpoints already use.

### Why this shape of fix 

This is not a new opinion about how pagination should behave, it is the fix this project already made for the same defect. #8934 fixed exactly this in `getEntitledAgents`, in this same file:

```java
- int safeLimit = Math.max(0, limit);
+ int safeLimit = Math.max(0, Math.min(limit, 500));
```

The compatible tools endpoint was added afterwards, in #8847, with its own pagination block, and reintroduced the unclamped pattern. Every other pagination site in `WellKnownResourceImpl` caps at 500, and the identical `fromIndex + safeLimit` arithmetic used elsewhere is safe only because of that cap.

Because the candidate list is already bounded by `MAX_COMPATIBLE_CANDIDATE_SCAN`, bounding the limit makes the addition unable to overflow at all. It also removes the second problem in the same line: without the cap the endpoint had no upper bound on page size.

**Tests.** Added `testFindCompatibleToolsLargeLimit`, covering a large limit at an offset inside the result set, at its last element, and one past its end. Offsets 1 and 2 both returned 500 before this change. I confirmed it is a real regression test by reverting only the production change and rerunning it:

```
Expected status code <200> but was <500>.
java.lang.IllegalArgumentException: fromIndex(1) > toIndex(-2147483648)
    at java.util.ArrayList.subList(ArrayList.java:1190)
    at WellKnownResourceImpl.buildPaginatedCompatibleResults(WellKnownResourceImpl.java:802)
    at WellKnownResourceImpl.findCompatibleTools(WellKnownResourceImpl.java:631)
```

The test declares its own tool schemas with a unique property name rather than reusing the existing pagination fixtures. Compatible candidates are searched across all groups, so a shared property name changes the counts `testFindCompatibleToolsPagination` asserts. The existing fixtures use unique names for the same reason.

I kept the literal `500` to match the five sibling clamps in this file rather than introducing a constant, since extracting one would mean touching unrelated lines. Happy to do that as a separate cleanup if you would prefer it.

## Checklist

- [ ] Linked issue has maintainer approval
- [x] No overlapping open PRs for the same issue
- [x] Checked the [Tried & Rejected list](https://github.com/Apicurio/apicurio-registry/discussions/8364)
- [x] Tests added for new code paths
- [x] Tested locally: `./mvnw test -pl app -am -Dlocal`
- [x] `./mvnw checkstyle:check -pl app` passes
- [x] All commits have DCO sign-off (`git commit -s`)

Notes on the checklist:

- Maintainer approval is left unchecked because I opened #9908 just a few mniutes ago. This is a bug fix that reapplies the clamp already merged in #8934 rather than new behaviour, so I opened the PR alongside the issue.