### PR TITLE
Fix/9905 parent version

### DIFF
--- a/perf-comparison-tests/pom.xml
+++ b/perf-comparison-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.apicurio</groupId>
     <artifactId>apicurio-registry</artifactId>
-    <version>3.3.2-SNAPSHOT</version>
+    <version>3.3.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>apicurio-registry-perf-comparison-tests</artifactId>

--- a/perf-tests/pom.xml
+++ b/perf-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.apicurio</groupId>
     <artifactId>apicurio-registry</artifactId>
-    <version>3.3.2-SNAPSHOT</version>
+    <version>3.3.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
Part of #9858

## What does this PR do?

Hardens the product-neutral performance comparison harness so runs with different Registry replica counts cannot be aggregated as comparable results.

## Changes

- Record the actual Registry replica count in `deployment-metadata.json`.
- Handle both Deployment-backed products and Redpanda's StatefulSet.
- Include replica count in the comparator's run-comparability key.
- Add regression coverage for both matching and mismatched replica counts.

## Validation

- `bash -n perf-comparison-tests/k8s/run-product.sh`
- `python3 -m unittest perf-comparison-tests/scripts/test_compare_results.py -v` — 4/4 passing
- `git diff --check` — clean

This is benchmark-harness work aligned with the performance credibility requirements in #9858. It does not duplicate the SQL sequence allocator implementation.