### PR TITLE
Remove unchecked generic varargs warning in unionOf #8905

### DIFF
--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/AbstractCompatibilityChecker.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/compatibility/AbstractCompatibilityChecker.java
@@ -109,11 +109,9 @@ public abstract class AbstractCompatibilityChecker<D extends CompatibilityDiffer
     protected abstract Set<D> isBackwardsCompatibleWith(String existing, String proposed,
             Map<String, TypedContent> resolvedReferences);
 
-    private Set<D> unionOf(Set<D>... from) {
-        Set<D> rval = new HashSet<>();
-        for (Set<D> f : from) {
-            rval.addAll(f);
-        }
+    private Set<D> unionOf(Set<D> first, Set<D> second) {
+        Set<D> rval = new HashSet<>(first);
+        rval.addAll(second);
         return rval;
     }
 


### PR DESCRIPTION
Closes #8905

## Summary

`unionOf` took `Set<D>...`, which creates a generic array and warns on every call. Both `FULL` / `FULL_TRANSITIVE` callers pass two sets, so I changed it to two arguments.

No behaviour change. `schema-util/common` compiles, checkstyle is clean, and `AbstractCompatibilityCheckerTest` still passes.

## Checklist

- [x] Linked issue has maintainer approval
- [x] No overlapping open PRs for the same issue
- [x] Checked the [Tried & Rejected list](https://github.com/Apicurio/apicurio-registry/discussions/8364)
- [ ] Tests added for new code paths
- [x] Tested locally: `./mvnw test -pl schema-util/common -am -Dlocal`
- [x] `./mvnw checkstyle:check -pl schema-util/common` passes
- [x] All commits have DCO sign-off (`git commit -s`)
