### PR TITLE
fix(perf-tests): align module parent versions

### DIFF
--- a/perf-comparison-tests/pom.xml
+++ b/perf-comparison-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.apicurio</groupId>
     <artifactId>apicurio-registry</artifactId>
-    <version>3.3.2-SNAPSHOT</version>
+    <version>3.3.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>apicurio-registry-perf-comparison-tests</artifactId>

--- a/perf-tests/pom.xml
+++ b/perf-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.apicurio</groupId>
     <artifactId>apicurio-registry</artifactId>
-    <version>3.3.2-SNAPSHOT</version>
+    <version>3.3.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
## What

- align the `perf-tests` parent version with the current root project version
- align the `perf-comparison-tests` parent version with the current root project version

## Why

Both opt-in modules still reference `3.3.2-SNAPSHOT`, while main is `3.3.3-SNAPSHOT`. Once the `perf-tests` profile activation was fixed, the post-merge performance workflow failed before compilation with:

```text
Non-resolvable parent POM for io.apicurio:apicurio-registry-perf-tests:3.3.2-SNAPSHOT
```

## Verification

- `./mvnw -q -Dfull -Pprod,perf-tests -pl app,distro/docker,operator,perf-tests -am validate -DskipTests -Dmaven.javadoc.skip -Daether.syncContext.named.factory=noop`
- `./mvnw -q -Pperf-comparison-tests -pl perf-comparison-tests validate -DskipTests -Daether.syncContext.named.factory=noop`
- `git diff --check`

Fixes #9905.

The same correction was independently contributed in #9918. This maintainer PR is being used because that fork-authored PR remains a draft and GitHub does not permit maintainers to mark it ready, while `perf-main` is failing on every push to `main`. Credit to @sakethalladaaa for the matching fix.
