### PR TITLE
test(perf): record replica count for comparable runs

### DIFF
--- a/perf-comparison-tests/k8s/run-product.sh
+++ b/perf-comparison-tests/k8s/run-product.sh
@@ -138,6 +138,12 @@ fi
 POD="$(kubectl get pod -n "$NAMESPACE" -l app=schema-registry -o jsonpath='{.items[0].metadata.name}')"
 IMAGE="$(kubectl get pod -n "$NAMESPACE" "$POD" -o jsonpath='{.spec.containers[0].image}')"
 IMAGE_ID="$(kubectl get pod -n "$NAMESPACE" "$POD" -o jsonpath='{.status.containerStatuses[0].imageID}')"
+REPLICAS=""
+if [[ "$PRODUCT" == redpanda ]]; then
+    REPLICAS="$(kubectl get statefulset -n "$NAMESPACE" schema-registry -o jsonpath='{.spec.replicas}')"
+else
+    REPLICAS="$(kubectl get deployment -n "$NAMESPACE" schema-registry -o jsonpath='{.spec.replicas}')"
+fi
 PROXY_IMAGE_ID="$(kubectl get pod -n "$NAMESPACE" -l app=benchmark-proxy -o jsonpath='{.items[0].status.containerStatuses[0].imageID}')"
 KAFKA_IMAGE_ID=""
 if [[ "$PRODUCT" != redpanda ]]; then
@@ -147,14 +153,14 @@ NODE_CAPACITY="$(kubectl get node -o json | python3 -c 'import json,sys; n=json.
 HOST="$(uname -a)" JAVA_VERSION="$(java -version 2>&1 | head -1)" \
 PRODUCT="$PRODUCT" OPERATION="$OPERATION" NAMESPACE="$NAMESPACE" URL="$URL" USERS="$USERS" \
 WARMUP="$WARMUP" DURATION="$DURATION" SEEDS="$SEEDS" IMAGE="$IMAGE" IMAGE_ID="$IMAGE_ID" \
-PROXY_IMAGE_ID="$PROXY_IMAGE_ID" KAFKA_IMAGE_ID="$KAFKA_IMAGE_ID" NODE_CAPACITY="$NODE_CAPACITY" \
+REPLICAS="$REPLICAS" PROXY_IMAGE_ID="$PROXY_IMAGE_ID" KAFKA_IMAGE_ID="$KAFKA_IMAGE_ID" NODE_CAPACITY="$NODE_CAPACITY" \
 python3 - <<'PY' > "$OUTPUT_DIR/deployment-metadata.json"
 import json
 import os
 
-keys = ["PRODUCT", "OPERATION", "NAMESPACE", "URL", "USERS", "WARMUP", "DURATION", "SEEDS", "IMAGE", "IMAGE_ID", "PROXY_IMAGE_ID", "KAFKA_IMAGE_ID", "HOST", "JAVA_VERSION"]
+keys = ["PRODUCT", "OPERATION", "NAMESPACE", "URL", "USERS", "WARMUP", "DURATION", "SEEDS", "IMAGE", "IMAGE_ID", "REPLICAS", "PROXY_IMAGE_ID", "KAFKA_IMAGE_ID", "HOST", "JAVA_VERSION"]
 data = {key.lower(): os.environ[key] for key in keys}
-for key in ["users", "warmup", "duration", "seeds"]:
+for key in ["users", "warmup", "duration", "seeds", "replicas"]:
     data[key] = int(data[key])
 data["nodecapacity"] = json.loads(os.environ["NODE_CAPACITY"])
 print(json.dumps(data, indent=2))

--- a/perf-comparison-tests/scripts/compare-results.py
+++ b/perf-comparison-tests/scripts/compare-results.py
@@ -75,7 +75,7 @@ def main():
     lines = ["# Product-neutral schema registry comparison", "", "| Operation | Product | Runs | Median successful measured-window RPS (95% CI) | Median p99 ms (95% CI) | Median p99.9 ms | Median failures |", "| --- | --- | ---: | ---: | ---: | ---: | ---: |"]
     for operation, product in sorted({(run["operation"], run["product"]) for run in runs}):
         group = [run for run in runs if run["operation"] == operation and run["product"] == product]
-        comparable = {(run["users"], run["warmup"], run["duration"], run["seeds"]) for run in group}
+        comparable = {(run["users"], run["warmup"], run["duration"], run["seeds"], run["replicas"]) for run in group}
         if len(comparable) != 1:
             raise ValueError(f"Incomparable run parameters for {operation}/{product}: {sorted(comparable)}")
         rps = [run["rps"] for run in group]

--- a/perf-comparison-tests/scripts/test_compare_results.py
+++ b/perf-comparison-tests/scripts/test_compare_results.py
@@ -50,6 +50,68 @@ var stats = {
             self.assertEqual(900000, result["ok"])
             self.assertEqual(2, result["ko"])
 
+    def write_comparison_run(self, root, repetition, replicas):
+        run_dir = root / f"repetition-{repetition}" / "apicurio"
+        stats_path = run_dir / "gatling" / "simulation" / "js" / "stats.js"
+        stats_path.parent.mkdir(parents=True)
+
+        (run_dir / "deployment-metadata.json").write_text(json.dumps({
+            "product": "apicurio",
+            "operation": "READ_ID",
+            "users": 100,
+            "warmup": 60,
+            "duration": 180,
+            "seeds": 1000,
+            "replicas": replicas
+        }))
+
+        stats_path.write_text("""
+var stats = {
+    contents: {
+        measured: {
+            type: "REQUEST", name: "Measured READ_ID",
+            stats: {
+                "numberOfRequests": {"total": "10", "ok": "10", "ko": "0"},
+                "meanResponseTime": {"total": "10", "ok": "10", "ko": "0"},
+                "percentiles1": {"total": "8", "ok": "8", "ko": "0"},
+                "percentiles2": {"total": "12", "ok": "12", "ko": "0"},
+                "percentiles3": {"total": "20", "ok": "20", "ko": "0"},
+                "percentiles4": {"total": "25", "ok": "25", "ko": "0"}
+            }
+        }
+    }
+}
+""")
+
+    def run_comparison(self, root):
+        original_argv = COMPARE_RESULTS.sys.argv
+        try:
+            COMPARE_RESULTS.sys.argv = [
+                "compare-results.py",
+                str(root),
+                str(root / "comparison")
+            ]
+            return COMPARE_RESULTS.main()
+        finally:
+            COMPARE_RESULTS.sys.argv = original_argv
+
+    def test_rejects_incomparable_replica_counts(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            self.write_comparison_run(root, 1, 1)
+            self.write_comparison_run(root, 2, 2)
+
+            with self.assertRaisesRegex(ValueError, "Incomparable run parameters"):
+                self.run_comparison(root)
+
+    def test_accepts_matching_replica_counts(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            self.write_comparison_run(root, 1, 2)
+            self.write_comparison_run(root, 2, 2)
+
+            self.assertIsNone(self.run_comparison(root))
+
     def test_rejects_invalid_measured_duration(self):
         with tempfile.TemporaryDirectory() as directory:
             run_dir = pathlib.Path(directory) / "run-1"


### PR DESCRIPTION
Part of #9858
## Summary

Hardens the product-neutral performance comparison harness so runs with different Registry replica counts cannot be aggregated as comparable results.

## Changes

- Record the actual Registry replica count in `deployment-metadata.json`.
- Handle both Deployment-backed products and Redpanda's StatefulSet.
- Include replica count in the comparator's run-comparability key.
- Add regression coverage for both matching and mismatched replica counts.

## Validation

- `bash -n perf-comparison-tests/k8s/run-product.sh`
- `python3 -m unittest perf-comparison-tests/scripts/test_compare_results.py -v` — 4/4 passing
- `git diff --check` — clean

This is benchmark-harness work aligned with the performance credibility requirements in #9858. It does not duplicate the SQL sequence allocator implementation.

## Checklist

- [x] Issue referenced
- [x] Tests added for the new code path
- [x] Local validation completed
- [x] Commit has DCO sign-off