### PR TITLE
fix(config): run experimental features validation at startup

### DIFF
--- a/app/src/main/java/io/apicurio/registry/config/ExperimentalFeaturesConfig.java
+++ b/app/src/main/java/io/apicurio/registry/config/ExperimentalFeaturesConfig.java
@@ -3,6 +3,7 @@ package io.apicurio.registry.config;
 import io.apicurio.common.apps.config.ExperimentalConfigPropertyDef;
 import io.apicurio.common.apps.config.ExperimentalConfigPropertyList;
 import io.apicurio.common.apps.config.Info;
+import io.quarkus.runtime.Startup;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -25,6 +26,7 @@ import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_SYS
  * features (e.g., GitOps storage variant) require special checks below.</p>
  */
 @Singleton
+@Startup
 public class ExperimentalFeaturesConfig {
 
     @Inject

--- a/app/src/test/java/io/apicurio/registry/config/ExperimentalFeaturesConfigTest.java
+++ b/app/src/test/java/io/apicurio/registry/config/ExperimentalFeaturesConfigTest.java
@@ -1,0 +1,89 @@
+package io.apicurio.registry.config;
+
+import io.apicurio.common.apps.config.ExperimentalConfigPropertyDef;
+import io.apicurio.common.apps.config.ExperimentalConfigPropertyList;
+import io.quarkus.runtime.Startup;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link ExperimentalFeaturesConfig}.
+ */
+public class ExperimentalFeaturesConfigTest {
+
+    private static ExperimentalFeaturesConfig configWith(boolean gateEnabled,
+            List<ExperimentalConfigPropertyDef> experimentalProperties, Map<String, String> properties) {
+        ExperimentalFeaturesConfig config = new ExperimentalFeaturesConfig();
+        config.log = LoggerFactory.getLogger(ExperimentalFeaturesConfigTest.class);
+        config.config = new SmallRyeConfigBuilder().withDefaultValues(properties).build();
+        config.experimentalProperties = new ExperimentalConfigPropertyList(experimentalProperties);
+        config.experimentalFeaturesEnabled = gateEnabled;
+        return config;
+    }
+
+    /**
+     * The gate is only useful if it is actually evaluated during startup. {@code validate()} is a
+     * {@code @PostConstruct} callback, and CDI only runs it once the bean is instantiated. Nothing injects
+     * this bean, so without {@code @Startup} it is never created and the whole gate is inert (#9630).
+     */
+    @Test
+    void testValidationIsWiredToStartup() {
+        assertTrue(ExperimentalFeaturesConfig.class.isAnnotationPresent(Startup.class),
+                "ExperimentalFeaturesConfig must be annotated with @Startup; nothing injects it, so without "
+                        + "eager instantiation @PostConstruct validate() never runs and the gate is inert.");
+    }
+
+    @Test
+    void testGitopsStorageRejectedWhenGateDisabled() {
+        ExperimentalFeaturesConfig config = configWith(false, List.of(),
+                Map.of("apicurio.storage.kind", "gitops"));
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class, config::validate);
+        assertTrue(thrown.getMessage().contains("apicurio.storage.kind=gitops"), thrown.getMessage());
+    }
+
+    @Test
+    void testKubernetesOpsStorageRejectedWhenGateDisabled() {
+        ExperimentalFeaturesConfig config = configWith(false, List.of(),
+                Map.of("apicurio.storage.kind", "kubernetesops"));
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class, config::validate);
+        assertTrue(thrown.getMessage().contains("apicurio.storage.kind=kubernetesops"), thrown.getMessage());
+    }
+
+    @Test
+    void testExperimentalTogglePropertyRejectedWhenGateDisabled() {
+        ExperimentalFeaturesConfig config = configWith(false,
+                List.of(new ExperimentalConfigPropertyDef("apicurio.iceberg.enabled", "Iceberg support")),
+                Map.of("apicurio.iceberg.enabled", "true"));
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class, config::validate);
+        assertTrue(thrown.getMessage().contains("apicurio.iceberg.enabled"), thrown.getMessage());
+    }
+
+    @Test
+    void testExperimentalFeaturesAllowedWhenGateEnabled() {
+        ExperimentalFeaturesConfig config = configWith(true,
+                List.of(new ExperimentalConfigPropertyDef("apicurio.iceberg.enabled", "Iceberg support")),
+                Map.of("apicurio.storage.kind", "gitops", "apicurio.iceberg.enabled", "true"));
+
+        assertDoesNotThrow(config::validate);
+    }
+
+    @Test
+    void testDefaultConfigurationIsAccepted() {
+        ExperimentalFeaturesConfig config = configWith(false,
+                List.of(new ExperimentalConfigPropertyDef("apicurio.iceberg.enabled", "Iceberg support")),
+                Map.of("apicurio.storage.kind", "sql", "apicurio.iceberg.enabled", "false"));
+
+        assertDoesNotThrow(config::validate);
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/storage/util/KubernetesOpsTestProfile.java
+++ b/app/src/test/java/io/apicurio/registry/storage/util/KubernetesOpsTestProfile.java
@@ -12,7 +12,8 @@ public class KubernetesOpsTestProfile implements QuarkusTestProfile {
     public Map<String, String> getConfigOverrides() {
         return Map.of(
                 "apicurio.storage.sql.kind", "h2",
-                "apicurio.storage.kind", "kubernetesops"
+                "apicurio.storage.kind", "kubernetesops",
+                "apicurio.features.experimental.enabled", "true"
         );
     }
 


### PR DESCRIPTION
## Problem

`ExperimentalFeaturesConfig` implements the global experimental features gate: its `@PostConstruct validate()` throws an `IllegalStateException` at startup if any experimental feature is enabled while `apicurio.features.experimental.enabled` is `false`.

That validation never runs.

The bean is a `@Singleton`, and CDI only instantiates a `@Singleton` when something injects it. Nothing does:

```
$ grep -rn "ExperimentalFeaturesConfig" --include="*.java" . | grep -v ExperimentalFeaturesConfig.java
(no results)
```

No injection point, no instance, no `@PostConstruct`. The gate is inert, so `gitops` / `kubernetesops` storage and every `@Info(experimental = true)` property can be enabled without the gate being set — which is what #9630 reports, and why the GitOps guide in #9186 had to stop documenting the startup failure.

## Root cause

`@Singleton` beans are lazily instantiated. The validation logic is correct; it is simply never reached.

## Solution

Add `@Startup` so the bean is created eagerly during boot. This matches the existing pattern in `DynamicConfigStartup` (same `config` package), and four other beans in `app` already use `@Startup` this way.

```java
 @Singleton
+@Startup
 public class ExperimentalFeaturesConfig {
```

## Second half of the fix

Once the gate actually runs, `KubernetesOpsTestProfile` fails at startup — it sets `apicurio.storage.kind=kubernetesops` without enabling the gate, and only passed because validation never ran:

```
Caused by: java.lang.IllegalStateException: The following experimental features are enabled but the
experimental features gate ('apicurio.features.experimental.enabled') is not enabled. ...
apicurio.storage.kind=kubernetesops (KubernetesOps storage)
```

Every sibling profile that enables an experimental feature already sets the gate — `GitopsTestProfile`, `GitopsMultiRepoTestProfile`, `McpToolsEnabledProfile`, `IcebergExperimentalFeaturesProfile`, `ElasticsearchSearchTestProfile`, `UsageTelemetryTest`. This aligns `KubernetesOpsTestProfile` with them.

I checked the other direction too: every experimental toggle in the default `application.properties` is `false` and the gate itself defaults to `false`, so default startup is unaffected.

## Testing

New `ExperimentalFeaturesConfigTest` (plain unit test, no Quarkus boot — follows `FileBasedSecretsInterceptorTest` in the same package):

- gitops storage rejected when the gate is disabled
- kubernetesops storage rejected when the gate is disabled
- a boolean `@Info(experimental = true)` property rejected when the gate is disabled
- experimental features allowed when the gate is enabled
- default configuration accepted
- **`testValidationIsWiredToStartup`** — the regression guard for this issue

```
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
```

The four `kubernetesops` tests also pass with the profile change:

```
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
KubernetesOpsReferencesTest, KubernetesOpsSmokeTest,
KubernetesOpsYamlPreservationTest, KubernetesWatchTest
```

I verified the guard actually guards — with `@Startup` removed (file byte-identical to `main`), the suite fails with exactly one failure:

```
testValidationIsWiredToStartup <<< FAILURE!
AssertionFailedError: ExperimentalFeaturesConfig must be annotated with @Startup; nothing
injects it, so without eager instantiation @PostConstruct validate() never runs and the
gate is inert. ==> expected: <true> but was: <false>
```

## Open question for reviewers

The issue suggests "a regression test that boots with an experimental feature enabled and the gate off, asserting startup failure". I could not find a way to assert a *startup failure* here — `@QuarkusTest` expects the application to come up, and `QuarkusUnitTest` / `quarkus-junit5-internal` is not a dependency of this project.

`testValidationIsWiredToStartup` asserts the `@Startup` annotation instead. That does catch the exact regression, but it is a weaker, more structural test than booting the app. If you would accept adding `quarkus-junit5-internal` as a test-scoped dependency, I am happy to replace it with a real startup-failure test in a follow-up commit — or to drop it if you would rather not assert on annotations.

Fixes #9630
