### PR TITLE
fix(ci): build operator controller for performance tests

### DIFF
--- a/.github/workflows/perf-main.yaml
+++ b/.github/workflows/perf-main.yaml
@@ -55,11 +55,11 @@ jobs:
           distribution: temurin
           cache: maven
 
-      # -Dfull: include the operator module needed for the operator image build.
+      # Select the controller explicitly because selecting the operator aggregator does not build its children.
       - name: Build app, operator, and perf-tests artifacts
         run: |
           ./mvnw -s ${{ github.workspace }}/.github/ci-settings.xml -B clean package -Dfull \
-            -pl app,distro/docker,operator,perf-tests -am -Pprod,perf-tests -DskipTests -Dmaven.javadoc.skip \
+            -pl app,distro/docker,operator/controller,perf-tests -am -Pprod,perf-tests -DskipTests -Dmaven.javadoc.skip \
             -Daether.syncContext.named.factory=noop
 
       - name: Build app image
@@ -224,4 +224,3 @@ jobs:
       job-name: "perf-test"
       job-status: "failure"
     secrets: inherit
-


### PR DESCRIPTION
## What

- select `operator/controller` instead of the `operator` aggregator in the performance workflow build
- clarify why the leaf module must be selected explicitly

## Why

Selecting an aggregator with Maven `-pl` does not include its children, and `-am` only adds required upstream projects. The workflow therefore completed its Maven step without creating `operator/controller/target`, then failed while building the operator image:

```text
ERROR: failed to build: unable to prepare context: path "controller/target" not found
```

## Clean Local Verification

From a fresh worktree at current main, the full CI build and all image builds completed successfully:

- `./mvnw -s .github/ci-settings.xml -B clean package -Dfull -pl app,distro/docker,operator/controller,perf-tests -am -Pprod,perf-tests -DskipTests -Dmaven.javadoc.skip -Daether.syncContext.named.factory=noop`
- Registry Docker image from `distro/docker/target/docker`
- Operator Docker image through `make IMAGE=local/perf-operator:test image-build` from `operator/`
- Performance runner Docker image from `perf-tests/`

The Maven reactor built 48 projects, including `Registry :: Operator :: Controller`.

Fixes #9957.
