### PR TITLE
fix(gitops): sanitize checkoutPath to prevent path traversal in dry-run validation

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GitOpsValidationTaskManager.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/gitops/GitOpsValidationTaskManager.java
@@ -230,8 +230,12 @@ public class GitOpsValidationTaskManager {
         taskState.setState(ValidationTaskStatus.VALIDATING);
         log.info("[validate:{}] Starting validation from checkout path", taskState.getTaskId());
 
-        Path checkoutPath = getCheckoutPath(taskState);
-        if (checkoutPath == null || !Files.exists(checkoutPath)) {
+        final Path checkoutPath = getCheckoutPath(taskState);
+        if (checkoutPath == null) {
+            failTask(taskState, "Invalid checkout path");
+            return;
+        }
+        if (!Files.exists(checkoutPath)) {
             failTask(taskState, "Checkout path does not exist: " + checkoutPath);
             return;
         }
@@ -460,7 +464,24 @@ public class GitOpsValidationTaskManager {
         if (taskState.getCheckoutPath() == null) {
             return null;
         }
-        return getValidateDir().resolve(taskState.getTaskId().value()).resolve(taskState.getCheckoutPath());
+
+        final Path taskDir = getValidateDir()
+                .resolve(taskState.getTaskId().value())
+                .toAbsolutePath()
+                .normalize();
+
+        final Path resolved = taskDir
+                .resolve(taskState.getCheckoutPath())
+                .toAbsolutePath()
+                .normalize();
+
+        if (!resolved.startsWith(taskDir)) {
+            log.warn("Rejected checkout path escaping task directory: {}",
+                    taskState.getCheckoutPath());
+            return null;
+        }
+
+        return resolved;
     }
 
     private boolean cleanupFiles(ValidationTaskState taskState) {

--- a/app/src/test/java/io/apicurio/registry/storage/impl/gitops/GitOpsValidateTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/gitops/GitOpsValidateTest.java
@@ -7,6 +7,8 @@ import io.quarkus.test.junit.TestProfile;
 import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -18,8 +20,10 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 @QuarkusTest
 @TestProfile(GitopsTestProfile.class)
@@ -160,7 +164,7 @@ public class GitOpsValidateTest {
                     .get("/apis/registry/v3/admin/gitops/validate/" + taskId)
                     .then()
                     .extract().path("state").toString();
-            org.junit.jupiter.api.Assertions.assertNotEquals("pending", state);
+            assertNotEquals("pending", state);
         });
 
         // Simulate the sidecar: create a checkout from the test repo
@@ -213,7 +217,7 @@ public class GitOpsValidateTest {
                     .get("/apis/registry/v3/admin/gitops/validate/" + taskId)
                     .then()
                     .extract().path("state").toString();
-            org.junit.jupiter.api.Assertions.assertNotEquals("pending", state);
+            assertNotEquals("pending", state);
         });
 
         // Simulate the sidecar with invalid data
@@ -228,6 +232,54 @@ public class GitOpsValidateTest {
                     .body("state", equalTo("completed"))
                     .body("result", equalTo("failure"))
                     .body("errors", not(empty()));
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"../../../../etc", "/etc", "repo/../../etc"})
+    void validationRejectsMaliciousCheckoutPath(String maliciousPath) throws Exception {
+        final var testRepository = GitTestRepositoryManager.getTestRepository();
+        testRepository.load("git/smoke01");
+
+        await().atMost(Duration.ofSeconds(30)).untilAsserted(() -> {
+            given()
+                    .when()
+                    .get("/apis/registry/v3/admin/gitops/status")
+                    .then()
+                    .statusCode(200)
+                    .body("syncState", equalTo("IDLE"));
+        });
+
+        final var taskId = given()
+                .contentType("application/json")
+                .body("""
+                        {"type": "pull", "repoId": "default", "ref": "main"}
+                        """)
+                .when()
+                .post("/apis/registry/v3/admin/gitops/validate")
+                .then()
+                .statusCode(200)
+                .extract().path("taskId").toString();
+
+        await().atMost(Duration.ofSeconds(15)).untilAsserted(() -> {
+            final var state = given()
+                    .when()
+                    .get("/apis/registry/v3/admin/gitops/validate/" + taskId)
+                    .then()
+                    .extract().path("state").toString();
+            assertNotEquals("pending", state);
+        });
+
+        simulateSidecarFetchWithTraversalPath(taskId, maliciousPath);
+
+        await().atMost(Duration.ofSeconds(30)).untilAsserted(() -> {
+            given()
+                    .when()
+                    .get("/apis/registry/v3/admin/gitops/validate/" + taskId)
+                    .then()
+                    .statusCode(200)
+                    .body("state", equalTo("failed"))
+                    .body("errors.detail", hasItem("Invalid checkout path"));
         });
     }
 
@@ -254,6 +306,24 @@ public class GitOpsValidateTest {
         request.setStatus(ValidationRequest.Status.builder()
                 .state(SidecarState.FETCHED)
                 .checkoutPath("repo")
+                .completedAt(Instant.now().toString())
+                .build());
+        JsonObjectMapper.MAPPER.writerWithDefaultPrettyPrinter()
+                .writeValue(requestFile.toFile(), request);
+    }
+
+    /**
+     * Simulates a malicious sidecar writing a path-traversal checkoutPath to the request file.
+     */
+    private void simulateSidecarFetchWithTraversalPath(String taskId, String maliciousPath) throws Exception {
+        final var testRepository = GitTestRepositoryManager.getTestRepository();
+        final Path validateDir = Path.of(testRepository.getGitRepoUrl()).getParent().resolve("validate");
+
+        final Path requestFile = validateDir.resolve(taskId + ".json");
+        final var request = JsonObjectMapper.MAPPER.readValue(requestFile.toFile(), ValidationRequest.class);
+        request.setStatus(ValidationRequest.Status.builder()
+                .state(SidecarState.FETCHED)
+                .checkoutPath(maliciousPath)
                 .completedAt(Instant.now().toString())
                 .build());
         JsonObjectMapper.MAPPER.writerWithDefaultPrettyPrinter()


### PR DESCRIPTION
## Summary

Fixes #9625

`GitOpsValidationTaskManager#getCheckoutPath()` resolves the `checkoutPath` value from the sidecar status JSON without verifying that the resulting path stays inside the expected task directory. A malicious or malformed status file could use path traversal sequences (`../../../../etc`) or absolute paths (`/etc`) to escape the intended directory boundary.

### Changes

- **`getCheckoutPath()`** — Normalize both the task directory and resolved checkout path using `toAbsolutePath().normalize()`, then verify containment with `startsWith()`. Returns `null` and logs a warning if the path escapes.
- **`executeValidation()`** — Split the `null` check from the `Files.exists()` check to provide distinct error messages: `"Invalid checkout path"` for rejected traversal vs. `"Checkout path does not exist"` for genuinely missing paths.
- **Tests** — Added a `@ParameterizedTest` covering three attack vectors: relative traversal (`../../../../etc`), absolute path (`/etc`), and embedded traversal (`repo/../../etc`). Assertions verify the task fails with the specific error message `"Invalid checkout path"`.
- **Cleanup** — Replaced inline `org.junit.jupiter.api.Assertions.assertNotEquals(...)` with a static import in two pre-existing test methods.

## Test plan

- [ ] `./mvnw test-compile -pl :apicurio-registry-app -am -DskipTests` compiles cleanly
- [ ] `./mvnw checkstyle:check -pl :apicurio-registry-app` passes with 0 violations
- [ ] Run `GitOpsValidateTest` — all 8 tests pass (6 existing + 1 parameterized with 3 cases)
- [ ] Verify traversal paths (`../../../../etc`, `/etc`, `repo/../../etc`) result in `state=failed` with error `"Invalid checkout path"`
- [ ] Verify valid path (`"repo"`) still works via `validationSucceedsWithValidData`