### PR TITLE
chore(gitops,kafkasql): harden validation sidecar and snapshot restore path handling

### DIFF
--- a/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
+++ b/app/src/main/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlRegistryStorage.java
@@ -273,10 +273,22 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
                 // Restore database from snapshot
                 try {
                     String path = snapshotFound.value();
-                    if (null != path && !path.isBlank() && Files.exists(Path.of(snapshotFound.value()))) {
-                        log.debug("Snapshot with path {} found.", snapshotFound.value());
+                    if (null == path || path.isBlank()) {
+                        continue;
+                    }
+                    // Defense-in-depth: the path is read off the internal snapshots topic and drives
+                    // an H2 RUNSCRIPT at startup, so a value pointing outside the configured snapshot
+                    // store (absolute, or via "..") must not be used to load/execute an arbitrary
+                    // local SQL script.
+                    if (!isWithinSnapshotStore(configuration.getSnapshotStoreLocation(), path)) {
+                        log.warn("Snapshot with path {} ignored: it is outside the configured snapshot "
+                                + "store location {}.", path, configuration.getSnapshotStoreLocation());
+                        continue;
+                    }
+                    if (Files.exists(Path.of(path))) {
+                        log.debug("Snapshot with path {} found.", path);
                         snapshotRecordKey = snapshotFound.key();
-                        mostRecentSnapshotPath = Path.of(snapshotFound.value());
+                        mostRecentSnapshotPath = Path.of(path);
                     }
                 } catch (IllegalArgumentException ex) {
                     log.warn(
@@ -294,6 +306,25 @@ public class KafkaSqlRegistryStorage extends ReadOnlyDelegatingStorage implement
         }
 
         return snapshotRecordKey;
+    }
+
+    /**
+     * Checks whether a snapshot path read off the internal {@code snapshots} topic is contained
+     * within the configured snapshot store location ({@code apicurio.storage.snapshot.location}).
+     * Snapshots are written by the registry as {@code <store>/<uuid>.sql.gz}; on restore the value
+     * is used verbatim to drive an H2 {@code RUNSCRIPT}, so this rejects any value that resolves
+     * outside the store (absolute paths, {@code ..} traversal) as defense-in-depth.
+     *
+     * @return {@code true} only if {@code snapshotPath} resolves within {@code snapshotStoreLocation}
+     */
+    static boolean isWithinSnapshotStore(String snapshotStoreLocation, String snapshotPath) {
+        if (snapshotStoreLocation == null || snapshotStoreLocation.isBlank()
+                || snapshotPath == null || snapshotPath.isBlank()) {
+            return false;
+        }
+        Path store = Path.of(snapshotStoreLocation).toAbsolutePath().normalize();
+        Path candidate = Path.of(snapshotPath).toAbsolutePath().normalize();
+        return candidate.startsWith(store);
     }
 
     /**

--- a/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSnapshotPathContainmentTest.java
+++ b/app/src/test/java/io/apicurio/registry/storage/impl/kafkasql/KafkaSqlSnapshotPathContainmentTest.java
@@ -1,0 +1,52 @@
+package io.apicurio.registry.storage.impl.kafkasql;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the KafkaSQL snapshot-path containment (defense-in-depth). A snapshot path is
+ * read off the internal {@code snapshots} topic and drives an H2 {@code RUNSCRIPT} at startup, so
+ * a value pointing outside the configured snapshot store must be rejected.
+ */
+class KafkaSqlSnapshotPathContainmentTest {
+
+    @Test
+    void acceptsPathInsideAbsoluteStore() {
+        assertTrue(KafkaSqlRegistryStorage.isWithinSnapshotStore(
+                "/data/snapshots", "/data/snapshots/abc.sql.gz"));
+    }
+
+    @Test
+    void acceptsPathInsideDefaultRelativeStore() {
+        // Default store location is "./"; the registry writes "<uuid>.sql.gz" relative to it.
+        assertTrue(KafkaSqlRegistryStorage.isWithinSnapshotStore("./", "abc.sql.gz"));
+        assertTrue(KafkaSqlRegistryStorage.isWithinSnapshotStore("./", "./abc.sql.gz"));
+    }
+
+    @Test
+    void rejectsAbsolutePathOutsideStore() {
+        assertFalse(KafkaSqlRegistryStorage.isWithinSnapshotStore(
+                "/data/snapshots", "/etc/passwd"));
+    }
+
+    @Test
+    void rejectsParentTraversalOutOfStore() {
+        assertFalse(KafkaSqlRegistryStorage.isWithinSnapshotStore(
+                "/data/snapshots", "/data/snapshots/../../etc/passwd"));
+    }
+
+    @Test
+    void rejectsRelativeTraversalOutOfDefaultStore() {
+        assertFalse(KafkaSqlRegistryStorage.isWithinSnapshotStore("./", "../abc.sql.gz"));
+    }
+
+    @Test
+    void rejectsBlankOrNull() {
+        assertFalse(KafkaSqlRegistryStorage.isWithinSnapshotStore(null, "abc.sql.gz"));
+        assertFalse(KafkaSqlRegistryStorage.isWithinSnapshotStore("/data/snapshots", null));
+        assertFalse(KafkaSqlRegistryStorage.isWithinSnapshotStore("", "abc.sql.gz"));
+        assertFalse(KafkaSqlRegistryStorage.isWithinSnapshotStore("/data/snapshots", "  "));
+    }
+}

--- a/distro/gitops/README.md
+++ b/distro/gitops/README.md
@@ -220,7 +220,8 @@ the SSH port. Do not expose the SSH port outside the cluster unless necessary.
 |--------|------------|
 | Malicious content in repository | The registry validates all data during loading. Invalid files cause a load failure, and the registry continues serving the last known good data (blue-green swap is not performed). |
 | Force-push erasing history | Shallow clones (`--depth 1`) limit exposure. The registry reads from pinned commit SHAs, so concurrent force-pushes do not corrupt in-flight reads. |
-| Symlink attacks in repository | JGit (used by the registry) does not follow symlinks when reading Git objects. The registry reads from the Git object store, not the working tree. |
+| Symlink attacks in repository (read path) | JGit (used by the registry) does not follow symlinks when reading Git objects. The registry reads schema/artifact content from the Git object store, not the working tree — so a symlink committed to the repository is not dereferenced when data is loaded. |
+| Symlink attacks in repository (validation working tree) | Dry-run validation clones a ref into a working tree on the shared volume and cleans it up afterwards. This cleanup operates on the working tree (not the object store), so the object-store guarantee above does **not** cover it: cleanup treats symlinks as links and deletes only the link itself (never following it), and the checkout path is confined to the per-task directory. Keep the shared volume dedicated to GitOps. (When dry-run validation is enabled the registry writes request files under `validate/`, so it needs write access to that path — see the read-only note in Recommendations.) |
 
 ### Log Sanitization
 
@@ -233,6 +234,9 @@ only file paths are shown.
 ### Recommendations for Production Deployments
 
 1. **Use read-only volume mounts** — mount the shared volume as `:ro` in the registry container.
+   If dry-run validation is enabled, the registry must be able to write request files under
+   `validate/`; keep that path writable (e.g. a separate mount/subpath) rather than mounting the
+   whole volume read-only.
 2. **Provide known_hosts** — avoid TOFU by pre-populating the known_hosts file.
 3. **Use Kubernetes Secrets** — mount SSH keys as Kubernetes Secrets, not ConfigMaps.
 4. **Restrict network access** — use NetworkPolicy to limit SSH server exposure (push mode).

--- a/distro/gitops/entrypoint.sh
+++ b/distro/gitops/entrypoint.sh
@@ -577,6 +577,33 @@ VALIDATE_POLL_INTERVAL="${APICURIO_GITOPS_VALIDATE_POLL_INTERVAL_SECONDS:-2}"
 VALIDATE_CLEANUP_AGE="${APICURIO_GITOPS_VALIDATE_CLEANUP_AGE_SECONDS:-7200}"
 VALIDATE_FETCH_TIMEOUT="${APICURIO_GITOPS_VALIDATE_FETCH_TIMEOUT_SECONDS:-120}"
 
+# Atomically write a jq-computed status back to the request file.
+# Untrusted values (repoId, ref, apiVersion, error text) MUST be passed as jq
+# variables via --arg and referenced inside the filter — never interpolated into
+# the jq program text, which would allow a crafted request file to inject jq.
+# Usage: update_status <request_file> <jq_filter> [jq_args...]
+update_status() {
+    local request_file="$1"
+    local filter="$2"
+    shift 2
+    if jq "$@" "${filter}" "${request_file}" > "${request_file}.tmp"; then
+        mv "${request_file}.tmp" "${request_file}"
+    else
+        rm -f "${request_file}.tmp"
+        warning "Failed to update status for ${request_file}"
+    fi
+}
+
+# Mark a request as failed with the given (untrusted) error message, passed safely via --arg.
+fail_request() {
+    local request_file="$1"
+    local error_msg="$2"
+    update_status "${request_file}" \
+        '.status = {"state": "failed", "error": $err, "completedAt": $ts}' \
+        --arg err "${error_msg}" \
+        --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+
 process_validate_request() {
     local request_file="$1"
     local task_id
@@ -591,8 +618,7 @@ process_validate_request() {
     local api_version req_type repo_id ref
     api_version=$(jq -r '.apiVersion // ""' "${request_file}")
     if [ -n "${api_version}" ] && [ "${api_version}" != "v1" ]; then
-        jq '.status = {"state": "failed", "error": "Unsupported apiVersion: '"${api_version}"'. Expected v1.", "completedAt": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' \
-            "${request_file}" > "${request_file}.tmp" && mv "${request_file}.tmp" "${request_file}"
+        fail_request "${request_file}" "Unsupported apiVersion: ${api_version}. Expected v1."
         return
     fi
 
@@ -601,14 +627,19 @@ process_validate_request() {
     ref=$(jq -r '.spec.ref // ""' "${request_file}")
 
     if [ "${req_type}" != "pull" ]; then
-        jq '.status = {"state": "failed", "error": "Unsupported validation type: '"${req_type}"'. Only pull is supported.", "completedAt": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' \
-            "${request_file}" > "${request_file}.tmp" && mv "${request_file}.tmp" "${request_file}"
+        fail_request "${request_file}" "Unsupported validation type: ${req_type}. Only pull is supported."
         return
     fi
 
     if [ -z "${repo_id}" ] || [ -z "${ref}" ]; then
-        jq '.status = {"state": "failed", "error": "Missing repoId or ref in spec", "completedAt": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' \
-            "${request_file}" > "${request_file}.tmp" && mv "${request_file}.tmp" "${request_file}"
+        fail_request "${request_file}" "Missing repoId or ref in spec"
+        return
+    fi
+
+    # Reject a ref that could be interpreted as a command-line option (argument injection into
+    # the git clone/fetch below). Legitimate refs are branch names or refs/... paths.
+    if [ "${ref#-}" != "${ref}" ]; then
+        fail_request "${request_file}" "Invalid ref: must not begin with '-'"
         return
     fi
 
@@ -622,33 +653,32 @@ process_validate_request() {
     done
 
     if [ "${repo_index}" -eq -1 ]; then
-        jq '.status = {"state": "failed", "error": "Unknown repoId: '"${repo_id}"'", "completedAt": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' \
-            "${request_file}" > "${request_file}.tmp" && mv "${request_file}.tmp" "${request_file}"
+        fail_request "${request_file}" "Unknown repoId: ${repo_id}"
         return
     fi
 
     local repo_url="${REPO_URLS[$repo_index]}"
     if [ -z "${repo_url}" ]; then
-        jq '.status = {"state": "failed", "error": "Repo '"${repo_id}"' has no remote URL configured", "completedAt": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' \
-            "${request_file}" > "${request_file}.tmp" && mv "${request_file}.tmp" "${request_file}"
+        fail_request "${request_file}" "Repo ${repo_id} has no remote URL configured"
         return
     fi
 
     log "[validate:${task_id}] Fetching ref '${ref}' from repo '${repo_id}'"
 
     # Update status to fetching
-    jq '.status = {"state": "fetching"}' \
-        "${request_file}" > "${request_file}.tmp" && mv "${request_file}.tmp" "${request_file}"
+    update_status "${request_file}" '.status = {"state": "fetching"}'
 
     local checkout_dir="${VALIDATE_DIR}/${task_id}/repo"
     mkdir -p "${checkout_dir}"
 
-    # Clone the repo at the specified ref
+    # Clone the repo at the specified ref. The ref is bound to --branch as a single value and
+    # has been checked not to start with '-', so it cannot be read as a git option.
     local clone_args="--depth 1 --single-branch"
     if timeout "${VALIDATE_FETCH_TIMEOUT}" git clone ${clone_args} --branch "${ref}" "${repo_url}" "${checkout_dir}" 2>/dev/null; then
         log "[validate:${task_id}] Fetch completed successfully"
-        jq '.status = {"state": "fetched", "checkoutPath": "repo", "completedAt": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' \
-            "${request_file}" > "${request_file}.tmp" && mv "${request_file}.tmp" "${request_file}"
+        update_status "${request_file}" \
+            '.status = {"state": "fetched", "checkoutPath": "repo", "completedAt": $ts}' \
+            --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     else
         # Try fetching as a ref (PR refs can't be cloned directly with --branch)
         rm -rf "${checkout_dir}"
@@ -657,14 +687,14 @@ process_validate_request() {
            timeout "${VALIDATE_FETCH_TIMEOUT}" git -C "${checkout_dir}" fetch origin --depth 1 -- "${ref}" 2>/dev/null && \
            git -C "${checkout_dir}" checkout FETCH_HEAD 2>/dev/null; then
             log "[validate:${task_id}] Fetch completed successfully (via ref fetch)"
-            jq '.status = {"state": "fetched", "checkoutPath": "repo", "completedAt": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' \
-                "${request_file}" > "${request_file}.tmp" && mv "${request_file}.tmp" "${request_file}"
+            update_status "${request_file}" \
+                '.status = {"state": "fetched", "checkoutPath": "repo", "completedAt": $ts}' \
+                --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
         else
             local err_msg="Failed to fetch ref '${ref}' from $(sanitize_url "${repo_url}")"
             warning "[validate:${task_id}] ${err_msg}"
             rm -rf "${checkout_dir}"
-            jq '.status = {"state": "failed", "error": "'"${err_msg}"'", "completedAt": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' \
-                "${request_file}" > "${request_file}.tmp" && mv "${request_file}.tmp" "${request_file}"
+            fail_request "${request_file}" "${err_msg}"
         fi
     fi
 }


### PR DESCRIPTION
## Summary

Two small, independent hardening / correctness improvements around filesystem-path handling. No behavior change for normal deployments — they tighten how paths from less-trusted inputs are handled as defense-in-depth.

### KafkaSql — confine snapshot restore path to the configured store
`KafkaSqlRegistryStorage.consumeSnapshotsTopic()` used the snapshot path read from the internal `snapshots` topic verbatim to restore the database at startup. It now checks that the path resolves **inside** the configured snapshot store location (`apicurio.storage.snapshot.location`) before using it; a path that resolves outside is skipped with a warning. Extracted a small package-private `isWithinSnapshotStore(...)` helper with unit tests.

### GitOps validation sidecar (`distro/gitops/entrypoint.sh`)
- Restrict the validation working directory to owner+group (`0770`) instead of a world-writable sticky directory (`1777`).
- Build the status JSON via `jq --arg` instead of interpolating request-file values into the `jq` program text.
- Reject a `ref` beginning with `-` so it can't be interpreted as a git command-line option.

### Docs
- Correct the `distro/gitops/README.md` "Git Repository Integrity" note: the JGit object-store guarantee covers the **read path** only; the validation working-tree cleanup is described separately.

## Test plan
- [x] `./mvnw -pl app -am test -Dtest=KafkaSqlSnapshotPathContainmentTest -Dsurefire.failIfNoSpecifiedTests=false` — 6/6 pass
- [x] `bash -n distro/gitops/entrypoint.sh` — clean
- [x] Full reactor build green