### PR TITLE
test(olm): gate namespaced-permissions test and widen v1 installer role for cluster-scoped bundles

### DIFF
--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/OperatorTestExtension.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/OperatorTestExtension.java
@@ -70,6 +70,14 @@ public class OperatorTestExtension implements InvocationInterceptor, AfterTestEx
                 lastException = e;
             }
 
+            // A JUnit assumption failure is a deliberate skip, not a failure: don't retry it and
+            // don't rethrow it as a failure -- let it propagate so the test is reported as aborted.
+            // This lets @RetryTest methods gate themselves at runtime with assumeTrue(...) on state
+            // that is only knowable after @BeforeAll has run (e.g. what the installed bundle grants).
+            if (lastException instanceof org.opentest4j.TestAbortedException) {
+                throw lastException;
+            }
+
             if (attempt < totalAttempts) {
                 log.warn("========================================");
                 log.warn("RETRY {}/{} for test: {}", attempt + 1, totalAttempts, method.getName());

--- a/operator/olm-tests/src/test/deploy/olmv1/cluster-role.yaml
+++ b/operator/olm-tests/src/test/deploy/olmv1/cluster-role.yaml
@@ -99,28 +99,29 @@ rules:
       - list
       - watch
 
-  # Kept in sync with the operator's runtime permissions in
-  # controller/src/main/deploy/rbac/namespaced: cluster-role.yaml grants get/list/watch on the parent
-  # CR (informer discovery), role.yaml grants patch/update on the CR and its /status. There is no
-  # list/watch endpoint for /status, so it only carries patch/update here. The operator never creates
-  # or deletes the CR.
+  # Kept in sync with the operator's runtime permissions on the parent CR and its /status. OLM v1
+  # always installs AllNamespaces (cluster-scoped), so the resolved bundle carries the *cluster*
+  # overlay's ClusterRole (controller/src/main/deploy/rbac/cluster/cluster-role.yaml), which grants
+  # the full verb set on both apicurioregistries3 and apicurioregistries3/status -- not the narrower
+  # namespaced overlay. Under escalation prevention the installer SA can only create that ClusterRole
+  # if it holds every verb in it, so this must mirror the cluster overlay's grant, not the namespaced
+  # subset. A bundle whose CSV declares these verbs in clusterPermissions (i.e. one built from the
+  # cluster overlay) will otherwise be rejected: an installer holding only get/list/patch/update/watch
+  # on the CR and patch/update on /status cannot grant the bundle's create/delete on the CR or
+  # create/delete/get/list/watch on /status.
   - apiGroups:
       - registry.apicur.io
     resources:
       - apicurioregistries3
+      - apicurioregistries3/status
     verbs:
+      - create
+      - delete
       - get
       - list
       - patch
       - update
       - watch
-  - apiGroups:
-      - registry.apicur.io
-    resources:
-      - apicurioregistries3/status
-    verbs:
-      - patch
-      - update
 
   - apiGroups:
       - apps

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/NamespacedPermissionsOLMITTest.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/NamespacedPermissionsOLMITTest.java
@@ -6,9 +6,13 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static io.apicurio.registry.operator.Tags.OLM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Permission-boundary test for the OwnNamespace install mode: the default OperatorGroup targets the
@@ -36,6 +40,15 @@ import static org.awaitility.Awaitility.await;
  * assumption then aborted before the CRD was registered; {@code @RetryTest} retried the aborted test,
  * and {@code OLMITBase.afterEach()} 404'd trying to delete a CR of a type the cluster did not know
  * about yet, which surfaced as a real test failure instead of a clean skip.
+ * <p>
+ * Under OLM v0 the test additionally gates itself on whether the installed bundle actually carries the
+ * least-privilege split. A productized/cluster-tier bundle declares the workload verbs in
+ * {@code clusterPermissions}, so OLM promotes them to a ClusterRole and the OwnNamespace boundary this
+ * test asserts does not exist. That is detected at runtime (a namespace-scoped Role granting Deployment
+ * creation) and skipped with {@code assumeTrue}. Unlike the v1 pitfall above, this in-method assumption
+ * is safe: it runs on the v0 path where {@code @BeforeAll} has already completed the install
+ * synchronously (CRD registered, so {@code afterEach} cleanup succeeds), and {@code OperatorTestExtension}
+ * now treats assumption aborts as clean skips rather than retrying them as failures.
  */
 @QuarkusTest
 @Tag(OLM)
@@ -52,21 +65,33 @@ public class NamespacedPermissionsOLMITTest extends OLMITBase {
                     .getReadyReplicas()).isEqualTo(1);
         });
 
+        var serviceAccountUser = operatorServiceAccountUser();
+
+        // Allowed: creating a Deployment in the operator's own (target) namespace. Poll rather than
+        // asserting once: OLM may create the RoleBinding a moment after the operator Deployment reports
+        // ready, so the grant can converge slightly later. Once this holds, the operator's workload RBAC
+        // has been applied and we can reliably tell how it was scoped.
+        await().ignoreExceptions().untilAsserted(() -> assertThat(canCreateDeployment(serviceAccountUser, namespace))
+                .withFailMessage(
+                        "Operator ServiceAccount should be allowed to create Deployments in its target namespace '%s'",
+                        namespace)
+                .isTrue());
+
+        // Applicability gate: the OwnNamespace boundary only exists when the bundle carries the
+        // least-privilege split, i.e. grants workload verbs through a namespace-scoped Role. A bundle
+        // that declares those verbs in clusterPermissions instead promotes them to a ClusterRole and
+        // creates no such Role, so the negative assertion below would not hold. Detect the split by the
+        // presence of a namespaced Role granting Deployment creation -- checked only after the grant
+        // above has converged, so absence means "cluster-wide", not "not yet applied" -- and skip
+        // cleanly otherwise (OperatorTestExtension reports the abort as a skip, not a failure).
+        assumeTrue(namespacedWorkloadRoleExists(),
+                "Bundle grants workload RBAC cluster-wide (no least-privilege namespaced split); "
+                        + "the OwnNamespace boundary asserted here does not apply. Skipping.");
+
         // A namespace the operator does not target, so OLM creates no Role/RoleBinding there.
         var foreignNamespace = ITBase.calculateNamespace();
         ITBase.createNamespace(client, foreignNamespace);
         try {
-            var serviceAccountUser = operatorServiceAccountUser();
-
-            // Allowed: creating a Deployment in the operator's own (target) namespace. Poll rather
-            // than asserting once: OLM may create the RoleBinding a moment after the operator
-            // Deployment reports ready, so the grant can converge slightly later.
-            await().ignoreExceptions().untilAsserted(() -> assertThat(canCreateDeployment(serviceAccountUser, namespace))
-                    .withFailMessage(
-                            "Operator ServiceAccount should be allowed to create Deployments in its target namespace '%s'",
-                            namespace)
-                    .isTrue());
-
             // Forbidden: creating a Deployment in a namespace the operator does not target. This is
             // checked after the positive grant has converged above, so a false result here reflects
             // the least-privilege boundary rather than RBAC not yet being applied.
@@ -80,5 +105,23 @@ public class NamespacedPermissionsOLMITTest extends OLMITBase {
                 client.namespaces().withName(foreignNamespace).delete();
             }
         }
+    }
+
+    /**
+     * Whether a namespace-scoped Role in the operator's install namespace grants creation of
+     * Deployments -- how the least-privilege split scopes the operator's workload permissions. A bundle
+     * without the split promotes those verbs to a ClusterRole instead, so no such Role exists.
+     */
+    private boolean namespacedWorkloadRoleExists() {
+        return client.rbac().roles().inNamespace(namespace).list().getItems().stream()
+                .filter(r -> r.getRules() != null)
+                .flatMap(r -> r.getRules().stream())
+                .anyMatch(rule -> grants(rule.getApiGroups(), "apps", "*")
+                        && grants(rule.getResources(), "deployments", "*")
+                        && grants(rule.getVerbs(), "create", "*"));
+    }
+
+    private static boolean grants(List<String> values, String... wanted) {
+        return values != null && Arrays.stream(wanted).anyMatch(values::contains);
     }
 }


### PR DESCRIPTION
## What

Two independent OLM test-infrastructure fixes surfaced while validating the operator OLM tests
against a cluster-scoped (cluster-tier RBAC) bundle:

1. **Gate `NamespacedPermissionsOLMITTest` on the presence of the least-privilege split.**
2. **Widen the OLM v1 installer `ClusterRole`** so it can install a bundle whose CSV declares the
   CR verbs in `clusterPermissions`.

Kept as two commits so each can be reviewed on its own.

## Why

### 1. Namespaced-permissions test gating

`NamespacedPermissionsOLMITTest` asserts the OwnNamespace least-privilege boundary: the operator
ServiceAccount may create Deployments in its own namespace but **not** in a foreign one. That
boundary only exists when the bundle carries the least-privilege RBAC split — i.e. declares the
workload verbs in the CSV's `permissions` (which OLM turns into a namespace-scoped Role). A bundle
that declares those verbs in `clusterPermissions` instead has them promoted to a ClusterRole,
granting workload access cluster-wide, so the negative assertion cannot hold and the test fails
against such a bundle.

The fix detects the split **at runtime** — a namespace-scoped Role granting Deployment creation,
checked only *after* the positive own-namespace grant has converged, so absence means "cluster-wide"
rather than "not yet applied" — and skips via `assumeTrue` when it's absent. A split that is present
but leaking to foreign namespaces still fails the test, so coverage on split-carrying bundles is
unchanged.

Supporting change: `OperatorTestExtension` now treats a JUnit assumption abort
(`org.opentest4j.TestAbortedException`) as a clean skip instead of retrying it as a failure. Without
this, a `@RetryTest` method cannot gate itself on cluster state that is only knowable after
`@BeforeAll` has run (the interceptor caught the abort as a `Throwable`, retried it, and rethrew it
as a failure).

### 2. Installer ClusterRole verbs (OLM v1)

OLM v1 always installs AllNamespaces, so the resolved bundle carries the *cluster* overlay's
ClusterRole, which grants the full verb set on `apicurioregistries3` and `apicurioregistries3/status`.
Under RBAC escalation prevention the installer ServiceAccount can only create that ClusterRole if it
already holds every verb in it, so `olmv1/cluster-role.yaml` must mirror the cluster overlay's grant
rather than the narrower namespaced subset. A bundle declaring these verbs in `clusterPermissions` is
otherwise rejected at install time and the `ClusterExtension` never reaches `Installed: True`.

The installer role remains a superset of the operator's declared RBAC, so `RbacInstallerSyncTest`
still passes.

## Notes

- Both changes are test-only (`operator/olm-tests` and a test util in `operator/controller`); no
  product/runtime code or shipped bundle content is affected.
- Independent of #9731 (OLM v1 upgrade tests) — different files, no overlap.
