### PR TITLE
fix(ui): replace POSIX shell test in install-sdk with a node script

### DIFF
--- a/ui/.scripts/ensure-sdk-built.cjs
+++ b/ui/.scripts/ensure-sdk-built.cjs
@@ -1,0 +1,40 @@
+#! /usr/bin/env node
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+// Resolved from this script's location rather than the working directory, so
+// the check works regardless of where npm invokes it from.
+const SDK_DIR = path.resolve(__dirname, "../../typescript-sdk");
+
+// On a fresh clone the Kiota client has not been generated and the SDK has not
+// been built, so the UI cannot resolve its "@sdk/..." imports.  If any of these
+// are missing, generate and build before continuing.
+const REQUIRED_FILES = [
+    "lib/generated-client/models/index.ts",
+    "lib/generated-client/apicurioRegistryClient.ts",
+    "dist/main.js",
+    "dist/generated-client/models/index.d.ts",
+    "dist/generated-client/search/versions/index.d.ts"
+];
+
+const missing = REQUIRED_FILES.filter(file => !fs.existsSync(path.join(SDK_DIR, file)));
+
+if (missing.length === 0) {
+    console.info("typescript-sdk is already generated and built.  Nothing to do.");
+    process.exit(0);
+}
+
+console.info("-------------------------------------------------------");
+console.info("typescript-sdk is not built.  Missing:");
+missing.forEach(file => console.info(`   ${file}`));
+console.info("Generating sources and building.");
+console.info("-------------------------------------------------------");
+
+try {
+    execSync("npm run generate-sources", { cwd: SDK_DIR, stdio: "inherit" });
+    execSync("npm run build", { cwd: SDK_DIR, stdio: "inherit" });
+} catch (error) {
+    console.error("Failed to generate and build the typescript-sdk.");
+    process.exit(error.status || 1);
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "postinstall": "npm run install-sdk && npm run install-app && npm run install-docs && npm run install-editors",
-        "install-sdk": "cd ../typescript-sdk && npm install && if [ ! -f lib/generated-client/models/index.ts ] || [ ! -f lib/generated-client/apicurioRegistryClient.ts ] || [ ! -f dist/main.js ] || [ ! -f dist/generated-client/models/index.d.ts ] || [ ! -f dist/generated-client/search/versions/index.d.ts ]; then npm run generate-sources && npm run build; fi",
+        "install-sdk": "cd ../typescript-sdk && npm install && node ../ui/.scripts/ensure-sdk-built.cjs",
         "install-app": "cd ui-app && npm install",
         "install-docs": "cd ui-docs && npm install",
         "install-editors": "cd ui-editors && npm install",


### PR DESCRIPTION
Closes #9964

## Summary

`install-sdk` used `if [ ! -f ... ]; then ... fi`. npm runs lifecycle scripts through cmd.exe on Windows, which cannot parse that and aborts on the `!`, so `cd ui && npm install` failed on its first postinstall step. The UI dev environment could not be set up on Windows by following the README.

The check now lives in `ui/.scripts/ensure-sdk-built.cjs`, next to the existing `generate-version.cjs` and `package.cjs`. It does the same five `existsSync` checks and runs `generate-sources` then `build` only when one of those files is missing. `shelljs` is already a devDependency of `ui`, so this adds no new dependency.

This restores Windows without changing the fresh-clone behaviour #9466 added for #8975.

## Testing

Windows 11, PowerShell, node 22.22.3, npm 10.9.8, default script shell (cmd.exe):

- SDK already built: `npm run install-sdk` prints "typescript-sdk is already generated and built." and exits 0. Before this change the same command failed with `! was unexpected at this time.`
- SDK incomplete (renamed `typescript-sdk/dist/main.js` away): the script detects the missing file, runs kiota generate and the vite build, `dist/main.js` is regenerated, exits 0.

## Checklist

- [ ] Linked issue has maintainer approval. I opened #9964 today so it has not been triaged. Happy to hold this until someone confirms the approach.
- [x] No overlapping open PRs for the same issue
- [x] Checked the [Tried & Rejected list](https://github.com/Apicurio/apicurio-registry/discussions/8364)
- [ ] Tests added for new code paths. The sibling scripts in `ui/.scripts/` have no test coverage, so I did not add a harness uninvited. Happy to add one if you want it.
- [x] Tested locally, see Testing above
- [ ] `./mvnw checkstyle:check` not applicable, no Java changed
- [x] All commits have DCO sign-off (`git commit -s`)
