### PR TITLE
fix(perf-tests): restore Netty-compatible Gatling version

### DIFF
--- a/perf-comparison-tests/pom.xml
+++ b/perf-comparison-tests/pom.xml
@@ -12,7 +12,7 @@
   <description>Opt-in Confluent-compatible API benchmark for schema registry products.</description>
   <properties>
     <projectRoot>${project.basedir}/..</projectRoot>
-    <gatling.version>3.15.1</gatling.version>
+    <gatling.version>3.13.5</gatling.version>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <maven.source.skip>true</maven.source.skip>
   </properties>
@@ -42,6 +42,27 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-netty-4.1</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>io.netty:*:[4.2,)</exclude>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/perf-tests/pom.xml
+++ b/perf-tests/pom.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <projectRoot>${project.basedir}/..</projectRoot>
-    <gatling.version>3.15.1</gatling.version>
+    <gatling.version>3.13.5</gatling.version>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <maven.source.skip>true</maven.source.skip>
   </properties>
@@ -69,6 +69,27 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-netty-4.1</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>io.netty:*:[4.2,)</exclude>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/renovate.json
+++ b/renovate.json
@@ -49,6 +49,17 @@
   ],
   "packageRules": [
     {
+      "description": "Keep fat-JAR runners on Netty 4.1-compatible Gatling until #9967 is resolved",
+      "matchFileNames": [
+        "perf-comparison-tests/pom.xml",
+        "perf-tests/pom.xml"
+      ],
+      "matchPackageNames": [
+        "io.gatling.highcharts:gatling-charts-highcharts"
+      ],
+      "allowedVersions": "3.13.5"
+    },
+    {
       "groupName": "Dependencies: Maven App: All",
       "matchFileNames": [
         "**/pom.xml"


### PR DESCRIPTION
## What

- restore Gatling 3.13.5 in both performance fat-JAR modules
- constrain Renovate from crossing the Netty 4.1/4.2 compatibility boundary automatically
- add Maven Enforcer rules that reject Netty 4.2+ in these mixed Gatling/Registry client classpaths

## Why

Renovate upgraded Gatling from 3.13.5 to 3.15.1. Gatling 3.15.1 requires Netty 4.2.14, while Registry's Vert.x SDK and root dependency management use Netty 4.1.136. The assembled runner therefore mixed incompatible Netty APIs and failed before load generation:

```text
java.lang.NoClassDefFoundError: io/netty/channel/IoHandle
    at io.gatling.netty.util.Transports.<clinit>(Transports.java:60)
```

Gatling 3.13.5 uses Netty 4.1 and resolves consistently with the Registry client dependencies. The pin can be removed when Registry moves to a compatible Netty 4.2 stack or the runner classpaths are isolated/shaded.

## Clean Local Verification

- exact current `perf-main` 48-module `clean package` command passed
- both performance modules built cleanly with checkstyle
- both resolved Netty dependency trees contain only `4.1.136.Final`, with no Netty 4.2 artifacts
- both assembled fat JARs initialize Gatling and proceed to their deliberately unreachable HTTP setup checks
- the actual `perf-tests` Docker image entrypoint initializes Gatling and reaches OAuth setup instead of failing in `Transports`
- Maven Enforcer guards pass and will reject future Netty 4.2 drift before merge
- `renovate.json` parses successfully
- `./scripts/validate-files.sh` passes

Fixes #9967.
