### PR TITLE
ci(operator): include rolling channel on pull_request_review runs

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -63,7 +63,10 @@ jobs:
         working-directory: operator
         run: |
           ROLLING_CHANNEL_ARG=""
-          if [ "${{ github.ref_name }}" = "main" ] || [ "${{ github.base_ref }}" = "main" ]; then
+          # base_ref is empty on pull_request_review events; check the PR payload's base
+          # ref too so review-triggered runs still include the rolling (3.x) channel.
+          if [ "${{ github.ref_name }}" = "main" ] || [ "${{ github.base_ref }}" = "main" ] \
+             || [ "${{ github.event.pull_request.base.ref }}" = "main" ]; then
             ROLLING_CHANNEL_ARG="ROLLING_CHANNEL=3.x"
           fi
           make $ROLLING_CHANNEL_ARG bundle
@@ -72,7 +75,10 @@ jobs:
         working-directory: operator
         run: |
           ROLLING_CHANNEL_ARG=""
-          if [ "${{ github.ref_name }}" = "main" ] || [ "${{ github.base_ref }}" = "main" ]; then
+          # base_ref is empty on pull_request_review events; check the PR payload's base
+          # ref too so review-triggered runs still include the rolling (3.x) channel.
+          if [ "${{ github.ref_name }}" = "main" ] || [ "${{ github.base_ref }}" = "main" ] \
+             || [ "${{ github.event.pull_request.base.ref }}" = "main" ]; then
             ROLLING_CHANNEL_ARG="ROLLING_CHANNEL=3.x"
           fi
           make $ROLLING_CHANNEL_ARG catalog


### PR DESCRIPTION
## What

Also check `github.event.pull_request.base.ref` in `operator.yaml`'s rolling-channel guard so
review-triggered runs build the catalog/bundle with the rolling `3.x` channel.

## Why

`verify.yaml` runs the operator test suite on `pull_request_review` events (added so that
submitting/dismissing a review re-evaluates the Decide gate). `operator.yaml` decides whether to
pass `ROLLING_CHANNEL=3.x` to `make bundle`/`make catalog` based on whether the run targets `main`:

```sh
if [ "${{ github.ref_name }}" = "main" ] || [ "${{ github.base_ref }}" = "main" ]; then
  ROLLING_CHANNEL_ARG="ROLLING_CHANNEL=3.x"
fi
```

On `pull_request_review` events **`github.base_ref` is empty** (it is only populated for
`pull_request`/`pull_request_target`), and `github.ref_name` is the PR merge ref, not `main`. So the
guard did not fire, the catalog/bundle were built with `--default-channel=3.3.x` (the minor channel)
instead of the rolling `3.x` channel, and `ChannelValidationOLMITTest.testDefaultChannel` — which
expects the default channel to be the rolling channel — failed deterministically on any
review-triggered run.

## Fix

Also check `github.event.pull_request.base.ref`, which **is** populated on `pull_request_review`
events, so review-triggered runs include the rolling channel just like `pull_request`-triggered runs.

## Notes

- CI-only. No change to tests, `catalog.template.yaml`, the `Makefile`, or `release-operator.yaml`
  (which has its own independent rolling-channel logic), so there is no impact on the release
  workflow.
