### PR TITLE
fix(perf-tests): bound external validation duration

### DIFF
--- a/.github/workflows/perf-main.yaml
+++ b/.github/workflows/perf-main.yaml
@@ -187,6 +187,8 @@ jobs:
       # attempt here isn't treated as a hard signal.
       - name: Run external high-concurrency read validation
         if: always()
+        continue-on-error: true
+        timeout-minutes: 10
         working-directory: perf-tests
         run: |
           JAR=$(find target -name 'apicurio-registry-perf-tests-*-jar-with-dependencies.jar' | head -1)

--- a/perf-tests/src/main/java/io/apicurio/registry/perftest/simulations/RegistryApiSimulation.java
+++ b/perf-tests/src/main/java/io/apicurio/registry/perftest/simulations/RegistryApiSimulation.java
@@ -359,8 +359,8 @@ public class RegistryApiSimulation extends Simulation {
         setUp(scn.injectClosed(rampConcurrentUsers(1).to(USERS).during(Duration.ofSeconds(RAMP_SECONDS)),
                 constantConcurrentUsers(USERS).during(Duration.ofSeconds(DURATION_SECONDS))))
                 .protocols(httpProtocol)
+                .maxDuration(Duration.ofSeconds(RAMP_SECONDS + DURATION_SECONDS + 120))
                 .assertions(global().failedRequests().percent().lte(1.0));
     }
 }
-
 


### PR DESCRIPTION
## What

- cap the Gatling simulation at ramp + measurement + two request-timeout windows
- cap the informational external validation step at 10 minutes
- keep that informational step non-gating so artifact collection can continue

## Why

Both storage variants now complete their in-cluster benchmark and upload valid results, but the external closed-user validation can spend an unbounded amount of time draining requests after injection stops. In run 33625934149, this consumed the remaining 84 minutes of the 90-minute matrix timeout and ended with exit code 143.

The existing `|| true` cannot contain a command that never returns before GitHub terminates the whole job.

## Verification

- Reproduced the exact external workload locally against a deployed topology: 200 clients, 180-second measurement, read-only.
- First run completed naturally in 244 seconds with a full Gatling report.
- Second run completed naturally in 255 seconds with a full Gatling report.
- The new Gatling maximum is 310 seconds, leaving 55 seconds beyond the slower observed run.
- The workflow's 10-minute step timeout remains an outer containment boundary for infrastructure or JVM failures.
- `./mvnw checkstyle:check -Pperf-tests -pl perf-tests -DskipTests -Daether.syncContext.named.factory=noop`
- Workflow YAML parsing, `git diff --check`, and `./scripts/validate-files.sh` pass.

Fixes #9979.
