### PR TITLE
fix(ci): unbreak main — restore image publishing and fix the OLM upgrade timeout

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -420,11 +420,28 @@ jobs:
 
   # ============================================================================
   # PUBLISH: Push images (only on push to main)
+  #
+  # always() is required, not cosmetic. gate runs under always() so that it can
+  # report on a run in which Decide legitimately skipped some of its needs
+  # (cli-verify and go-sdk-freshness are skipped on most pushes, by design).
+  # A skipped ancestor propagates "skipped" down to every descendant that does
+  # not opt out with always(), so without it this job is skipped on every push
+  # to main even when build-java and gate both succeed — which is exactly what
+  # happened between 2026-08-22 and 2026-09-03, leaving latest-snapshot stale
+  # on quay.io for twelve days and latest-snapshot-mutable never published at
+  # all. The explicit result checks below restore the safety property that the
+  # implicit success() was providing: publish only a commit that built cleanly
+  # and passed the Verification Gate.
   # ============================================================================
   publish:
     name: Publish Images
     needs: [build-java, gate]
-    if: github.event_name == 'push' && github.repository_owner == 'Apicurio'
+    if: >-
+      always()
+      && github.event_name == 'push'
+      && github.repository_owner == 'Apicurio'
+      && needs.build-java.result == 'success'
+      && needs.gate.result == 'success'
     uses: ./.github/workflows/verify-publish.yaml
     with:
       image-tag: ${{ github.sha }}

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogInfo.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/CatalogInfo.java
@@ -97,6 +97,28 @@ public class CatalogInfo {
     }
 
     /**
+     * Returns the number of replaces-chain hops OLM has to walk to get from the given entry up to
+     * the channel head, or -1 if the channel or the entry is not found. Entries are ordered
+     * head-first along the replaces chain, so this is simply the entry's index.
+     * <p>
+     * Callers use this to size upgrade timeouts: OLM installs one CSV per hop, and every hop costs
+     * a bundle-unpack Job (an image pull) plus an operator Deployment rollout, so a chain that
+     * grows by one release makes the whole upgrade measurably slower.
+     */
+    public int getHopsToHead(String channelName, String csvName) {
+        var entries = channels.get(channelName);
+        if (entries == null) {
+            return -1;
+        }
+        for (int i = 0; i < entries.size(); i++) {
+            if (entries.get(i).getCsvName().equals(csvName)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
      * Finds the channel with the highest minor version that is strictly less than the current version's
      * minor, excluding the rolling channel. Returns null if no such channel exists.
      */

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMITTest.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/UpgradeOLMITTest.java
@@ -46,8 +46,21 @@ public class UpgradeOLMITTest implements OperatorTestContext {
 
     private static final Logger log = LoggerFactory.getLogger(UpgradeOLMITTest.class);
 
+    // Budget for an upgrade that OLM can satisfy in a single step. Also the floor for
+    // multi-hop upgrades.
     private static final Duration UPGRADE_TIMEOUT = Duration.ofSeconds(
             Integer.getInteger("test.operator.timeout.olm-upgrade", 1200));
+
+    // Extra budget per additional replaces-chain hop. OLM walks the chain one CSV at a time and
+    // each hop costs a bundle-unpack Job (an image pull) plus an operator Deployment rollout, so
+    // a single fixed budget silently decays as releases accumulate in a channel: the 3.x
+    // cross-minor upgrade was 3.2.5 -> 3.3.1 (3 hops) when these tests were written and is
+    // 3.2.5 -> 3.3.3-snapshot (4 hops) today, which is what pushed it past the fixed 1200s and
+    // wedged CI mid-chain at "BundleUnpacking: UnpackingInProgress". Scaling by the hops the
+    // resolver actually has to walk keeps the assertion meaningful instead of turning it into a
+    // slow race against the release cadence.
+    private static final Duration UPGRADE_TIMEOUT_PER_HOP = Duration.ofSeconds(
+            Integer.getInteger("test.operator.timeout.olm-upgrade-per-hop", 300));
 
     private static final String SUBSCRIPTION_NAME = "apicurio-registry-operator-subscription";
 
@@ -232,16 +245,17 @@ public class UpgradeOLMITTest implements OperatorTestContext {
 
         var crossMinorEntry = catalog.getCrossMinorEntry(rollingChannel());
         var headVersion = catalog.getChannelHeadVersion(rollingChannel());
+        var hops = catalog.getHopsToHead(rollingChannel(), crossMinorEntry.getCsvName());
 
-        log.info("Testing upgrade via {} channel: {} -> {}",
-                rollingChannel(), crossMinorEntry.getVersion(), headVersion);
+        log.info("Testing upgrade via {} channel: {} -> {} ({} hops)",
+                rollingChannel(), crossMinorEntry.getVersion(), headVersion, hops);
 
         deployCatalogAndSubscribe(rollingChannel(), crossMinorEntry.getCsvName());
         waitForOperatorVersion(crossMinorEntry.getVersion());
 
         log.info("Operator {} deployed, waiting for upgrade to {}",
                 crossMinorEntry.getVersion(), headVersion);
-        verifyUpgradeTo(headVersion);
+        verifyUpgradeTo(headVersion, hops);
 
         verifyUpgradeCompleted(crossMinorEntry.getVersion(), headVersion);
 
@@ -544,8 +558,12 @@ public class UpgradeOLMITTest implements OperatorTestContext {
     }
 
     private void verifyUpgradeTo(Semver targetVersion) {
+        verifyUpgradeTo(targetVersion, 1);
+    }
+
+    private void verifyUpgradeTo(Semver targetVersion, int hops) {
         var name = deploymentName(targetVersion);
-        upgradeAwait().untilAsserted(() -> {
+        upgradeAwait(hops).untilAsserted(() -> {
             var deployment = client.apps().deployments().inNamespace(namespace)
                     .withName(name).get();
             assertThat(deployment)
@@ -585,7 +603,18 @@ public class UpgradeOLMITTest implements OperatorTestContext {
     //     of the startCSV -> install -> upgrade sequence: the resolver re-runs while the
     //     just-created CSV is not linked yet, and self-heals when the CSV succeeds.
     private ConditionFactory upgradeAwait() {
-        return await().atMost(UPGRADE_TIMEOUT).ignoreExceptions()
+        return upgradeAwait(1);
+    }
+
+    /**
+     * Awaitility factory budgeted for an upgrade spanning {@code hops} replaces-chain steps.
+     * Unknown hop counts (-1, entry not found in the channel) fall back to the single-hop budget.
+     */
+    private ConditionFactory upgradeAwait(int hops) {
+        var timeout = hops > 1
+                ? UPGRADE_TIMEOUT.plus(UPGRADE_TIMEOUT_PER_HOP.multipliedBy(hops - 1L))
+                : UPGRADE_TIMEOUT;
+        return await().atMost(timeout).ignoreExceptions()
                 .failFast("Subscription resolution failed", this::subscriptionResolutionFailed);
     }
 


### PR DESCRIPTION
Fixes #9984

Fixes the two independent failures currently red on `main`.

## 1. `Publish Images` has been skipped on every push to `main` since 2026-08-22

`publish` needs `gate`, and `gate` runs under `if: always()` so it can report on runs where Decide legitimately skipped some of its needs — `cli-verify` is skipped on *every* push to main, `go-sdk-freshness` on most. A skipped ancestor propagates `skipped` down to every descendant that does not opt out with `always()`, so `publish` was skipped even on fully green runs where `build-java` and `gate` both succeeded.

Evidence:

- Run 33603289434 (all jobs green): `gate` completed `08:31:05`, `Publish Images` evaluated `08:31:06` and recorded `skipped` with zero steps.
- Every push-to-main Verify run I checked back to 2026-08-28 shows the same, and in each one `CLI Verification` is skipped.
- `notify-slack` carries an identical `event_name`/`repository_owner` guard and *does* run — the only difference is that it has `always()`.
- All four publish secrets exist and are visible to this repo, so it is not a secrets problem.
- Bisect: run 32556385295 (Aug 22, 06:13) published normally. At that point `publish` did not depend on the gate — it in fact published while the gate was *failing*. #9758 correctly made publish depend on the gate, and that is when it stopped running.

Consequences: `quay.io/apicurio/apicurio-registry:latest-snapshot` has not been updated since 2026-08-22, `latest-snapshot-mutable` (added in #9900) was never published at all, and the scheduled Trivy Image Scan therefore fails with `MANIFEST_UNKNOWN`. The non-mutable Trivy scan has meanwhile been silently green while scanning a twelve-day-old image.

The fix adds `always()` and restates the two conditions the implicit `success()` was providing, so the safety property is unchanged: publish only a commit that built cleanly and passed the Verification Gate. No separate change is needed for the Trivy scan — it clears on the first green run after this merges.

## 2. `UpgradeOLMITTest.testUpgradeAcrossMinors` timeout

Not the catalog-endpoints race — that fix is already on main and `ChannelValidationOLMITTest` passes in the failing runs.

The `3.x` channel in `catalog.template.yaml` is a pure `replaces` chain with no `skipRange`, so OLM walks every intermediate CSV: today `3.2.5 -> 3.3.0 -> 3.3.1 -> 3.3.2 -> 3.3.3-snapshot`. Each hop costs a bundle-unpack Job (an image pull) plus an operator Deployment rollout. The budget was a flat 1200s for the whole walk.

In run 33672930845 it expired with `installedCSV: apicurio-registry-3.v3.3.1` and the 3.3.2 bundle still reporting `BundleUnpacking: UnpackingInProgress`. Not a stall — just not enough budget for the hops being walked.

This decays with every release: the walk was 3 hops when the test was written and is 4 now, which is why it passed on the morning of Sep 2 and failed that evening. `CatalogInfo.getHopsToHead()` returns the chain length (entries are stored head-first, so it is the entry's index) and the budget becomes 1200s + 300s per additional hop, both overridable via system property. The assertions are unchanged.

## Not included

Adding `skipRange` to the `3.x` head would cut the walk to a single hop and is arguably the real bug — a user on 3.2.5 also walks four CSV installs today. I left it out deliberately: `release-catalog-template-update` rebuilds the head entry as exactly `{name, replaces}` so it would need Makefile changes to survive a release, and collapsing four hops to one shrinks the window in which `waitForOperatorVersion(3.2.5)` can observe the intermediate deployment, which risks trading a understood timeout for a subtler race in `testUpgradeAcrossMinors` and `testChannelSwitchFromRollingToMinor`. Worth its own PR judged on CI evidence.

## Verification

- `test-compile` clean and `checkstyle:check` clean on `:apicurio-registry-operator-olm-tests` (needs `-Dfull` to be in the reactor).
- The workflow change is validated by CI itself: if `Publish Images` runs on merge, it worked.
- I confirmed the build artifact includes `distro/*/target/`, so `Dockerfile.mutable.jvm` is present and the mutable publish will succeed once unskipped.

