### PR TITLE
docs(a2a): fix stale endpoint docs and document AI Catalog / ARD

### DIFF
--- a/app/src/main/java/io/apicurio/registry/a2a/A2AConfig.java
+++ b/app/src/main/java/io/apicurio/registry/a2a/A2AConfig.java
@@ -64,14 +64,6 @@ public class A2AConfig {
     @Info(category = CATEGORY_A2A, description = "Whether the agent supports push notifications", availableSince = "3.0.0")
     boolean capabilitiesPushNotifications;
 
-    @ConfigProperty(name = "apicurio.a2a.public-discovery.enabled", defaultValue = "true")
-    @Info(category = CATEGORY_A2A, description = "Enable public (unauthenticated) agent discovery endpoint", availableSince = "3.0.0")
-    boolean publicDiscoveryEnabled;
-
-    @ConfigProperty(name = "apicurio.a2a.entitlements.enabled", defaultValue = "true")
-    @Info(category = CATEGORY_A2A, description = "Enable entitlement-based agent filtering", availableSince = "3.0.0")
-    boolean entitlementsEnabled;
-
     @ConfigProperty(name = "apicurio.a2a.default-visibility", defaultValue = "entitled")
     @Info(category = CATEGORY_A2A, description = "Default visibility for new Agent Card artifacts (public, entitled, private)", availableSince = "3.0.0")
     String defaultVisibility;
@@ -138,14 +130,6 @@ public class A2AConfig {
 
     public Optional<String> getIconUrl() {
         return iconUrl;
-    }
-
-    public boolean isPublicDiscoveryEnabled() {
-        return publicDiscoveryEnabled;
-    }
-
-    public boolean isEntitlementsEnabled() {
-        return entitlementsEnabled;
     }
 
     public String getDefaultVisibility() {

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -49,6 +49,7 @@ endif::[]
 ** xref:getting-started/assembly-mcp-tool-features.adoc[]
 ** xref:getting-started/assembly-mcp-server-integration.adoc[]
 ** xref:getting-started/assembly-agent-discovery-patterns.adoc[]
+** xref:getting-started/assembly-ai-catalog-ard.adoc[]
 ** xref:getting-started/assembly-llm-artifact-types-implementation.adoc[]
 * Confluent Schema Registry Compatibility
 ** xref:getting-started/assembly-confluent-schema-registry-compatibility.adoc[]

--- a/docs/modules/ROOT/pages/getting-started/assembly-a2a-features.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-a2a-features.adoc
@@ -226,75 +226,6 @@ Retrieves a specific registered Agent Card.
 +
 Response: Agent Card JSON document
 
-// ref-a2a-discovery-endpoints
-[id="a2a-discovery-endpoints_{context}"]
-== Agent discovery and entitlement endpoints
-
-:_mod-docs-content-type: REFERENCE
-
-[role="_abstract"]
-{registry} provides a three-tier agent discovery model for enterprise agent catalogs, based on the link:https://github.com/a2aproject/A2A/discussions/741[A2A community proposal].
-
-GET /.well-known/agents/public::
-Returns agents explicitly marked as public. No authentication required.
-+
-Only Agent Card artifacts labeled with `apicurio.agent.visibility=public` are returned.
-+
-*Query parameters*
-+
-* `offset` (integer) - Pagination offset (default: 0)
-* `limit` (integer) - Pagination limit (default: 20)
-+
-.Example request
-[source,bash]
-----
-curl "http://localhost:8080/.well-known/agents/public"
-----
-
-GET /.well-known/agents/entitled::
-Returns agents the authenticated caller is entitled to access, filtered by visibility:
-+
-* `public` agents are always included
-* `entitled` agents (default) are included for any authenticated user
-* `private` agents are included only for the artifact owner or admins
-+
-*Query parameters*
-+
-* `offset` (integer) - Pagination offset (default: 0)
-* `limit` (integer) - Pagination limit (default: 20)
-+
-.Example request
-[source,bash]
-----
-curl -H "Authorization: Bearer <token>" \
-  "http://localhost:8080/.well-known/agents/entitled"
-----
-
-POST /.well-known/agents/search::
-Advanced agent search with combined text query and structured filters. Respects the caller's entitlements when entitlement filtering is enabled.
-+
-.Example request body
-[source,json]
-----
-{
-  "query": "customer support",
-  "filters": {
-    "capabilities": { "streaming": true },
-    "skills": ["ticket-creation"],
-    "labels": { "department": "engineering" },
-    "inputModes": ["text"],
-    "outputModes": ["text"],
-    "protocolBindings": ["http+json"]
-  },
-  "limit": 20,
-  "offset": 0
-}
-----
-+
-All filter fields are optional. When multiple filters are specified, results must match all of them.
-+
-NOTE: The `query` field matches artifact metadata name and artifact ID, not Agent Card JSON content. Full-text content search is planned for a future release.
-
 // ref-a2a-visibility-model
 [id="a2a-visibility-model_{context}"]
 == Agent visibility model
@@ -302,7 +233,7 @@ NOTE: The `query` field matches artifact metadata name and artifact ID, not Agen
 :_mod-docs-content-type: REFERENCE
 
 [role="_abstract"]
-Agent Cards support three visibility levels, controlled by the `apicurio.agent.visibility` artifact label.
+Agent Cards support three visibility levels, controlled by the `apicurio.agent.visibility` artifact label. Visibility is enforced by `GET /.well-known/agents` (and by the ARD-shaped `GET /ard/agents` and `POST /ard/search`, described in xref:getting-started/assembly-ai-catalog-ard.adoc[AI Catalog and ARD discovery]) whenever authentication is enabled.
 
 .Agent visibility levels
 [cols="1,3"]
@@ -310,7 +241,7 @@ Agent Cards support three visibility levels, controlled by the `apicurio.agent.v
 |Visibility |Behavior
 
 |`public`
-|Visible to everyone, including unauthenticated clients via `/.well-known/agents/public`
+|Visible to everyone, including unauthenticated clients
 
 |`entitled`
 |Visible to any authenticated user (this is the default)
@@ -338,14 +269,6 @@ curl -X PUT "http://localhost:8080/apis/registry/v3/groups/my-agents/artifacts/m
 [cols="2,1,3"]
 |===
 |Property |Default |Description
-
-|`apicurio.a2a.public-discovery.enabled`
-|`true`
-|Enable the public (unauthenticated) agent discovery endpoint
-
-|`apicurio.a2a.entitlements.enabled`
-|`true`
-|Enable entitlement-based agent filtering
 
 |`apicurio.a2a.default-visibility`
 |`entitled`

--- a/docs/modules/ROOT/pages/getting-started/assembly-agent-discovery-patterns.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-agent-discovery-patterns.adoc
@@ -32,10 +32,6 @@ The following table lists all available well-known endpoints.
 |GET
 |Returns the agent card for this {registry} instance. Use this endpoint for standard A2A protocol discovery.
 
-|`/.well-known/a2a`
-|GET
-|Returns the agent card for this {registry} instance. As the canonical A2A v1.0 discovery endpoint, it returns the same response as `/.well-known/agent.json`.
-
 |`/.well-known/agent-card.json`
 |GET
 |Returns the agent card for this {registry} instance. This alias exists for compatibility with IBM watsonx Orchestrate, which discovers agents at this path by default. It returns the same response as `/.well-known/agent.json`.
@@ -59,15 +55,25 @@ The following table lists all available well-known endpoints.
 |`/.well-known/schemas/\{type}/\{version}`
 |GET
 |Returns the JSON schema for a specific LLM artifact type. Supported types are `prompt-template`, `model-schema`, and `mcp-tool`, each with version `v1`.
+
+|`/.well-known/ai-catalog.json`
+|GET
+|Returns an AI Catalog document (see xref:getting-started/assembly-ai-catalog-ard.adoc[AI Catalog and ARD discovery]) projecting registered `AGENT_CARD` and `MCP_TOOL` artifacts.
+
+|`/.well-known/ard.json`
+|GET
+|Returns the same document as `/.well-known/ai-catalog.json`, at the path mandated by the ARD (Agentic Resource Discovery) specification.
 |===
 
-The `/.well-known/agent.json` and `/.well-known/a2a` endpoints return the {registry} instance agent card, which represents the registry itself as an A2A agent. These endpoints require no authentication.
+The `/.well-known/agent.json` endpoint returns the {registry} instance agent card, which represents the registry itself as an A2A agent. This endpoint requires no authentication.
 
 The `/.well-known/agents` and `/.well-known/agents/\{groupId}/\{artifactId}` endpoints operate on agent cards that you store in {registry} as `AGENT_CARD` artifacts. These endpoints require read-level authorization.
 
 The `/.well-known/mcp-tools` and `/.well-known/mcp-tools/\{groupId}/\{artifactId}` endpoints operate on MCP tool definitions that you store in {registry} as `MCP_TOOL` artifacts. These endpoints require read-level authorization and are available only when MCP tools support is enabled.
 
 The `/.well-known/schemas/\{type}/\{version}` endpoint serves built-in JSON schemas that you can use for IDE autocompletion and validation of `PROMPT_TEMPLATE`, `MODEL_SCHEMA`, and `MCP_TOOL` artifacts. This endpoint requires no authentication.
+
+The `/.well-known/ai-catalog.json` and `/.well-known/ard.json` endpoints require no authentication for public entries; visibility labels apply the same way as for `/.well-known/agents`. See xref:getting-started/assembly-ai-catalog-ard.adoc[AI Catalog and ARD discovery] for the full ARD search API.
 
 [role="_additional-resources"]
 .Additional resources

--- a/docs/modules/ROOT/pages/getting-started/assembly-ai-catalog-ard.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-ai-catalog-ard.adoc
@@ -1,0 +1,208 @@
+include::{mod-loc}shared/all-attributes.adoc[]
+
+:dp-support-scope: link:https://access.redhat.com/support/offerings/devpreview[Developer Preview Support Scope]
+[id="assembly-ai-catalog-ard_{context}"]
+= AI Catalog and ARD discovery
+
+:_mod-docs-content-type: ASSEMBLY
+
+[role="_abstract"]
+{registry} can publish a spec-compliant AI Catalog document and expose the ARD (Agentic Resource Discovery) search API, so registered `AGENT_CARD` and `MCP_TOOL` artifacts are discoverable by any AI Catalog- or ARD-aware client, not just {registry}'s own well-known endpoints.
+
+ifdef::service-registry-downstream[]
+WARNING: This section describes Developer Preview features. Developer Preview features are not supported by Red Hat in any way and are not functionally complete or production-ready. Do not use Developer Preview features for production or business-critical workloads. Developer Preview features provide early access to functionality in advance of possible inclusion in a Red Hat product offering. Customers can use these features to test functionality and provide feedback during the development process. Developer Preview features might not have any documentation, are subject to change or removal at any time, and have received limited testing. Red Hat might provide ways to submit feedback on Developer Preview features without an associated SLA. For more information about the support scope of Red Hat Developer Preview features, see {dp-support-scope}.
+endif::[]
+
+// con-ai-catalog-ard-overview
+[id="ai-catalog-ard-overview_{context}"]
+== AI Catalog and ARD overview
+
+:_mod-docs-content-type: CONCEPT
+
+[role="_abstract"]
+link:https://ai-catalog.io/[AI Catalog] and link:https://agenticresourcediscovery.org/[ARD] are two related, community-driven discovery standards for agentic AI artifacts (A2A agent cards, MCP servers, and others), maintained by a Linux Foundation working group.
+
+AI Catalog:: A static, artifact-agnostic JSON envelope, typically served at `/.well-known/ai-catalog.json`. It lists entries that identify an artifact by IANA media type and either link to it (`url`) or embed it (`data`).
+ARD:: Builds on AI Catalog by adding a domain-anchored identifier scheme (`urn:air:<publisher>:<namespace>:<name>`), a mandatory `POST /search` REST API for dynamic discovery, and optional `GET /agents` and `POST /explore` endpoints. ARD's normative publish/consume path is `/.well-known/ard.json`.
+
+{registry} projects its existing `AGENT_CARD` and `MCP_TOOL` artifacts into both formats as a read-only view over existing storage — no schema migration, no new artifact types.
+
+// ref-ai-catalog-configuration
+[id="ai-catalog-ard-configuration_{context}"]
+== AI Catalog and ARD configuration properties
+
+:_mod-docs-content-type: REFERENCE
+
+[role="_abstract"]
+Both features are disabled by default and independently feature-gated.
+
+[cols="2,1,3"]
+|===
+|Property |Default |Description
+
+|`apicurio.ai-catalog.enabled`
+|`false`
+|Enable the `/.well-known/ai-catalog.json` and `/.well-known/ard.json` endpoints
+
+|`apicurio.ai-catalog.publisher-domain`
+|_derived from request host_
+|The `<publisher>` segment used when building `urn:air:` identifiers. When not configured, it is derived from the incoming request's host and port.
+
+|`apicurio.ai-catalog.host-name`
+|`Apicurio Registry`
+|Display name for this registry instance, reported as the catalog's `host.displayName`
+
+|`apicurio.ai-catalog.spec-version`
+|`1.0`
+|The AI Catalog specification version reported in the catalog document
+
+|`apicurio.ard.enabled`
+|`false`
+|Enable the `POST /ard/search`, `GET /ard/agents`, and `POST /ard/explore` endpoints
+
+|`apicurio.ard.federation.default`
+|`none`
+|Default ARD federation mode advertised by this registry. Only `none` (no federation) is currently implemented; other values are accepted for forward compatibility but do not change behavior.
+|===
+
+// ref-ai-catalog-publishing
+[id="ai-catalog-publishing_{context}"]
+== AI Catalog publishing
+
+:_mod-docs-content-type: REFERENCE
+
+[role="_abstract"]
+When `apicurio.ai-catalog.enabled=true`, {registry} serves an AI Catalog document at two equivalent paths.
+
+GET /.well-known/ai-catalog.json::
+Returns the AI Catalog document. This is the predecessor path, retained for AI-Catalog-only consumers.
+
+GET /.well-known/ard.json::
+Returns the identical document. This is the path a strictly-conformant ARD crawler resolves per the ARD specification; a consumer that only fetches `ard.json` is fully conformant, so publish here if you can serve only one path.
+
+.Example response
+[source,json]
+----
+{
+  "specVersion": "1.0",
+  "host": {
+    "displayName": "Apicurio Registry",
+    "identifier": "registry.example.com:8080"
+  },
+  "entries": [
+    {
+      "identifier": "urn:air:registry.example.com:8080:ai-agents:translator-agent",
+      "displayName": "Translation Agent",
+      "type": "application/a2a-agent-card+json",
+      "url": "http://registry.example.com:8080/.well-known/agents/ai-agents/translator-agent",
+      "description": "Translates text between languages",
+      "capabilities": ["translation"],
+      "version": "1.0.0"
+    },
+    {
+      "identifier": "urn:air:registry.example.com:8080:system:registry",
+      "displayName": "Apicurio Registry",
+      "type": "application/ai-registry+json",
+      "url": "http://registry.example.com:8080/.well-known/ard/search",
+      "description": "ARD search API for this registry."
+    }
+  ]
+}
+----
+
+Every entry's `identifier` follows the `urn:air:<publisher>:<namespace>:<name>` form. Entries backed by `AGENT_CARD` artifacts use `application/a2a-agent-card+json`; entries backed by `MCP_TOOL` artifacts use `application/mcp-server-card+json`. When `apicurio.ard.enabled=true`, the catalog also includes a self-describing entry of type `application/ai-registry+json` pointing at this registry's own `/.well-known/ard/search` endpoint, so a crawler that only ingests the static catalog can still discover the live search API, per the ARD specification.
+
+Only artifacts visible under the caller's visibility (`public`/`entitled`/`private`, the same model used by `/.well-known/agents`) are included.
+
+// ref-ard-search-api
+[id="ard-search-api_{context}"]
+== ARD search API
+
+:_mod-docs-content-type: REFERENCE
+
+[role="_abstract"]
+When `apicurio.ard.enabled=true`, {registry} exposes the ARD REST search surface, mirrored under both `/.well-known/ard/*` and `/apis/registry/v3/well-known/ard/*`.
+
+POST /ard/search::
+The ARD-mandated search endpoint. Accepts a `query` object with a required `text` field and an optional structured `filter` (supported keys: `type`, `tags`, `capabilities`, `publisher`). Values within a filter key are OR-ed together; different keys are AND-ed.
++
+.Example request
+[source,json]
+----
+{
+  "query": {
+    "text": "translation",
+    "filter": {
+      "type": ["application/a2a-agent-card+json"]
+    }
+  },
+  "pageSize": 10
+}
+----
++
+.Example response
+[source,json]
+----
+{
+  "results": [
+    {
+      "identifier": "urn:air:registry.example.com:8080:ai-agents:translator-agent",
+      "displayName": "Translation Agent",
+      "type": "application/a2a-agent-card+json",
+      "url": "http://registry.example.com:8080/.well-known/agents/ai-agents/translator-agent",
+      "score": 100,
+      "source": "http://registry.example.com:8080"
+    }
+  ],
+  "pageToken": null
+}
+----
++
+NOTE: Because only entries satisfying every requested criterion are returned at all, every result's `score` is a deterministic `100` in this release — there is no fuzzy or semantic ranking yet. Only `federation: none` semantics are implemented; other `federation` values are accepted for forward compatibility but do not change behavior.
+
+GET /ard/agents::
+Optional, deterministic browsing endpoint. Accepts a `filter` query parameter using the form `key=value[ AND key=value]*` (supported keys: `type`, `tags`, `capabilities`, `publisher`), plus `orderBy`, `pageSize`, and `pageToken`. Returns an AI Catalog document; when more results remain, `nextPageToken` is populated so you can request the next page.
++
+.Example request
+[source,bash]
+----
+curl -G "http://localhost:8080/.well-known/ard/agents" \
+  --data-urlencode "filter=type=application/a2a-agent-card+json" \
+  --data-urlencode "pageSize=10"
+----
+
+POST /ard/explore::
+Optional facet-aggregation endpoint. Accepts the same `query` as `POST /search` plus a required `resultType.facets` array naming the fields to aggregate (supported: `type`, `publisher`). Returns bucketed counts, not ranked entries.
++
+.Example request
+[source,json]
+----
+{
+  "resultType": {
+    "facets": [
+      { "field": "type" }
+    ]
+  }
+}
+----
+
+// ref-ai-catalog-ard-scope
+[id="ai-catalog-ard-scope_{context}"]
+== Scope and limitations
+
+:_mod-docs-content-type: REFERENCE
+
+[role="_abstract"]
+This implementation is a read-only projection over existing artifacts, consistent with {registry}'s role as a metadata store and governance tool, not a runtime platform.
+
+* No Trust Manifest support (optional in the specification; not yet implemented).
+* No federation — {registry} always searches only its own index (`federation: none`).
+* No catalog importer — {registry} does not crawl external `ai-catalog.json`/`ard.json` documents to register their entries as artifacts.
+* Relevance ranking is not yet semantic; `score` is always `100` for matching results. Full-text search (tracked separately) is expected to enable real relevance scoring in a future release.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://ai-catalog.io/[AI Catalog specification]
+* link:https://agenticresourcediscovery.org/[ARD specification]
+* xref:getting-started/assembly-a2a-features.adoc[A2A protocol features]
+* xref:getting-started/assembly-agent-discovery-patterns.adoc[Agent discovery and multi-agent orchestration]

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -82,16 +82,6 @@ The following {registry} configuration options are available for each component 
 |`false`
 |`3.0.0`
 |Enable A2A protocol support _(experimental)_
-|`apicurio.a2a.entitlements.enabled`
-|`boolean`
-|`true`
-|`3.0.0`
-|Enable entitlement-based agent filtering
-|`apicurio.a2a.public-discovery.enabled`
-|`boolean`
-|`true`
-|`3.0.0`
-|Enable public (unauthenticated) agent discovery endpoint
 |===
 
 == aicatalog


### PR DESCRIPTION
## What

Fixes the documentation/examples gap identified after #9974 removed several Developer-Preview-only endpoints, and after PR #9801/#9970/#9971/#9978 landed the AI Catalog/ARD feature set without any documentation.

## Stale documentation fixed

- `assembly-a2a-features.adoc` had an entire "Agent discovery and entitlement endpoints" section documenting `GET /.well-known/agents/public`, `GET /.well-known/agents/entitled`, and `POST /.well-known/agents/search` — all three removed in #9974. Removed the dead section; rewrote the "Agent visibility model" section to describe the surviving `GET /.well-known/agents` endpoint (same visibility semantics, consolidated implementation).
- `assembly-agent-discovery-patterns.adoc` documented `/.well-known/a2a` as a live endpoint (also removed in #9974). Removed the row and prose; added rows for `/.well-known/ai-catalog.json` and `/.well-known/ard.json`.

## New documentation added

- `assembly-ai-catalog-ard.adoc` (new, wired into `nav.adoc`): covers AI Catalog publishing (`ai-catalog.json`/`ard.json`, the self-describing `application/ai-registry+json` entry), the full ARD search API (`POST /ard/search`, `GET /ard/agents`, `POST /ard/explore`), all `apicurio.ai-catalog.*`/`apicurio.ard.*` config properties, and explicit scope/limitations (no Trust Manifest, no federation, no importer, no semantic ranking yet).

## Related code cleanup

- `A2AConfig`: removed `apicurio.a2a.public-discovery.enabled` and `apicurio.a2a.entitlements.enabled` — both became dead configuration once #9974 removed their only consumers (`getPublicAgents`, `getEntitledAgents`). Keeping non-functional config properties around would have meant documenting config that silently does nothing, which is arguably worse than removing it. Regenerated `ref-registry-all-configs.adoc` accordingly (clean diff: exactly the two removed properties, nothing else).

## Verified, not just assumed

- Grepped `examples/` and `mcp/` for the removed endpoint paths — zero stale references found (they only ever used `/.well-known/agent.json` and `/.well-known/agents`, both of which survived #9974 unchanged).
- `./mvnw -pl app checkstyle:check` — 0 violations.
- `./mvnw -pl app -am test -Dtest=WellKnownResourceTest,WellKnownAiCatalogTest,WellKnownArdTest,A2AAuthTest,AiCatalogFeatureGateTest` — all passing, no regressions from the config removal.

Closes #9988
