### PR TITLE
perf(metrics): cache method signatures/timers for storage interceptors + fix perf-tests external-validation hang (#9887)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/metrics/StorageMethodSignatureCache.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/StorageMethodSignatureCache.java
@@ -1,0 +1,39 @@
+package io.apicurio.registry.metrics;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Precomputes and caches the human-readable method signature string (e.g. {@code "getContentById(long)"})
+ * used as a tag/attribute value by {@link StorageMetricsInterceptor} and {@link StorageTracingInterceptor}.
+ * <p>
+ * Building this string involves a {@link StringBuilder} and array iteration; since storage methods are
+ * called on the hot path and {@link java.lang.reflect.Method} instances are stable across calls for a given
+ * intercepted method, computing it once per {@link Method} and reusing the cached value avoids repeating
+ * that allocation on every single storage call.
+ */
+final class StorageMethodSignatureCache {
+
+    private static final ConcurrentHashMap<Method, String> CACHE = new ConcurrentHashMap<>();
+
+    private StorageMethodSignatureCache() {
+    }
+
+    static String of(Method method) {
+        return CACHE.computeIfAbsent(method, StorageMethodSignatureCache::build);
+    }
+
+    private static String build(Method method) {
+        StringBuilder res = new StringBuilder(method.getName());
+        res.append('(');
+        Class<?>[] types = method.getParameterTypes();
+        for (int i = 0; i < types.length; i++) {
+            res.append(types[i].getSimpleName());
+            if (i != types.length - 1) {
+                res.append(',');
+            }
+        }
+        res.append(')');
+        return res.toString();
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/metrics/StorageMetricsInterceptor.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/StorageMetricsInterceptor.java
@@ -10,6 +10,7 @@ import org.eclipse.microprofile.context.ThreadContext;
 
 import java.lang.reflect.Method;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static io.apicurio.registry.metrics.MetricsConstants.STORAGE_METHOD_CALL;
 import static io.apicurio.registry.metrics.MetricsConstants.STORAGE_METHOD_CALL_DESCRIPTION;
@@ -18,6 +19,12 @@ import static io.apicurio.registry.metrics.MetricsConstants.STORAGE_METHOD_CALL_
 
 /**
  * Fail readiness check if the duration of processing a artifactStore operation is too high.
+ * <p>
+ * For KafkaSQL, both the federated {@code KafkaSqlRegistryStorage} method and the underlying
+ * {@code SqlRegistryStorage} method it delegates reads to are annotated with {@link StorageMetricsApply},
+ * so a single logical read intentionally produces two timer recordings (one per layer). This mirrors a
+ * parent/child span relationship and is left as-is; collapsing it would require changing how
+ * {@code KafkaSqlRegistryStorage} invokes its injected {@code sqlStore}, which is out of scope here.
  */
 @Interceptor
 @StorageMetricsApply
@@ -28,6 +35,14 @@ public class StorageMetricsInterceptor {
 
     @Inject
     ThreadContext threadContext;
+
+    /**
+     * Caches the two {@link Timer} instances (failure/success) for each intercepted method, keyed by
+     * {@link Method}. Building a {@code Timer} involves constructing tags and doing a registry lookup by
+     * {@code Meter.Id}; since the set of intercepted methods is fixed, precomputing and reusing the timers
+     * avoids repeating that work on every storage call.
+     */
+    private final ConcurrentHashMap<Method, Timer[]> timerCache = new ConcurrentHashMap<>();
 
     @AroundInvoke
     public Object intercept(InvocationContext context) throws Exception {
@@ -60,23 +75,22 @@ public class StorageMetricsInterceptor {
     }
 
     private void record(Timer.Sample sample, Method method, boolean success) {
-        Timer timer = Timer.builder(STORAGE_METHOD_CALL).description(STORAGE_METHOD_CALL_DESCRIPTION)
-                .tag(STORAGE_METHOD_CALL_TAG_METHOD, getMethodString(method))
-                .tag(STORAGE_METHOD_CALL_TAG_SUCCESS, String.valueOf(success)).register(registry);
-        sample.stop(timer);
+        sample.stop(timerFor(method, success));
     }
 
-    private static String getMethodString(Method method) {
-        StringBuilder res = new StringBuilder();
-        res.append(method.getName());
-        res.append('(');
-        Class<?>[] types = method.getParameterTypes();
-        for (int i = 0; i < types.length; i++) {
-            res.append(types[i].getSimpleName());
-            if (i != types.length - 1)
-                res.append(',');
-        }
-        res.append(')');
-        return res.toString();
+    private Timer timerFor(Method method, boolean success) {
+        Timer[] timers = timerCache.computeIfAbsent(method, this::buildTimers);
+        return timers[success ? 1 : 0];
+    }
+
+    private Timer[] buildTimers(Method method) {
+        String methodTag = StorageMethodSignatureCache.of(method);
+        return new Timer[] { buildTimer(methodTag, false), buildTimer(methodTag, true) };
+    }
+
+    private Timer buildTimer(String methodTag, boolean success) {
+        return Timer.builder(STORAGE_METHOD_CALL).description(STORAGE_METHOD_CALL_DESCRIPTION)
+                .tag(STORAGE_METHOD_CALL_TAG_METHOD, methodTag)
+                .tag(STORAGE_METHOD_CALL_TAG_SUCCESS, String.valueOf(success)).register(registry);
     }
 }

--- a/app/src/main/java/io/apicurio/registry/metrics/StorageTracingInterceptor.java
+++ b/app/src/main/java/io/apicurio/registry/metrics/StorageTracingInterceptor.java
@@ -13,6 +13,7 @@ import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Interceptor that creates OpenTelemetry spans for storage operations.
@@ -30,16 +31,25 @@ public class StorageTracingInterceptor {
     private static final String INSTRUMENTATION_NAME = "io.apicurio.registry.storage";
     private static final String INSTRUMENTATION_VERSION = "3.x";
 
+    /**
+     * Precomputed, immutable span metadata (span name, method signature, and target class name) for each
+     * intercepted method. Even with a no-op tracer, building this data involves string concatenation and a
+     * reflective {@code getSimpleName()} call on every invocation; since the set of intercepted methods (and
+     * their target class) is fixed per deployment, computing it once and reusing it avoids repeating that
+     * work on every storage call.
+     */
+    private final ConcurrentHashMap<Method, SpanMetadata> spanMetadataCache = new ConcurrentHashMap<>();
+
     @AroundInvoke
     public Object intercept(InvocationContext context) throws Exception {
         Tracer tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME, INSTRUMENTATION_VERSION);
-        String spanName = "storage." + context.getMethod().getName();
+        SpanMetadata metadata = spanMetadataCache.computeIfAbsent(context.getMethod(),
+                method -> buildSpanMetadata(method, context.getTarget()));
 
-        Span span = tracer.spanBuilder(spanName)
-                .setSpanKind(SpanKind.INTERNAL)
-                .setAttribute(OTelAttributes.ATTR_STORAGE_METHOD, context.getMethod().getName())
-                .setAttribute(OTelAttributes.ATTR_STORAGE_CLASS, context.getTarget().getClass().getSimpleName())
-                .setAttribute(OTelAttributes.ATTR_STORAGE_METHOD_SIGNATURE, getMethodString(context.getMethod()))
+        Span span = tracer.spanBuilder(metadata.spanName).setSpanKind(SpanKind.INTERNAL)
+                .setAttribute(OTelAttributes.ATTR_STORAGE_METHOD, metadata.methodName)
+                .setAttribute(OTelAttributes.ATTR_STORAGE_CLASS, metadata.className)
+                .setAttribute(OTelAttributes.ATTR_STORAGE_METHOD_SIGNATURE, metadata.methodSignature)
                 .startSpan();
 
         try (Scope scope = span.makeCurrent()) {
@@ -55,17 +65,22 @@ public class StorageTracingInterceptor {
         }
     }
 
-    private static String getMethodString(Method method) {
-        StringBuilder res = new StringBuilder();
-        res.append(method.getName());
-        res.append('(');
-        Class<?>[] types = method.getParameterTypes();
-        for (int i = 0; i < types.length; i++) {
-            res.append(types[i].getSimpleName());
-            if (i != types.length - 1)
-                res.append(',');
+    private static SpanMetadata buildSpanMetadata(Method method, Object target) {
+        return new SpanMetadata("storage." + method.getName(), method.getName(),
+                target.getClass().getSimpleName(), StorageMethodSignatureCache.of(method));
+    }
+
+    private static final class SpanMetadata {
+        private final String spanName;
+        private final String methodName;
+        private final String className;
+        private final String methodSignature;
+
+        private SpanMetadata(String spanName, String methodName, String className, String methodSignature) {
+            this.spanName = spanName;
+            this.methodName = methodName;
+            this.className = className;
+            this.methodSignature = methodSignature;
         }
-        res.append(')');
-        return res.toString();
     }
 }

--- a/app/src/test/java/io/apicurio/registry/metrics/StorageMetricsInterceptorTest.java
+++ b/app/src/test/java/io/apicurio/registry/metrics/StorageMetricsInterceptorTest.java
@@ -1,0 +1,119 @@
+package io.apicurio.registry.metrics;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.interceptor.InvocationContext;
+import org.eclipse.microprofile.context.ThreadContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link StorageMetricsInterceptor}, in particular that the timer-caching optimization does
+ * not change observable metric behavior: names/tags/counts/success-failure recording stay the same across
+ * repeated and varied (success/failure) invocations of the same method.
+ */
+class StorageMetricsInterceptorTest {
+
+    private SimpleMeterRegistry registry;
+    private StorageMetricsInterceptor interceptor;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+        interceptor = new StorageMetricsInterceptor();
+        interceptor.registry = registry;
+        interceptor.threadContext = ThreadContext.builder().build();
+    }
+
+    private InvocationContext contextFor(Method method, Object result) throws Exception {
+        InvocationContext context = mock(InvocationContext.class);
+        when(context.getMethod()).thenReturn(method);
+        when(context.proceed()).thenReturn(result);
+        return context;
+    }
+
+    @Test
+    void repeatedSuccessfulCallsAccumulateOnASingleReusedTimer() throws Exception {
+        Method method = TestStorageClass.class.getMethod("getArtifact", String.class);
+
+        interceptor.intercept(contextFor(method, "ok"));
+        interceptor.intercept(contextFor(method, "ok"));
+        interceptor.intercept(contextFor(method, "ok"));
+
+        double count = registry.find(MetricsConstants.STORAGE_METHOD_CALL)
+                .tag(MetricsConstants.STORAGE_METHOD_CALL_TAG_METHOD, "getArtifact(String)")
+                .tag(MetricsConstants.STORAGE_METHOD_CALL_TAG_SUCCESS, "true").timer().count();
+
+        assertEquals(3, count);
+        // Only one Timer meter should have been registered for this (method, success) pair, not one per call.
+        assertEquals(1,
+                registry.find(MetricsConstants.STORAGE_METHOD_CALL)
+                        .tag(MetricsConstants.STORAGE_METHOD_CALL_TAG_METHOD, "getArtifact(String)")
+                        .tag(MetricsConstants.STORAGE_METHOD_CALL_TAG_SUCCESS, "true").timers().size());
+    }
+
+    @Test
+    void successAndFailureAreRecordedOnDistinctTimersForTheSameMethod() throws Exception {
+        Method method = TestStorageClass.class.getMethod("deleteArtifact");
+
+        InvocationContext okContext = mock(InvocationContext.class);
+        when(okContext.getMethod()).thenReturn(method);
+        when(okContext.proceed()).thenReturn(null);
+        interceptor.intercept(okContext);
+
+        InvocationContext failContext = mock(InvocationContext.class);
+        when(failContext.getMethod()).thenReturn(method);
+        when(failContext.proceed()).thenThrow(new RuntimeException("boom"));
+        assertThrows(RuntimeException.class, () -> interceptor.intercept(failContext));
+
+        double successCount = registry.find(MetricsConstants.STORAGE_METHOD_CALL)
+                .tag(MetricsConstants.STORAGE_METHOD_CALL_TAG_METHOD, "deleteArtifact()")
+                .tag(MetricsConstants.STORAGE_METHOD_CALL_TAG_SUCCESS, "true").timer().count();
+        double failureCount = registry.find(MetricsConstants.STORAGE_METHOD_CALL)
+                .tag(MetricsConstants.STORAGE_METHOD_CALL_TAG_METHOD, "deleteArtifact()")
+                .tag(MetricsConstants.STORAGE_METHOD_CALL_TAG_SUCCESS, "false").timer().count();
+
+        assertEquals(1, successCount);
+        assertEquals(1, failureCount);
+    }
+
+    @Test
+    void asyncResultIsRecordedOnCompletion() throws Exception {
+        Method method = TestStorageClass.class.getMethod("getArtifactAsync", String.class);
+        CompletableFuture<String> future = new CompletableFuture<>();
+        InvocationContext context = mock(InvocationContext.class);
+        when(context.getMethod()).thenReturn(method);
+        when(context.proceed()).thenReturn(future);
+
+        Object result = interceptor.intercept(context);
+        future.complete("ok");
+
+        double count = registry.find(MetricsConstants.STORAGE_METHOD_CALL)
+                .tag(MetricsConstants.STORAGE_METHOD_CALL_TAG_METHOD, "getArtifactAsync(String)")
+                .tag(MetricsConstants.STORAGE_METHOD_CALL_TAG_SUCCESS, "true").timer().count();
+
+        assertEquals(future, result);
+        assertEquals(1, count);
+    }
+
+    public static class TestStorageClass {
+        public String getArtifact(String groupId) {
+            return "artifact";
+        }
+
+        public void deleteArtifact() {
+            // no-op
+        }
+
+        public CompletableFuture<String> getArtifactAsync(String groupId) {
+            return CompletableFuture.completedFuture("artifact");
+        }
+    }
+}

--- a/perf-tests/k8s/common/run-external-load.sh
+++ b/perf-tests/k8s/common/run-external-load.sh
@@ -67,13 +67,46 @@ kubectl -n default patch apicurioregistry3 perf-test --type='json' -p="[
 kubectl -n default rollout status deployment/perf-test-app-deployment --timeout=3m
 
 REGISTRY_URL="http://${MINIKUBE_IP}:${APP_NODEPORT}/apis/registry/v3"
+TOKEN_URL="${KEYCLOAK_EXTERNAL_URL}/protocol/openid-connect/token"
+
+# kubectl reporting the rollout as complete only means the new pod passed its readiness probe -
+# not that DNS/service resolution, the JVM's JIT/class-loading warm-up, or (under contention right
+# after deploy.sh just started the entire topology - Kafka/Keycloak/Toxiproxy/app all at once) the
+# node's CPU scheduling have caught up. Requests sent in that gap can fail with 401 even though
+# both the token and the registry's authServerUrl config are already correct - this is a
+# readiness/warm-up race, not a reconciliation bug: manually re-tested the exact same
+# CR-patch-to-working-token round trip below in isolation (not immediately after a fresh
+# deploy.sh) and it consistently completed in under 2 seconds. Poll with one real authenticated
+# request until it actually succeeds, instead of assuming rollout status alone means "ready to
+# authenticate", with a generous bound to cover cold-start contention right after deploy.sh.
+echo "Waiting for the registry to accept tokens from the new authServerUrl..."
+READY=""
+for i in $(seq 1 90); do
+  TOKEN="$(curl -sf -X POST "$TOKEN_URL" \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    -d 'grant_type=client_credentials&client_id=registry-api&client_secret=perf-test-secret' \
+    | sed -n 's/.*"access_token"\s*:\s*"\([^"]*\)".*/\1/p')" || true
+  if [ -n "$TOKEN" ]; then
+    STATUS="$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer ${TOKEN}" \
+      "${REGISTRY_URL}/groups/perf-test-seed/artifacts?limit=1")" || true
+    if [ "$STATUS" != "401" ]; then
+      READY="1"
+      break
+    fi
+  fi
+  sleep 2
+done
+if [ -z "$READY" ]; then
+  echo "WARNING: registry still returning 401 for the new authServerUrl after 180s - proceeding" \
+    "anyway, but seeding/the load run will likely fail authentication." >&2
+fi
 
 echo "Running the load generator externally: PERF_USERS=${PERF_USERS} PERF_DURATION_SECONDS=${PERF_DURATION_SECONDS} PERF_WRITE_RATIO=${PERF_WRITE_RATIO}"
 echo "  REGISTRY_URL=${REGISTRY_URL}"
-echo "  AUTH_TOKEN_ENDPOINT=${KEYCLOAK_EXTERNAL_URL}/protocol/openid-connect/token"
+echo "  AUTH_TOKEN_ENDPOINT=${TOKEN_URL}"
 
 REGISTRY_URL="$REGISTRY_URL" \
-AUTH_TOKEN_ENDPOINT="${KEYCLOAK_EXTERNAL_URL}/protocol/openid-connect/token" \
+AUTH_TOKEN_ENDPOINT="${TOKEN_URL}" \
 AUTH_CLIENT_ID="registry-api" \
 AUTH_CLIENT_SECRET="perf-test-secret" \
 PERF_USERS="$PERF_USERS" \

--- a/perf-tests/src/main/java/io/apicurio/registry/perftest/simulations/RegistryApiSimulation.java
+++ b/perf-tests/src/main/java/io/apicurio/registry/perftest/simulations/RegistryApiSimulation.java
@@ -109,7 +109,12 @@ public class RegistryApiSimulation extends Simulation {
 
     // Cached, shared across all virtual users - see class Javadoc "Token handling".
     private static final AtomicReference<String> CACHED_TOKEN = new AtomicReference<>();
-    private static final HttpClient SETUP_HTTP_CLIENT = HttpClient.newHttpClient();
+    // Bounded connect timeout: without one, a stuck connection during setup (token fetch/seeding)
+    // can block the calling thread indefinitely, which previously turned an early, already-logged
+    // failure into a silent hang until an external (e.g. CI step) timeout killed the process.
+    private static final HttpClient SETUP_HTTP_CLIENT = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10)).build();
+    private static final Duration SETUP_REQUEST_TIMEOUT = Duration.ofSeconds(15);
     private static final Pattern ACCESS_TOKEN_PATTERN = Pattern
             .compile("\"access_token\"\\s*:\\s*\"([^\"]+)\"");
 
@@ -160,7 +165,18 @@ public class RegistryApiSimulation extends Simulation {
                                 + "failed - see logs above. Aborting rather than running the whole "
                                 + "load test unauthenticated.");
             }
-            ScheduledExecutorService refreshExecutor = Executors.newSingleThreadScheduledExecutor();
+            ScheduledExecutorService refreshExecutor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+                // Daemon: if the JVM's main thread exits (normally, or via an uncaught exception -
+                // e.g. Gatling's Runner crashing during setup, before this executor is ever
+                // explicitly shut down anywhere), this background token-refresh thread must not be
+                // the only thing keeping the process alive. A non-daemon thread here previously
+                // caused runs that crashed early (e.g. all seed requests failing auth) to hang
+                // until an external timeout killed the process, rather than exiting promptly with
+                // the real error already printed.
+                Thread thread = new Thread(runnable, "oauth-token-refresh");
+                thread.setDaemon(true);
+                return thread;
+            });
             // Refresh well before the realm's access-token lifespan (300s in the perf-main
             // Keycloak realm) expires - a fixed conservative interval rather than parsing
             // expires_in per-refresh keeps this simple and safe for typical realm configs.
@@ -265,7 +281,7 @@ public class RegistryApiSimulation extends Simulation {
             HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                     .uri(URI.create(REGISTRY_URL + "/groups/" + SEED_GROUP
                             + "/artifacts?ifExists=FIND_OR_CREATE_VERSION"))
-                    .header("Content-Type", "application/json")
+                    .header("Content-Type", "application/json").timeout(SETUP_REQUEST_TIMEOUT)
                     .POST(HttpRequest.BodyPublishers.ofString(body));
             String token = CACHED_TOKEN.get();
             if (token != null) {
@@ -305,7 +321,7 @@ public class RegistryApiSimulation extends Simulation {
                     + CLIENT_SECRET;
             HttpRequest request = HttpRequest.newBuilder().uri(URI.create(TOKEN_ENDPOINT))
                     .header("Content-Type", "application/x-www-form-urlencoded")
-                    .POST(HttpRequest.BodyPublishers.ofString(form)).build();
+                    .timeout(SETUP_REQUEST_TIMEOUT).POST(HttpRequest.BodyPublishers.ofString(form)).build();
             HttpResponse<String> response = SETUP_HTTP_CLIENT.send(request,
                     HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() != 200) {


### PR DESCRIPTION
## What

Two related changes bundled into one PR (both touch the same area — the perf-tests
infrastructure surfaced the second one while validating the first):

### 1. Workstream 4 of #9887: storage metrics/tracing allocation

`StorageMetricsInterceptor` and `StorageTracingInterceptor` previously rebuilt a method-signature
string (`StringBuilder` + array iteration) and, for metrics, a full `Timer.builder(...).tag(...).register(registry)`
call (allocating `Tag`/`Meter.Id` objects and doing a registry lookup) on **every single storage
call** — even though the set of intercepted methods is fixed for the life of the process.

- New `StorageMethodSignatureCache`: precomputes and caches the method-signature string once per
  `Method`, shared by both interceptors (previously duplicated).
- `StorageMetricsInterceptor`: caches the two `Timer` instances (success/failure) per method
  instead of rebuilding them per call.
- `StorageTracingInterceptor`: caches span name, method signature, and target class name per
  method instead of recomputing them (including a reflective `getSimpleName()` call) on every
  invocation, even when tracing is a no-op.
- Verified the async (`CompletionStage`) context-capture path was **already** correctly scoped to
  only the async branch, not a new change - confirmed via the new/existing tests.
- Documented the "KafkaSQL delegated reads: 1 or 2 metrics/spans?" question raised in #9887: left
  as 2 (federation layer + underlying SQL layer) - collapsing it would require restructuring how
  `KafkaSqlRegistryStorage` invokes its injected `sqlStore`, out of scope here.

No change to metric/span names, tags, counts, or success/failure semantics - only per-call
allocation and registry-lookup overhead removed.

### 2. Fix: `perf-main.yaml`'s external-validation step burning its full 10-minute timeout

While trying to get before/after throughput numbers for this PR (see below), found that the "Run
external high-concurrency read validation" step has been failing this way on every recent
`main` run, including the one right after #9898 merged - it's not something this PR's own change
caused, but it's what's currently preventing that CI job from producing real numbers at all, so
fixing it was a prerequisite to answering the "did this help?" question honestly.

Two compounding bugs:

- **Readiness/warm-up race right after `deploy.sh`, not a reconciliation bug** (I initially
  suspected a broken operator reconciliation path and disproved that - see commit message for the
  isolated repro showing auth propagation actually completes in 0-2s outside the cold-start
  window): `run-external-load.sh` patches the registry CR's `authServerUrl` and waits for
  `kubectl rollout status`, then immediately starts seeding. Right after `deploy.sh` just started
  Kafka/Keycloak/Toxiproxy/the app simultaneously, that's not enough margin - all 200 parallel seed
  requests failed with 401, crashing Gatling with "Feeder must not be empty" (empty artifact pool).
  Fixed by polling with a real authenticated request until it actually succeeds (bounded, ~180s)
  instead of trusting rollout status alone.
- **That crash then hung instead of exiting**: `RegistryApiSimulation`'s background OAuth-token-refresh
  `ScheduledExecutorService` used a non-daemon thread, so the crash above (an uncaught exception
  in Gatling's `Runner.load()`) left the JVM alive indefinitely - nothing left to ever call
  `shutdown()` on it - until the CI step's own `timeout-minutes: 10` killed the whole job. Fixed by
  making that thread a daemon thread.
- Also added bounded connect/request timeouts to the setup `HttpClient` (token fetch, seeding), so
  a stuck connection during setup can't cause the same class of hang by itself.

## Why

Workstream 4 of the performance epic tracked in #9887 (storage metrics/tracing allocation, ~9.7%
of the profiled JFR overhead). The perf-tests fix is a prerequisite for that epic's own DoD
(measured before/after throughput), which is currently broken on `main`.

## Local benchmark investigation (informational, not a merge gate for either change)

Reproduced the kafkasql scenario end-to-end on a local minikube (podman driver - not CI's
`driver=none`, so absolute numbers aren't comparable to the published baseline) to validate the
perf-tests fix and get a directional read on WS4's impact:

- Confirmed the fix works: the external-validation step's process now exits immediately on
  failure instead of hanging, and (once auth is stable) completes the full run.
- 5 paired reps (before = `cdb0e41648`, pre-WS2/WS4; after = this branch), 200 concurrent clients,
  180s each, same host, interleaved order:

  | | mean RPS | stdev |
  |---|---:|---:|
  | before | 2,966.1 | 303 |
  | after | 3,029.8 | 410 |

  Paired mean delta: +63.7 RPS (+2.2%), paired t-stat = 0.81 (df=4) - **not statistically
  significant**. Per-rep host load variance (±150-270 RPS swings) exceeds the mean effect size at
  this sample size. Direction is mildly positive, consistent with the change's intent, but this
  local environment's noise floor is too high to confirm or rule out a real effect - that needs
  the dedicated-hardware `perf-main.yaml` run this PR's second change unblocks.

## Testing

- New `StorageMetricsInterceptorTest` (3 cases) - no test existed for this interceptor before.
- Existing `StorageTracingInterceptorTest` (6 cases) - unmodified, passes unchanged.
- Full `io.apicurio.registry.metrics.*Test` suite (10 classes, 53 tests, including several
  `@QuarkusTest` full-boot classes): all pass.
- `./mvnw checkstyle:check -pl app` and `-pl perf-tests`: clean.
- `./mvnw clean install -pl app -am -DskipTests`: full build succeeds.
- perf-tests fix validated end-to-end against a live local reproduction of the kafkasql scenario
  (see above) - confirmed the hang is gone and the step now completes.

Relates to #9887 (not closing it - this covers only workstream 4 of that tracking epic, plus the
perf-tests fix needed to measure it; other workstreams are tracked separately).
