### PR TITLE
feat(mcp): add ard_search MCP tool wrapping ARD POST /search

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -124,6 +124,14 @@ The MCP server currently supports the following operations:
 - Groups - create, get, list, search, update
 - Artifacts - create, get, list, search, update
 - Versions - create, get, list, search, update
+- A2A agents / MCP tools - discover, get
+- ARD (Agentic Resource Discovery) search - `ard_search` wraps the registry's
+  `POST /.well-known/ard/search` endpoint so LLM orchestrators can query the ARD index
+  natively via MCP, per the ARD spec's Protocol Wrappers section. It accepts a
+  natural-language query plus optional `type` / `tags` / `capabilities` / `publisher`
+  filters, and returns matching entries in the ARD entry format. Requires ARD support to
+  be enabled on the target registry (`apicurio.ard.enabled=true`); otherwise the call
+  fails with an error indicating ARD support is disabled.
 
 *(\*) Some operations are restricted for safety reasons.*
 

--- a/mcp/src/main/java/io/apicurio/registry/mcp/Descriptions.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/Descriptions.java
@@ -133,6 +133,34 @@ public final class Descriptions {
              Global ID is a numeric identifier unique within an Apicurio Registry instance. \
              It is assigned by incrementing a counter each time an artifact version is created.""";
 
+    public static final String ARD_SEARCH_TEXT = """
+            Natural-language search query, describing the agent, tool, or capability you are looking for. \
+            This is matched against the name, description, and other metadata of registered A2A agents and MCP tools.""";
+
+    public static final String ARD_SEARCH_TYPE = """
+            Restrict results to one or more ARD entry types. \
+            Provide a comma-separated list, e.g. "application/agent-card+json,application/mcp-server-card+json". \
+            Leave empty to search across all types.""";
+
+    public static final String ARD_SEARCH_TAGS = """
+            Restrict results to entries carrying any of the given tags. \
+            Provide a comma-separated list, e.g. "streaming,production".""";
+
+    public static final String ARD_SEARCH_CAPABILITIES = """
+            Restrict results to entries advertising any of the given capabilities. \
+            Provide a comma-separated list, e.g. "java,pushNotifications".""";
+
+    public static final String ARD_SEARCH_PUBLISHER = """
+            Restrict results to entries published by any of the given publisher domains. \
+            Provide a comma-separated list.""";
+
+    public static final String ARD_SEARCH_PAGE_TOKEN = """
+            Opaque pagination token returned by a previous "ard_search" call, used to fetch the next page of results. \
+            Leave empty to fetch the first page.""";
+
+    public static final String ARD_SEARCH_PAGE_SIZE = """
+            Maximum number of results to return in a single page (defaults to 10 if not provided).""";
+
     private Descriptions() {
     }
 }

--- a/mcp/src/main/java/io/apicurio/registry/mcp/RegistryService.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/RegistryService.java
@@ -1,6 +1,10 @@
 package io.apicurio.registry.mcp;
 
 import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.rest.client.models.ArdFilter;
+import io.apicurio.registry.rest.client.models.ArdSearchQuery;
+import io.apicurio.registry.rest.client.models.ArdSearchRequest;
+import io.apicurio.registry.rest.client.models.ArdSearchResponse;
 import io.apicurio.registry.rest.client.models.ArtifactMetaData;
 import io.apicurio.registry.rest.client.models.ArtifactSortBy;
 import io.apicurio.registry.rest.client.models.ArtifactTypeInfo;
@@ -32,7 +36,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @ApplicationScoped
 public class RegistryService {
@@ -432,6 +438,54 @@ public class RegistryService {
                 throw new ToolCallException("Unable to retrieve MCP tool.");
             }
             return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * Invokes the registry's {@code POST /.well-known/ard/search} endpoint (ARD - Agentic
+     * Resource Discovery). {@code type}, {@code tags}, {@code capabilities} and
+     * {@code publisher} are comma-separated lists that populate the corresponding
+     * {@code query.filter} keys (OR semantics within a key, AND semantics across keys), per
+     * the ARD spec.
+     */
+    public String ardSearch(
+            String text,
+            String type,
+            String tags,
+            String capabilities,
+            String publisher,
+            String pageToken,
+            Integer pageSize
+    ) throws Exception {
+        var query = new ArdSearchQuery();
+        query.setText(text);
+
+        Map<String, Object> filter = new HashMap<>();
+        putCommaSeparatedFilter(filter, "type", type);
+        putCommaSeparatedFilter(filter, "tags", tags);
+        putCommaSeparatedFilter(filter, "capabilities", capabilities);
+        putCommaSeparatedFilter(filter, "publisher", publisher);
+        if (!filter.isEmpty()) {
+            var ardFilter = new ArdFilter();
+            ardFilter.setAdditionalData(filter);
+            query.setFilter(ardFilter);
+        }
+
+        var request = new ArdSearchRequest();
+        request.setQuery(query);
+        request.setPageToken(pageToken);
+        request.setPageSize(pageSize);
+
+        ArdSearchResponse response = client().wellKnown().ard().search().post(request);
+        return utils.toPrettyJson(response);
+    }
+
+    private void putCommaSeparatedFilter(Map<String, Object> filter, String key, String value) {
+        if (value != null && !value.isBlank()) {
+            filter.put(key, Arrays.stream(value.split(","))
+                    .map(String::trim)
+                    .filter(v -> !v.isEmpty())
+                    .toList());
         }
     }
 

--- a/mcp/src/main/java/io/apicurio/registry/mcp/servers/ArdMCPServer.java
+++ b/mcp/src/main/java/io/apicurio/registry/mcp/servers/ArdMCPServer.java
@@ -1,0 +1,53 @@
+package io.apicurio.registry.mcp.servers;
+
+import io.apicurio.registry.mcp.RegistryService;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import jakarta.inject.Inject;
+
+import static io.apicurio.registry.mcp.Descriptions.ARD_SEARCH_CAPABILITIES;
+import static io.apicurio.registry.mcp.Descriptions.ARD_SEARCH_PAGE_SIZE;
+import static io.apicurio.registry.mcp.Descriptions.ARD_SEARCH_PAGE_TOKEN;
+import static io.apicurio.registry.mcp.Descriptions.ARD_SEARCH_PUBLISHER;
+import static io.apicurio.registry.mcp.Descriptions.ARD_SEARCH_TAGS;
+import static io.apicurio.registry.mcp.Descriptions.ARD_SEARCH_TEXT;
+import static io.apicurio.registry.mcp.Descriptions.ARD_SEARCH_TYPE;
+import static io.apicurio.registry.mcp.Utils.handleError;
+
+/**
+ * Exposes the registry's ARD (Agentic Resource Discovery) search API,
+ * {@code POST /.well-known/ard/search}, as an MCP tool, per ARD spec &sect;5.3.5 (Protocol
+ * Wrappers).
+ *
+ * <p>If ARD support is disabled on the target registry ({@code apicurio.ard.enabled=false}),
+ * the underlying REST call returns a 404, which is translated into a
+ * {@link io.quarkiverse.mcp.server.ToolCallException} by {@link RegistryService#ardSearch}
+ * / {@link io.apicurio.registry.mcp.Utils#handleError}, the same pattern already used by
+ * {@link AgentsMCPServer} for the {@code apicurio.a2a.enabled} / {@code apicurio.mcp-tools.enabled}
+ * gates. The MCP server process does not have direct access to the target registry's
+ * configuration (it is a separate client process, potentially pointed at a remote registry),
+ * so gating happens at call time rather than at tool-registration time.
+ */
+public class ArdMCPServer {
+
+    @Inject
+    RegistryService service;
+
+    @Tool(description = """
+            Search Apicurio Registry's Agentic Resource Discovery (ARD) index, \
+            https://agenticresourcediscovery.org/spec/. Given a natural-language query and \
+            optional structured filters, returns matching A2A agents and MCP tools \
+            registered in Apicurio Registry, in the ARD entry format (identifier, \
+            displayName, type, url, description, capabilities, tags, publisher, etc).""")
+    String ard_search(
+            @ToolArg(description = ARD_SEARCH_TEXT) String text,
+            @ToolArg(description = ARD_SEARCH_TYPE, required = false) String type,
+            @ToolArg(description = ARD_SEARCH_TAGS, required = false) String tags,
+            @ToolArg(description = ARD_SEARCH_CAPABILITIES, required = false) String capabilities,
+            @ToolArg(description = ARD_SEARCH_PUBLISHER, required = false) String publisher,
+            @ToolArg(description = ARD_SEARCH_PAGE_TOKEN, required = false) String pageToken,
+            @ToolArg(description = ARD_SEARCH_PAGE_SIZE, required = false) Integer pageSize
+    ) {
+        return handleError(() -> service.ardSearch(text, type, tags, capabilities, publisher, pageToken, pageSize));
+    }
+}

--- a/mcp/src/test/java/io/apicurio/registry/mcp/RegistryServiceTest.java
+++ b/mcp/src/test/java/io/apicurio/registry/mcp/RegistryServiceTest.java
@@ -33,6 +33,7 @@ public class RegistryServiceTest {
     private int port;
     private final Map<String, String> lastHeaders = new ConcurrentHashMap<>();
     private volatile String lastUri;
+    private volatile String lastRequestBody;
 
     @BeforeEach
     public void setUp() throws IOException {
@@ -107,6 +108,30 @@ public class RegistryServiceTest {
 
             if (path.matches(".*/well-known/mcp-tools/g1/m1.*")) {
                 String response = "{\"id\":\"m1\",\"name\":\"tool-m1\"}";
+                exchange.getResponseHeaders().set("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, response.length());
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response.getBytes(StandardCharsets.UTF_8));
+                }
+                return;
+            }
+
+            if (path.endsWith("/well-known/ard/search") && "POST".equals(exchange.getRequestMethod())) {
+                byte[] body = exchange.getRequestBody().readAllBytes();
+                lastRequestBody = new String(body, StandardCharsets.UTF_8);
+                boolean disabled = lastRequestBody.contains("ard-disabled");
+                if (disabled) {
+                    String response = "{\"error_code\":404,\"message\":\"ARD support is disabled\"}";
+                    exchange.getResponseHeaders().set("Content-Type", "application/json");
+                    exchange.sendResponseHeaders(404, response.length());
+                    try (OutputStream os = exchange.getResponseBody()) {
+                        os.write(response.getBytes(StandardCharsets.UTF_8));
+                    }
+                    return;
+                }
+                String response = "{\"results\":[{\"identifier\":\"air://example.com/system/entry-1\","
+                        + "\"displayName\":\"Test Agent\",\"type\":\"application/agent-card+json\","
+                        + "\"url\":\"http://example.com/agent\"}],\"pageToken\":null}";
                 exchange.getResponseHeaders().set("Content-Type", "application/json");
                 exchange.sendResponseHeaders(200, response.length());
                 try (OutputStream os = exchange.getResponseBody()) {
@@ -416,6 +441,48 @@ public class RegistryServiceTest {
         ToolCallException exEmpty = assertThrows(ToolCallException.class,
                 () -> service.updateVersionState("g1", "a1", "1", "  "));
         assertTrue(exEmpty.getMessage().contains("Invalid version state: '  '"));
+    }
+
+    @Test
+    public void testArdSearchSendsQueryTextAndFilters() throws Exception {
+        RegistryService service = createService("http://localhost:" + port, false);
+        String result = service.ardSearch("discover agents", "application/agent-card+json",
+                "streaming,production", "java", "example.com", null, 5);
+
+        assertNotNull(result);
+        assertTrue(result.contains("Test Agent"));
+        assertTrue(result.contains("air://example.com/system/entry-1"));
+
+        assertNotNull(lastRequestBody);
+        assertTrue(lastRequestBody.contains("\"text\":\"discover agents\""));
+        assertTrue(lastRequestBody.contains("\"type\""));
+        assertTrue(lastRequestBody.contains("application/agent-card+json"));
+        assertTrue(lastRequestBody.contains("\"tags\""));
+        assertTrue(lastRequestBody.contains("streaming"));
+        assertTrue(lastRequestBody.contains("production"));
+        assertTrue(lastRequestBody.contains("\"capabilities\""));
+        assertTrue(lastRequestBody.contains("java"));
+        assertTrue(lastRequestBody.contains("\"publisher\""));
+        assertTrue(lastRequestBody.contains("example.com"));
+        assertTrue(lastRequestBody.contains("\"pageSize\":5"));
+    }
+
+    @Test
+    public void testArdSearchOmitsFilterWhenNoStructuredFiltersProvided() throws Exception {
+        RegistryService service = createService("http://localhost:" + port, false);
+        String result = service.ardSearch("discover agents", null, null, null, null, null, null);
+
+        assertNotNull(result);
+        assertNotNull(lastRequestBody);
+        assertTrue(lastRequestBody.contains("\"text\":\"discover agents\""));
+        assertTrue(!lastRequestBody.contains("\"filter\""));
+    }
+
+    @Test
+    public void testArdSearchThrowsWhenArdDisabled() {
+        RegistryService service = createService("http://localhost:" + port, false);
+        assertThrows(Exception.class,
+                () -> service.ardSearch("ard-disabled", null, null, null, null, null, null));
     }
 }
 


### PR DESCRIPTION
## What

Adds a new MCP tool, `ard_search`, to the `mcp/` module that wraps the registry's ARD (Agentic Resource Discovery) search API — `POST /.well-known/ard/search` — so LLM orchestrators connected via MCP can query the ARD index natively instead of going through raw HTTP.

## Why

ADR-0004 originally deferred this to "Step 3 — optional/later," but reference ARD implementations (Hugging Face Discover Tool, GitHub Agent Finder, Ora Directory) all expose ARD search as a first-class MCP tool. ARD spec §5.3.5 (Protocol Wrappers) explicitly permits this: the tool's response follows the same entry model as the REST search, while the request shape is adapted to MCP conventions (flat scalar args instead of a nested request body).

## Changes

- `RegistryService.ardSearch(...)`: builds an `ArdSearchRequest` (text + `type`/`tags`/`capabilities`/`publisher` filters, encoded as comma-separated strings and expanded into the ARD filter map) and calls `client().wellKnown().ard().search().post(...)`, returning the `ArdSearchResponse` as pretty JSON.
- `ArdMCPServer`: new `@Tool ard_search` following the same style as `AgentsMCPServer`.
- `Descriptions`: new tool-arg descriptions for the ARD search parameters.
- Tests added to `RegistryServiceTest` covering: query text + all four structured filters are serialized correctly, no `filter` object is sent when no structured filters are provided, and the 404 returned when ARD is disabled on the target registry propagates as an error.
- `mcp/README.md` updated to document the new tool.

## Gating (`apicurio.ard.enabled`) — implementation note

The `mcp/` module is a separate client process that talks to a (potentially remote) Apicurio Registry instance via the Java SDK/`RegistryClient`; it has no direct access to the target registry's `apicurio.ard.enabled` config value, so it cannot gate MCP tool *registration* at CDI-bean level the way a bundled extension could.

Instead, gating is enforced exactly the same way the existing `AgentsMCPServer` tools already handle the `apicurio.a2a.enabled` / `apicurio.mcp-tools.enabled` gates: the REST endpoint itself returns 404 when the feature is disabled, and that error is surfaced to the calling LLM as a tool-call error (via the existing `Utils.handleError` in the `ard_search` tool method). This is a deliberate deviation from a literal "do not advertise the tool" reading of the acceptance criteria, since the module's architecture makes compile-time/registration-time gating on a remote server's config unworkable; the behavioral outcome (the tool cannot be used against a registry where ARD is disabled) is preserved.

Closes #9972