### PR TITLE
docs(ai-catalog): local verification + conformance CLI results + draft ai-catalog.io listing

### DIFF
--- a/claudedocs/9973-ai-catalog-listing-draft.md
+++ b/claudedocs/9973-ai-catalog-listing-draft.md
@@ -1,0 +1,98 @@
+# Issue #9973 — Draft PR: Add Apicurio Registry to `ai-catalog.io/implementations/`
+
+Date: 2026-09-03
+Status: **DRAFT ONLY — not submitted.** Per task scope, opening a PR against an external
+org's repo (`Agent-Card/ai-catalog`) requires a human decision about how Apicurio wants to
+represent itself there. This file captures the exact proposed diff for review.
+
+## Source verified
+
+Fetched the live current content of the file backing
+`https://ai-catalog.io/implementations/` from the actual GitHub repo:
+
+```bash
+gh api repos/Agent-Card/ai-catalog/contents/docs/implementations.md --jq '.content' | base64 -d
+```
+
+Repo: `Agent-Card/ai-catalog`, file: `docs/implementations.md`, default branch: `main`.
+
+Current content (as of 2026-09-03):
+
+```markdown
+---
+icon: material/code-braces
+---
+
+# Implementations
+
+This page lists implementations and tooling for the AI Catalog specification.
+
+## Official
+
+These implementations are maintained by the Agent Card Working Group or its member organisations.
+
+- [spec-works/ai-catalog](https://github.com/spec-works/ai-catalog) (C#, Python)
+- [ai-catalog-go-sdk](https://github.com/agntcy/ai-catalog-go-sdk/) (Go)
+- [ai-catalog-rust](https://github.com/agntcy/ai-catalog-rust) (Rust)
+- [tomevault-io/ai-catalog-reference](https://github.com/tomevault-io/ai-catalog-reference) (Python, Trust Manifest signer/verifier)
+- [AI Catalog](https://ai-catalog.outshift.io/) (testbed service)
+
+## Community Projects
+
+Community-built tools, libraries, and integrations. Listed here to help discovery — not formally endorsed by the working group.
+
+!!! tip "Add your project"
+    Have an implementation to share? Open a pull request to add it here.
+```
+
+The "Community Projects" section is currently empty of entries (only the "add your
+project" tip). No prior community PR has landed a bullet entry there yet — checked via
+`gh api "repos/Agent-Card/ai-catalog/commits?path=docs/implementations.md"`, which shows
+only "Official" entries added so far (`tomevault-io/ai-catalog-reference`, the initial page
+scaffold, and the Official/Community split). This PR would be the first Community Projects
+entry, so the exact bullet style is inferred from the "Official" section's existing
+convention: `[name](url) (short parenthetical description)`.
+
+## Proposed diff
+
+```diff
+ ## Community Projects
+ 
+ Community-built tools, libraries, and integrations. Listed here to help discovery — not formally endorsed by the working group.
+ 
++- [Apicurio Registry](https://github.com/Apicurio/apicurio-registry) (Java, Quarkus-based open-source API/schema registry — serves `/.well-known/ai-catalog.json` and `/.well-known/ard.json` projecting registered A2A `AGENT_CARD` and MCP `MCP_TOOL` artifacts)
++
+ !!! tip "Add your project"
+     Have an implementation to share? Open a pull request to add it here.
+```
+
+## Proposed PR description (for a human to review/edit before submitting)
+
+**Title:** `docs: add Apicurio Registry to Community Projects`
+
+**Body:**
+
+> Apicurio Registry (https://github.com/Apicurio/apicurio-registry) is an open-source,
+> Quarkus-based API and schema registry. It implements A2A `AGENT_CARD` and MCP `MCP_TOOL`
+> artifact types with governance features (visibility tiers, versioning), and serves both
+> `/.well-known/ai-catalog.json` and `/.well-known/ard.json` (per ARD v0.91) projecting its
+> registered agent/tool artifacts into the AI Catalog entry envelope. It also implements the
+> ARD `POST /search` and `POST /explore` REST endpoints.
+>
+> This PR adds a single Community Projects entry linking to the project repository.
+
+**Sign-off:** would need a real committer's DCO sign-off, not a fabricated one — flagged as
+a human action item.
+
+## What still requires human sign-off before this can actually be submitted
+
+1. **Confirm project representation**: is a bare link to the GitHub repo sufficient, or
+   should Apicurio point to a docs page (e.g. the A2A/AI-Catalog integration docs) instead?
+2. **Decide whether to wait for the registry-mode conformance gap fix** (see
+   `9973-conformance-cli-output.md`) before publicly claiming ARD support in the PR
+   description — the `ai-catalog.io` listing itself doesn't require conformance, but the
+   PR text implicitly claims "implements ARD search/explore," which is true, so this is a
+   judgment call about wording precision, not a blocker.
+3. **Fork `Agent-Card/ai-catalog` and open the actual PR** from an authorized GitHub
+   identity/account acting on behalf of the Apicurio project — not done by this task.
+4. **DCO sign-off** on the real commit, from whoever actually opens the PR.

--- a/claudedocs/9973-conformance-cli-output.md
+++ b/claudedocs/9973-conformance-cli-output.md
@@ -1,0 +1,131 @@
+# Issue #9973 — Official ARD Conformance CLI Results
+
+Date: 2026-09-03
+Tool: `ards-project/ard-spec` (cloned read-only to `/tmp/ard-spec-conformance-check`,
+not added to this repo as a submodule or dependency), `conformance/bin/conformance-test`,
+CLI version reported as `v0.9.1`.
+
+```
+$ git clone --depth 1 https://github.com/ards-project/ard-spec /tmp/ard-spec-conformance-check
+$ chmod +x /tmp/ard-spec-conformance-check/conformance/bin/conformance-test
+$ pip3 install jsonschema   # optional, enables JSON Schema Draft 2020-12 checks
+```
+
+## CLI usage (from `--help`)
+
+```
+Agentic Resource Discovery Conformance CLI v0.9.1
+Usage:
+  conformance-test manifest  <local_file_path_or_url>
+  conformance-test publisher <domain>   # resolves /.well-known/ard.json per §5.1
+  conformance-test registry  <registry_base_url> [--header 'Name: value']...
+```
+
+Target: the local Apicurio instance from `9973-local-verification.md`
+(`quarkus:dev` on `localhost:8091`, `apicurio.ai-catalog.enabled=true`,
+`apicurio.ard.enabled=true`, seeded with one `AGENT_CARD` and one `MCP_TOOL` artifact).
+
+## 1. Manifest Validation Mode — PASS
+
+```bash
+curl -s http://localhost:8091/.well-known/ard.json -o /tmp/ard-manifest.json
+conformance-test manifest /tmp/ard-manifest.json
+```
+
+```
+=== Validating Manifest: /tmp/ard-manifest.json ===
+  ✓ Manifest parsed successfully as valid JSON.
+  ✓ Manifest validates against ArdManifest.
+  ✓ All 3 entries validate against ArdEntry.
+  • Running custom semantic checks...
+  • Top-level members ignored by ARD (transport-defined): host, specVersion.
+  • Found 3 entries to validate.
+
+  Entry: Apicurio Registry
+  ✓ [Apicurio Registry] Valid URN format. Publisher: 'localhost', Name: 'registry'.
+  ✓ [Apicurio Registry] Correct Value-or-Reference delivery format (using url).
+  ⚠ [Apicurio Registry] No 'representativeQueries'. The semantic index is built from this term, so the entry will not be found by search — it is a valid catalog entry but not a discoverable ARD entry.
+
+  Entry: CatalogAgent
+  ✓ [CatalogAgent] Valid URN format. Publisher: 'localhost', Name: 'catalog-agent'.
+  ✓ [CatalogAgent] Correct Value-or-Reference delivery format (using url).
+
+  Entry: Catalog Lookup
+  ✓ [Catalog Lookup] Valid URN format. Publisher: 'localhost', Name: 'catalog-lookup-tool'.
+  ✓ [Catalog Lookup] Correct Value-or-Reference delivery format (using url).
+  ⚠ [Catalog Lookup] No 'representativeQueries'. The semantic index is built from this term, so the entry will not be found by search — it is a valid catalog entry but not a discoverable ARD entry.
+
+=== Conformance Validation Summary ===
+CONFORMANCE STATUS: PASS
+Validated with 0 critical specification errors and 2 warnings.
+```
+
+Exit code: `0`.
+
+**Interpretation:** the `application/ai-registry+json` self-describing entry and the
+`MCP_TOOL` entry (`Catalog Lookup`) don't carry `representativeQueries` — expected, since
+Step 4 of ADR-0004 explicitly only populates that field for `AGENT_CARD` entries from A2A
+skill `examples`, not for the self-describing entry or `MCP_TOOL` entries (documented gap,
+tracked as a known follow-up in the ADR, not a regression). These are warnings, not
+failures, and don't affect conformance status.
+
+## 2. Registry API Validation Mode — FAIL
+
+```bash
+conformance-test registry http://localhost:8091/.well-known/ard
+```
+
+```
+=== Validating Agent Registry: http://localhost:8091/.well-known/ard ===
+
+  Probing GET /agents...
+  ✓ GET /agents responded successfully with 200 OK.
+  ✗ GET /agents response is not a valid paginated object. Missing 'items' array.
+
+  Probing POST /search (Mandated Discovery endpoint)...
+  ✓ POST /search responded successfully with 200 OK.
+  ✓ POST /search returned valid results list (0 items).
+
+  Probing POST /explore (Optional Introspection endpoint)...
+  ✓ POST /explore responded successfully with 200 OK.
+  ✓ POST /explore returned valid facets object.
+
+=== Conformance Validation Summary ===
+CONFORMANCE STATUS: FAIL
+Found 1 critical specification errors. Implementation is NOT conformant.
+```
+
+Exit code: `1`.
+
+**Root cause of the single failure:** the CLI's registry-mode probe for `GET /agents`
+requires a paginated response shaped `{"items": [...], ...}` (per ARD §5.3, the *ARD Agent
+Registry API* `GET /agents` browsing-endpoint schema). Apicurio's
+`GET /.well-known/ard/agents` instead returns the same envelope shape as the
+`ai-catalog.json`/`ard.json` manifest endpoints (`{"specVersion", "host", "entries": [...]}`
+— see `AiCatalogEntry`/manifest projection in `WellKnownResourceImpl`). This is a real,
+reproducible gap between the implemented `GET /ard/agents` endpoint and the ARD Registry API
+`items`-paginated schema the conformance tool expects — **not** a bug introduced or
+"fixed" as part of this task. Per the task instructions, this is reported here for a human
+to triage (e.g. as a new, separate issue) rather than patched in this PR.
+
+The `POST /search` "0 items" result is expected, not a bug: the CLI's registry probe sends a
+fixed mock query (`"weather forecast tools"`) that does not match either seeded artifact's
+text content — the endpoint itself behaves correctly (`200`, well-formed empty `results`
+array). A separately-run manual query for `"catalog"` (see `9973-local-verification.md`)
+confirms the search endpoint does return non-empty, well-scored results when the query
+actually matches seeded content.
+
+`POST /explore` fully passes; no notes.
+
+## Summary
+
+| Mode | Result | Notes |
+|---|---|---|
+| `manifest` | **PASS** (0 errors, 2 warnings) | Warnings are a known, tracked gap (`representativeQueries` not yet populated for the self-describing entry or `MCP_TOOL` entries) |
+| `registry` | **FAIL** (1 critical error) | `GET /ard/agents` doesn't return the `items`-paginated shape the CLI's Registry API mode expects; `POST /search` and `POST /explore` both pass |
+| `publisher <domain>` | Not run | Requires a publicly resolvable domain on standard ports (`https://<domain>/.well-known/ard.json`); not applicable to a `localhost:8091` dev instance. Should be re-run once a real public demo instance exists. |
+
+**This registry-mode failure must be triaged by a human/separate issue before Apicurio can
+be listed as an ARD conformance-passing reference implementation** on
+`agenticresourcediscovery.org/ref_implementations/`. No attempt was made to fix it as part
+of this task, per the task's explicit scope boundary.

--- a/claudedocs/9973-local-verification.md
+++ b/claudedocs/9973-local-verification.md
@@ -1,0 +1,249 @@
+# Issue #9973 — Local Verification: AI Catalog / ARD End-to-End
+
+Date: 2026-09-03
+Scope: Sub-goal 1 of #9973 — verify locally that `apicurio.ai-catalog.enabled=true` and
+`apicurio.ard.enabled=true` work end-to-end, as evidence prior to any public deployment
+decision (which this task explicitly does NOT make).
+
+## Environment
+
+- Branch: `task/get-listed-ai-catalog-ard` (built from latest `origin/main`, which already
+  includes the AI Catalog/ARD implementation — see `07f95d419e`, `2fca072751`,
+  `e7bf042dde` in `git log`).
+- Started via:
+
+  ```bash
+  cd app && ../mvnw quarkus:dev -Dlocal \
+    -Dapicurio.ai-catalog.enabled=true \
+    -Dapicurio.ard.enabled=true \
+    -Dquarkus.http.port=8091
+  ```
+
+- Storage: default H2 (dev mode), no external infra.
+- No public exposure — bound to `localhost:8091` only, for the duration of this
+  verification session, then torn down.
+
+## Seed data
+
+Reused the exact `AGENT_CARD` and `MCP_TOOL` sample payloads from the project's own test
+suite (`app/src/test/java/io/apicurio/registry/noprofile/rest/aicatalog/WellKnownAiCatalogTest.java`,
+`AGENT_CARD_CONTENT` / `MCP_TOOL_CONTENT` constants), rather than fabricating new content,
+plus a `representativeQueries`-bearing variant (skill `examples`) to exercise that field.
+
+Created via the standard v3 REST API:
+
+```bash
+curl -s -X POST http://localhost:8091/apis/registry/v3/groups/demo-9973/artifacts \
+  -H "Content-Type: application/json" \
+  -d '{"artifactId":"catalog-agent","artifactType":"AGENT_CARD","firstVersion":{"content":{"content":"<agent-card.json>","contentType":"application/json"}}}'
+
+curl -s -X POST http://localhost:8091/apis/registry/v3/groups/demo-9973/artifacts \
+  -H "Content-Type: application/json" \
+  -d '{"artifactId":"catalog-lookup-tool","artifactType":"MCP_TOOL","firstVersion":{"content":{"content":"<mcp-tool.json>","contentType":"application/json"}}}'
+```
+
+Both returned `200`/creation success with `globalId` 1 and 2 respectively.
+
+Agent card content (`AGENT_CARD` artifact, `catalog-agent`):
+
+```json
+{
+    "name": "CatalogAgent",
+    "description": "An agent listed in the AI catalog",
+    "version": "1.2.3",
+    "supportedInterfaces": [
+        { "url": "https://example.com/agent", "protocolBinding": "http+json", "protocolVersion": "1.0" }
+    ],
+    "capabilities": { "streaming": true },
+    "skills": [
+        {
+            "id": "catalog-skill",
+            "name": "Catalog Skill",
+            "description": "A skill used for catalog tests",
+            "tags": ["catalog"],
+            "examples": ["What can this agent do?", "Show me the catalog skill"]
+        }
+    ],
+    "defaultInputModes": ["text"],
+    "defaultOutputModes": ["text"]
+}
+```
+
+MCP tool content (`MCP_TOOL` artifact, `catalog-lookup-tool`):
+
+```json
+{
+    "name": "catalog_lookup",
+    "title": "Catalog Lookup",
+    "description": "Look up entries in the product catalog",
+    "inputSchema": {
+        "type": "object",
+        "properties": { "query": { "type": "string" } },
+        "required": ["query"]
+    }
+}
+```
+
+## `GET /.well-known/ai-catalog.json`
+
+```bash
+curl -s http://localhost:8091/.well-known/ai-catalog.json | python3 -m json.tool
+```
+
+```json
+{
+    "specVersion": "1.0",
+    "host": {
+        "displayName": "Apicurio Registry",
+        "identifier": "localhost:8091"
+    },
+    "entries": [
+        {
+            "identifier": "urn:air:localhost:8091:system:registry",
+            "displayName": "Apicurio Registry",
+            "type": "application/ai-registry+json",
+            "url": "http://localhost:8091/.well-known/ard/search",
+            "description": "ARD search API for this registry."
+        },
+        {
+            "identifier": "urn:air:localhost:8091:demo-9973:catalog-agent",
+            "displayName": "CatalogAgent",
+            "type": "application/a2a-agent-card+json",
+            "url": "http://localhost:8091/.well-known/agents/demo-9973/catalog-agent",
+            "capabilities": ["catalog-skill"],
+            "version": "1.2.3",
+            "updatedAt": "2026-09-03T19:17:15.252Z",
+            "representativeQueries": [
+                "What can this agent do?",
+                "Show me the catalog skill"
+            ]
+        },
+        {
+            "identifier": "urn:air:localhost:8091:demo-9973:catalog-lookup-tool",
+            "displayName": "Catalog Lookup",
+            "type": "application/mcp-server-card+json",
+            "url": "http://localhost:8091/.well-known/mcp-tools/demo-9973/catalog-lookup-tool",
+            "capabilities": [],
+            "updatedAt": "2026-09-03T19:17:15.350Z"
+        }
+    ]
+}
+```
+
+Confirms: `specVersion`, `host`, the self-describing `application/ai-registry+json` entry
+(ADR-0004 gap 7 fix), `urn:air:` identifiers, `representativeQueries` populated from A2A
+skill `examples` (ADR-0004 Step 4), and correct IANA media types for both artifact types.
+
+## `GET /.well-known/ard.json`
+
+Byte-identical to `ai-catalog.json` above (confirmed via diff on the raw bodies), matching
+the ADR-0004 Amendment decision to serve both paths with the same payload, `ard.json` as
+canonical.
+
+## `POST /.well-known/ard/search`
+
+Text query matching seeded content:
+
+```bash
+curl -s -X POST http://localhost:8091/.well-known/ard/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": {"text": "catalog"}, "pageSize": 2}' | python3 -m json.tool
+```
+
+```json
+{
+    "results": [
+        {
+            "identifier": "urn:air:localhost:8091:demo-9973:catalog-agent",
+            "displayName": "CatalogAgent",
+            "type": "application/a2a-agent-card+json",
+            "url": "http://localhost:8091/.well-known/agents/demo-9973/catalog-agent",
+            "capabilities": ["catalog-skill"],
+            "version": "1.2.3",
+            "updatedAt": "2026-09-03T19:17:15.252Z",
+            "score": 100,
+            "source": "http://localhost:8091"
+        },
+        {
+            "identifier": "urn:air:localhost:8091:demo-9973:catalog-lookup-tool",
+            "displayName": "Catalog Lookup",
+            "type": "application/mcp-server-card+json",
+            "url": "http://localhost:8091/.well-known/mcp-tools/demo-9973/catalog-lookup-tool",
+            "capabilities": [],
+            "updatedAt": "2026-09-03T19:17:15.350Z",
+            "score": 100,
+            "source": "http://localhost:8091"
+        }
+    ]
+}
+```
+
+Filtered query (`type` facet + text) correctly narrowed to one result:
+
+```bash
+curl -s -X POST http://localhost:8091/.well-known/ard/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": {"text": "catalog", "filter": {"type": ["application/a2a-agent-card+json"]}}}'
+```
+→ returned only the `catalog-agent` entry.
+
+A query with empty `query.text` and no match (`"query": {"text": "weather forecast tools"}`)
+correctly returned `{"results": []}` (0 items, not an error) — this is what the official
+conformance CLI also observed (see `9973-conformance-cli-output.md`), and is expected
+behavior, not a bug, since neither seeded artifact's text matches that query.
+
+## `GET /.well-known/ard/agents`
+
+```bash
+curl -s http://localhost:8091/.well-known/ard/agents | python3 -m json.tool
+```
+
+Returns the same `ai-catalog.json`-shaped envelope (`entries[]`), listing both seeded
+artifacts. **Note:** this is the same shape as the manifest endpoints, not a
+`{"items": [...]}` paginated-list shape. The official ARD conformance CLI expects `items`
+here — see the conformance run write-up for details; this is a real, reportable gap, not
+something fixed in this task.
+
+## `POST /.well-known/ard/explore`
+
+```bash
+curl -s -X POST http://localhost:8091/.well-known/ard/explore \
+  -H "Content-Type: application/json" \
+  -d '{"resultType": {"facets": [{"field": "type"}, {"field": "publisher"}]}}' | python3 -m json.tool
+```
+
+```json
+{
+    "resultType": "facets",
+    "facets": {
+        "type": {
+            "buckets": [
+                { "value": "application/a2a-agent-card+json", "count": 1 },
+                { "value": "application/mcp-server-card+json", "count": 1 }
+            ],
+            "otherCount": 0
+        },
+        "publisher": {
+            "buckets": [
+                { "value": "localhost", "count": 2 }
+            ],
+            "otherCount": 0
+        }
+    }
+}
+```
+
+Facet aggregation over `type` and `publisher` works correctly.
+
+## Conclusion
+
+All four endpoints (`ai-catalog.json`, `ard.json`, `ard/search`, `ard/explore`) work
+end-to-end against a local instance seeded with realistic `AGENT_CARD`/`MCP_TOOL` content,
+confirming the feature functions as designed when both feature-gate properties are enabled.
+`GET /ard/agents` also works but returns a different envelope shape than the official
+conformance CLI expects (see `9973-conformance-cli-output.md`).
+
+This is local-only evidence. It does **not** substitute for a real public HTTPS instance,
+which is required for the `agenticresourcediscovery.org/ref_implementations/` listing bar
+and is a human/infrastructure decision out of scope for this task (see PR/issue summary for
+what a human needs to decide: hosting provider, TLS, domain, ongoing operational ownership).


### PR DESCRIPTION
## What

Prep/evidence documents for #9973 (get Apicurio listed on `ai-catalog.io/implementations/`
and `agenticresourcediscovery.org/ref_implementations/`). No code changes.

- `claudedocs/9973-local-verification.md` — full transcript of running the registry locally
  (`quarkus:dev`) with `apicurio.ai-catalog.enabled=true` and `apicurio.ard.enabled=true`,
  seeded with `AGENT_CARD`/`MCP_TOOL` sample artifacts (reused from the project's own test
  suite), confirming `/.well-known/ai-catalog.json`, `/.well-known/ard.json`,
  `POST /ard/search`, and `POST /ard/explore` all work end-to-end.
- `claudedocs/9973-conformance-cli-output.md` — full output of the official
  `ards-project/ard-spec` `conformance-test` CLI, run against the same local instance:
  **manifest mode PASSES** (0 errors, 2 expected warnings); **registry mode FAILS** because
  `GET /.well-known/ard/agents` returns the manifest-shaped `{entries: [...]}` envelope
  instead of the `{items: [...]}` paginated shape the CLI's Registry API mode requires. This
  is reported as a real, reproducible gap for separate follow-up — not fixed in this PR
  (out of scope per the task).
- `claudedocs/9973-ai-catalog-listing-draft.md` — the actual current content of
  `Agent-Card/ai-catalog`'s `docs/implementations.md` (fetched via `gh api`), plus a
  drafted (not submitted) diff/PR description adding Apicurio to the "Community Projects"
  section, in the same style as the existing "Official" entries.

## Why

ADR-0004 Step 5 ("Get listed") requires this evidence before any of the harder,
infrastructure/organizational decisions (public instance, actual external PR, Discord/TSC
engagement) can responsibly be made by a human. This PR captures everything that can safely
be done without provisioning real public infrastructure or committing the project to an
external org's repo.

## What's still needed (human action, not done here)

- Decide on and provision a real public/staging HTTPS instance (hosting, TLS, domain,
  ongoing ownership) — required for the `ref_implementations` listing bar.
- Re-run `conformance-test registry <public-url>` and `conformance-test publisher <domain>`
  against that instance once it exists.
- Triage/fix the `GET /ard/agents` items-vs-entries shape gap found above (recommend a new,
  separate issue).
- Review and, if desired, actually fork+submit the drafted PR to `Agent-Card/ai-catalog`.
- Join the AI Catalog Discord, attend one TSC meeting, file 1–2 scoped issues (ADR-0004
  community engagement plan) — inherently human actions.

Refs #9973