### PR TITLE
perf(rest): check Accept-Encoding before resolving dynamic compression config (#9887)

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/HttpCompressionWriterInterceptor.java
+++ b/app/src/main/java/io/apicurio/registry/rest/HttpCompressionWriterInterceptor.java
@@ -61,9 +61,14 @@ public class HttpCompressionWriterInterceptor implements WriterInterceptor {
     }
 
     private boolean isCompressible(WriterInterceptorContext context) {
-        if (!restConfig.isCompressionEnabled()) {
-            return false;
-        }
+        // Check cheap, purely local conditions (headers already on hand, and the
+        // quarkus.http.compress-media-types list, which is a static/env-derived property resolved
+        // once and cached in compressMediaTypes) before resolving the dynamic
+        // apicurio.rest.compression.enabled property below. That last check is the only one that
+        // goes through the @Dynamic Supplier/MicroProfile Config resolution chain, so ordering it
+        // last means a request with no Accept-Encoding header, an already-encoded body, or a
+        // non-compressible media type - the common case for most responses - never pays that cost
+        // at all.
         String acceptEncoding = httpHeaders.getHeaderString(HttpHeaders.ACCEPT_ENCODING);
         if (!clientAcceptsGzip(acceptEncoding)) {
             return false;
@@ -75,8 +80,11 @@ public class HttpCompressionWriterInterceptor implements WriterInterceptor {
         if (mediaType == null) {
             return false;
         }
-        return getCompressMediaTypes().contains(
-                (mediaType.getType() + "/" + mediaType.getSubtype()).toLowerCase(Locale.ROOT));
+        if (!getCompressMediaTypes().contains(
+                (mediaType.getType() + "/" + mediaType.getSubtype()).toLowerCase(Locale.ROOT))) {
+            return false;
+        }
+        return restConfig.isCompressionEnabled();
     }
 
     private List<String> getCompressMediaTypes() {

--- a/app/src/test/java/io/apicurio/registry/config/RegistryStorageConfigCacheTest.java
+++ b/app/src/test/java/io/apicurio/registry/config/RegistryStorageConfigCacheTest.java
@@ -1,0 +1,138 @@
+package io.apicurio.registry.config;
+
+import io.apicurio.common.apps.config.DynamicConfigPropertyDto;
+import io.apicurio.registry.storage.RegistryStorage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link RegistryStorageConfigCache}: an in-memory cache of dynamic config property
+ * reads, invalidated on local writes and refreshed periodically (bounded, for cross-replica
+ * consistency) - see the class javadoc/{@link io.apicurio.registry.storage.decorator.RegistryStorageDecoratorOrderConstants}.
+ */
+public class RegistryStorageConfigCacheTest {
+
+    private RegistryStorage delegate;
+    private RegistryStorageConfigCache cache;
+
+    @BeforeEach
+    void setUp() {
+        delegate = mock(RegistryStorage.class);
+
+        cache = new RegistryStorageConfigCache();
+        cache.enabled = true;
+        cache.log = LoggerFactory.getLogger(RegistryStorageConfigCacheTest.class);
+        cache.setDelegate(delegate);
+    }
+
+    @Test
+    void getConfigPropertyCachesAcrossRepeatedCalls() {
+        DynamicConfigPropertyDto property = new DynamicConfigPropertyDto("apicurio.some.property", "value");
+        when(delegate.getConfigProperty("apicurio.some.property")).thenReturn(property);
+
+        DynamicConfigPropertyDto first = cache.getConfigProperty("apicurio.some.property");
+        DynamicConfigPropertyDto second = cache.getConfigProperty("apicurio.some.property");
+
+        assertEquals(property, first);
+        assertEquals(property, second);
+        verify(delegate, times(1)).getConfigProperty("apicurio.some.property");
+    }
+
+    @Test
+    void getConfigPropertyCachesNotFoundResultToo() {
+        when(delegate.getConfigProperty("apicurio.missing.property")).thenReturn(null);
+
+        DynamicConfigPropertyDto first = cache.getConfigProperty("apicurio.missing.property");
+        DynamicConfigPropertyDto second = cache.getConfigProperty("apicurio.missing.property");
+
+        assertNull(first);
+        assertNull(second);
+        // The "not found" result must be cached too (a NULL_DTO sentinel internally), not just the
+        // present-value case, otherwise a property that legitimately has no override configured
+        // would hit storage on every single read forever.
+        verify(delegate, times(1)).getConfigProperty("apicurio.missing.property");
+    }
+
+    @Test
+    void setConfigPropertyInvalidatesTheWholeCache() {
+        DynamicConfigPropertyDto propertyA = new DynamicConfigPropertyDto("apicurio.a", "1");
+        DynamicConfigPropertyDto propertyB = new DynamicConfigPropertyDto("apicurio.b", "1");
+        when(delegate.getConfigProperty("apicurio.a")).thenReturn(propertyA);
+        when(delegate.getConfigProperty("apicurio.b")).thenReturn(propertyB);
+
+        // Warm the cache for both properties.
+        cache.getConfigProperty("apicurio.a");
+        cache.getConfigProperty("apicurio.b");
+        verify(delegate, times(1)).getConfigProperty("apicurio.a");
+        verify(delegate, times(1)).getConfigProperty("apicurio.b");
+
+        DynamicConfigPropertyDto updatedA = new DynamicConfigPropertyDto("apicurio.a", "2");
+        cache.setConfigProperty(updatedA);
+        verify(delegate).setConfigProperty(updatedA);
+
+        // Both entries must be invalidated (not just the one that was written), since the cache
+        // invalidates in bulk rather than per-key.
+        when(delegate.getConfigProperty("apicurio.a")).thenReturn(updatedA);
+        cache.getConfigProperty("apicurio.a");
+        cache.getConfigProperty("apicurio.b");
+        verify(delegate, times(2)).getConfigProperty("apicurio.a");
+        verify(delegate, times(2)).getConfigProperty("apicurio.b");
+    }
+
+    @Test
+    void scheduledRefreshInvalidatesCacheWhenStalePropertiesAreDetected() {
+        DynamicConfigPropertyDto property = new DynamicConfigPropertyDto("apicurio.a", "1");
+        when(delegate.getConfigProperty("apicurio.a")).thenReturn(property);
+        when(delegate.isReady()).thenReturn(true);
+
+        // Warm the cache, then run the scheduled refresh once so lastRefresh is set to a non-null
+        // instant (the first run only records a baseline timestamp - see class javadoc/refresh()).
+        cache.getConfigProperty("apicurio.a");
+        cache.run();
+        verify(delegate, times(1)).getConfigProperty("apicurio.a");
+
+        // No stale properties: cache must NOT be invalidated.
+        when(delegate.getStaleConfigProperties(any(Instant.class))).thenReturn(List.of());
+        cache.run();
+        cache.getConfigProperty("apicurio.a");
+        verify(delegate, times(1)).getConfigProperty("apicurio.a");
+
+        // A stale property reported by storage (e.g. another replica wrote a new value): cache
+        // must be invalidated, so the next read goes back to storage.
+        when(delegate.getStaleConfigProperties(any(Instant.class))).thenReturn(List.of(property));
+        cache.run();
+        cache.getConfigProperty("apicurio.a");
+        verify(delegate, times(2)).getConfigProperty("apicurio.a");
+    }
+
+    @Test
+    void scheduledRefreshDoesNothingWhenDisabled() {
+        cache.enabled = false;
+
+        cache.run();
+
+        verify(delegate, times(0)).isReady();
+        verify(delegate, times(0)).getStaleConfigProperties(any(Instant.class));
+    }
+
+    @Test
+    void isEnabledReflectsConfigProperty() {
+        cache.enabled = true;
+        assertEquals(true, cache.isEnabled());
+
+        cache.enabled = false;
+        assertEquals(false, cache.isEnabled());
+    }
+}

--- a/app/src/test/java/io/apicurio/registry/rest/HttpCompressionWriterInterceptorAroundWriteToTest.java
+++ b/app/src/test/java/io/apicurio/registry/rest/HttpCompressionWriterInterceptorAroundWriteToTest.java
@@ -1,0 +1,123 @@
+package io.apicurio.registry.rest;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.WriterInterceptorContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link HttpCompressionWriterInterceptor#aroundWriteTo}, in particular that cheap,
+ * purely local checks (Accept-Encoding, already-encoded body, compressible media type) are
+ * evaluated before the dynamic {@code apicurio.rest.compression.enabled} property is resolved, so
+ * that property is never consulted for requests/responses that could never be compressed anyway.
+ */
+class HttpCompressionWriterInterceptorAroundWriteToTest {
+
+    @BeforeAll
+    static void setCompressMediaTypes() {
+        System.setProperty("quarkus.http.compress-media-types", "application/json");
+    }
+
+    @AfterAll
+    static void clearCompressMediaTypes() {
+        System.clearProperty("quarkus.http.compress-media-types");
+    }
+
+    private static WriterInterceptorContext mockContext(MediaType mediaType) throws Exception {
+        WriterInterceptorContext context = mock(WriterInterceptorContext.class);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        when(context.getHeaders()).thenReturn(headers);
+        when(context.getMediaType()).thenReturn(mediaType);
+        when(context.getOutputStream()).thenReturn(new ByteArrayOutputStream());
+        return context;
+    }
+
+    private static HttpCompressionWriterInterceptor interceptorWithAcceptEncoding(String acceptEncoding,
+            RestConfig restConfig) {
+        HttpCompressionWriterInterceptor interceptor = new HttpCompressionWriterInterceptor();
+        HttpHeaders httpHeaders = mock(HttpHeaders.class);
+        when(httpHeaders.getHeaderString(HttpHeaders.ACCEPT_ENCODING)).thenReturn(acceptEncoding);
+        interceptor.httpHeaders = httpHeaders;
+        interceptor.restConfig = restConfig;
+        return interceptor;
+    }
+
+    @Test
+    void doesNotResolveCompressionConfig_whenClientDoesNotAcceptGzip() throws Exception {
+        RestConfig restConfig = mock(RestConfig.class);
+        HttpCompressionWriterInterceptor interceptor = interceptorWithAcceptEncoding(null, restConfig);
+        WriterInterceptorContext context = mockContext(MediaType.APPLICATION_JSON_TYPE);
+
+        interceptor.aroundWriteTo(context);
+
+        verify(context).proceed();
+        verify(restConfig, never()).isCompressionEnabled();
+        assertNull(context.getHeaders().getFirst(HttpHeaders.CONTENT_ENCODING));
+    }
+
+    @Test
+    void doesNotResolveCompressionConfig_whenAlreadyEncoded() throws Exception {
+        RestConfig restConfig = mock(RestConfig.class);
+        HttpCompressionWriterInterceptor interceptor = interceptorWithAcceptEncoding("gzip", restConfig);
+        WriterInterceptorContext context = mockContext(MediaType.APPLICATION_JSON_TYPE);
+        context.getHeaders().putSingle(HttpHeaders.CONTENT_ENCODING, "br");
+
+        interceptor.aroundWriteTo(context);
+
+        verify(context).proceed();
+        verify(restConfig, never()).isCompressionEnabled();
+    }
+
+    @Test
+    void doesNotResolveCompressionConfig_whenMediaTypeNotCompressible() throws Exception {
+        RestConfig restConfig = mock(RestConfig.class);
+        HttpCompressionWriterInterceptor interceptor = interceptorWithAcceptEncoding("gzip", restConfig);
+        WriterInterceptorContext context = mockContext(MediaType.TEXT_PLAIN_TYPE);
+
+        interceptor.aroundWriteTo(context);
+
+        verify(context).proceed();
+        verify(restConfig, never()).isCompressionEnabled();
+    }
+
+    @Test
+    void resolvesCompressionConfig_andCompresses_whenEligibleAndEnabled() throws Exception {
+        RestConfig restConfig = mock(RestConfig.class);
+        when(restConfig.isCompressionEnabled()).thenReturn(true);
+        HttpCompressionWriterInterceptor interceptor = interceptorWithAcceptEncoding("gzip", restConfig);
+        WriterInterceptorContext context = mockContext(MediaType.APPLICATION_JSON_TYPE);
+
+        interceptor.aroundWriteTo(context);
+
+        verify(context).proceed();
+        verify(restConfig).isCompressionEnabled();
+        assertEquals("gzip", context.getHeaders().getFirst(HttpHeaders.CONTENT_ENCODING));
+    }
+
+    @Test
+    void resolvesCompressionConfig_butSkipsCompression_whenDisabled() throws Exception {
+        RestConfig restConfig = mock(RestConfig.class);
+        when(restConfig.isCompressionEnabled()).thenReturn(false);
+        HttpCompressionWriterInterceptor interceptor = interceptorWithAcceptEncoding("gzip", restConfig);
+        WriterInterceptorContext context = mockContext(MediaType.APPLICATION_JSON_TYPE);
+
+        interceptor.aroundWriteTo(context);
+
+        verify(context).proceed();
+        verify(restConfig).isCompressionEnabled();
+        assertNull(context.getHeaders().getFirst(HttpHeaders.CONTENT_ENCODING));
+    }
+}


### PR DESCRIPTION
## What

Workstream 3 of #9887 ("Dynamic configuration") turned out to be mostly already done, and this PR
is scoped to what was genuinely still missing plus closing a test-coverage gap.

### Investigation: is there already an in-memory snapshot?

The issue's ask was: "Replace storage-backed per-request reads with an in-memory atomically
replaced snapshot. Update via: event-driven invalidation OR documented bounded refresh mechanism."

`RegistryStorageConfigCache` (`app/src/main/java/io/apicurio/registry/config/`) already does
exactly this, and has since `Dynamic config properties (final?)` (#2304) - long before this
epic existed:

- A `RegistryStorageDecorator` wrapping `RegistryStorage#getConfigProperty`/`setConfigProperty` in
  a `ConcurrentHashMap`.
- Local writes invalidate the whole cache immediately (`setConfigProperty` → `invalidateCache()`).
- A `@Scheduled` job (`apicurio.config.refresh.every`, default `1m`) polls
  `getStaleConfigProperties(since)` and invalidates if anything changed - the "bounded refresh
  mechanism" for multi-replica consistency (a replica that didn't make the write itself sees it
  within one refresh interval).
- `apicurio.config.cache.enabled` (default `true`) to disable it entirely if needed.

So that part of the workstream needed no new implementation - just confirming it's real and
correcting the tracking assumption that it still needed to be built.

### What was genuinely missing

The issue also explicitly calls out: "Check Accept-Encoding before resolving compression
configuration." That part was **not** done: `HttpCompressionWriterInterceptor.isCompressible()`
called the `@Dynamic Supplier<Boolean> apicurio.rest.compression.enabled` property **first**,
unconditionally, on every single response - before checking the Accept-Encoding header, whether
the body was already encoded, or whether the media type is even compressible. Even with
`RegistryStorageConfigCache` avoiding a storage hit, that `Supplier#get()` call still walks the
full MicroProfile Config resolution chain (`ConfigSource`s by ordinal, `ConfigProducerUtil`,
boxing) on every response, including the common case of a client that sent no `Accept-Encoding`
header at all.

Fixed by reordering `isCompressible()`: check the cheap, purely local conditions first (header
already in hand, media type check backed by a static/env-derived property already cached in a
field), and only resolve the dynamic property once all of them already indicate compression could
apply. Same final behavior - verified via the existing end-to-end `HttpCompressionTest`
(unmodified, 8/8 still passing) - just skips the dynamic config resolution entirely for responses
that could never be compressed anyway.

### Also: test coverage

`RegistryStorageConfigCache` had **zero** test coverage despite existing since 2019. Added
`RegistryStorageConfigCacheTest` covering cache-hit avoidance, caching of not-found results, bulk
invalidation on write, and the scheduled stale-property refresh (both the no-op and invalidating
cases) - this is now regression-protected for any future change to this decorator.

## Why

Workstream 3 of the performance epic tracked in #9887 (~6.8% of the profiled JFR overhead
attributed to per-request dynamic config resolution).

## Testing

- New `RegistryStorageConfigCacheTest` (6 cases) - first test coverage this class has ever had.
- New `HttpCompressionWriterInterceptorAroundWriteToTest` (5 cases) - verifies
  `restConfig.isCompressionEnabled()` is never invoked when the cheap checks already rule out
  compression, and is correctly invoked (and respected) when they don't.
- Existing `HttpCompressionWriterInterceptorTest` (29 cases, static Accept-Encoding parser) and
  `HttpCompressionTest` (8 cases, full `@QuarkusTest` end-to-end): both unmodified, still pass.
- `./mvnw checkstyle:check -pl app`: clean.
- `./mvnw clean install -pl app -am -DskipTests`: full build succeeds.

Relates to #9887 (not closing it - covers only workstream 3; other workstreams are tracked
separately, and this one turned out to be smaller in scope than the original analysis assumed).
