### PR TITLE
fix(perf): stop the external load validation passing while measuring nothing

### DIFF
--- a/.github/workflows/perf-main.yaml
+++ b/.github/workflows/perf-main.yaml
@@ -171,25 +171,35 @@ jobs:
 
       # A single Gatling process's own connection handling degrades well before the registry's
       # actual capacity does above roughly 250-300 concurrent connections (see
-      # perf-tests/k8s/README.md and perf-tests/k8s/common/run-external-load.sh) - so this runs at
-      # a concurrency safely below that, from *outside* the cluster, to validate a real
-      # higher-concurrency read-throughput number without either the load generator's own
-      # connection-handling limit or in-cluster resource sharing confounding the result. Runs for
-      # 3 minutes (not a short smoke-test duration) because throughput was found to be understated
-      # by more than 3x in short (20-30s) runs due to JVM/JIT warm-up - see
+      # perf-tests/k8s/README.md and perf-tests/k8s/common/run-external-load.sh) - so this runs
+      # from *outside* the cluster to validate a real higher-concurrency read-throughput number
+      # without the load generator's own connection-handling limit confounding the result. Runs
+      # for 3 minutes (not a short smoke-test duration) because throughput was found to be
+      # understated by more than 3x in short (20-30s) runs due to JVM/JIT warm-up - see
       # run-external-load.sh's usage comment. This is the same methodology used to produce the
       # sizing-guide numbers in
       # docs/modules/ROOT/pages/getting-started/assembly-registry-sizing-guide.adoc.
       #
-      # Informational only, like the baseline check above (see this workflow's top-of-file
-      # comment on why perf-main doesn't hard-gate on performance trends) - GitHub-hosted runners
-      # vary in underlying hardware/noisy-neighbor conditions run to run, so a single failed
-      # attempt here isn't treated as a hard signal.
+      # PERF_EXTERNAL_USERS is deliberately well below the 200 this used to run at. The "outside
+      # the cluster" premise in run-external-load.sh - that the generator gets the machine's own
+      # resources rather than competing with the workload - holds on a dedicated box, but *not*
+      # on a GitHub-hosted runner, where Minikube is that same machine. At 200 the registry,
+      # Postgres/Kafka, Keycloak, Toxiproxy, the operator and a 200-user Gatling JVM all
+      # contended for the runner's 4 vCPUs and the registry became repeatedly unavailable
+      # mid-run: ~95% of requests failed with ECONNREFUSED in bursts on a ~30-40s cycle, which is
+      # a restart loop, not a latency measurement. Raise this only on a dedicated machine.
+      #
+      # The measured *numbers* stay informational (continue-on-error) - GitHub-hosted runners
+      # vary in hardware and noisy-neighbour conditions, so a single slow attempt is not a hard
+      # signal. Whether the run happened at all is a different question and is gated below.
       - name: Run external high-concurrency read validation
         if: always()
         continue-on-error: true
         timeout-minutes: 10
         working-directory: perf-tests
+        env:
+          PERF_EXTERNAL_USERS: '50'
+          PERF_EXTERNAL_DURATION: '180'
         run: |
           JAR=$(find target -name 'apicurio-registry-perf-tests-*-jar-with-dependencies.jar' | head -1)
           if [ -z "$JAR" ]; then
@@ -197,16 +207,70 @@ jobs:
             exit 0
           fi
           mkdir -p /tmp/external-load-results
+          # No bare `|| true` here: a non-zero exit means the load run itself failed (for example
+          # Gatling's own <=1% failed-events assertion), and that has to stay visible. `|| RC=$?`
+          # captures it without `set -e` aborting the step first, so the summary below is still
+          # written; the step is continue-on-error, so re-raising it marks the step red without
+          # failing the job.
+          RC=0
           GATLING_RESULTS_FOLDER=/tmp/external-load-results/gatling \
-            ./k8s/common/run-external-load.sh "$JAR" 200 180 0 \
-            > /tmp/external-load-results/console.log 2>&1 || true
+            ./k8s/common/run-external-load.sh "$JAR" \
+            "$PERF_EXTERNAL_USERS" "$PERF_EXTERNAL_DURATION" 0 \
+            > /tmp/external-load-results/console.log 2>&1 || RC=$?
           tail -n 60 /tmp/external-load-results/console.log
           {
-            echo "### External high-concurrency read validation (${{ matrix.storage }}, 200 concurrent clients)"
+            echo "### External high-concurrency read validation (${{ matrix.storage }}, ${PERF_EXTERNAL_USERS} concurrent clients)"
             echo '```'
             grep -A11 "Global Information" /tmp/external-load-results/console.log | tail -11 || echo "(no summary captured - see uploaded artifact)"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+          exit $RC
+
+      # Cluster-side state, captured whatever the outcome. Without this the only artefact of a
+      # collapsed run was a Gatling report full of ECONNREFUSED with nothing to say why, which is
+      # what made the failure above unexplainable for as long as it went unnoticed.
+      - name: Capture cluster diagnostics
+        if: always()
+        run: |
+          mkdir -p /tmp/external-load-results/diagnostics
+          cd /tmp/external-load-results/diagnostics
+          kubectl -n default get pods -o wide > pods.txt 2>&1 || true
+          kubectl -n default get events --sort-by=.lastTimestamp > events.txt 2>&1 || true
+          kubectl -n default describe deployment perf-test-app-deployment > app-deployment.txt 2>&1 || true
+          for p in $(kubectl -n default get pods -l app=perf-test-app -o name 2>/dev/null); do
+            n=$(basename "$p")
+            kubectl -n default describe "$p" > "describe-$n.txt" 2>&1 || true
+            kubectl -n default logs "$p" --tail=-1 > "logs-$n.txt" 2>&1 || true
+            # The interesting log when a pod is restarting is the one from the container that died.
+            kubectl -n default logs "$p" --previous --tail=-1 > "logs-previous-$n.txt" 2>&1 || true
+          done
+          RESTARTS=$(kubectl -n default get pods -l app=perf-test-app \
+            -o jsonpath='{.items[*].status.containerStatuses[*].restartCount}' 2>/dev/null || echo "")
+          echo "registry pod restartCount: ${RESTARTS:-unknown}" | tee restarts.txt
+
+      # The numbers being slow is informational; the target having been down is not a measurement
+      # at all, and silently reporting it as one is how a 95%-ECONNREFUSED run was published as a
+      # throughput figure. Gate on the run being *valid*, separately from what it measured.
+      - name: Verify the external load run was valid
+        if: always()
+        working-directory: perf-tests
+        run: |
+          LOG=/tmp/external-load-results/console.log
+          if [ ! -f "$LOG" ]; then
+            echo "No external load console log - the validation step did not run." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if ! grep -q "Global Information" "$LOG"; then
+            echo "::error::External load run produced no Gatling summary - the run did not complete."
+            exit 1
+          fi
+          # Capture rather than pipe: piping into tee would make tee's exit status the step's,
+          # which is the same class of mistake as the `|| true` this change removes.
+          RC=0
+          OUT=$(python3 scripts/check-external-validity.py "$LOG" --max-ko-percent 25) || RC=$?
+          printf '%s\n' "$OUT"
+          printf '%s\n' "$OUT" >> "$GITHUB_STEP_SUMMARY"
+          exit $RC
 
       - name: Upload external validation results
         if: always()

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -77,6 +77,9 @@ jobs:
       - name: Test performance comparison result parser
         run: python3 -m unittest discover -s perf-comparison-tests/scripts -p 'test_*.py' -v
 
+      - name: Test performance test result parsers
+        run: python3 -m unittest discover -s perf-tests/scripts -p 'test_*.py' -v
+
       - name: Verify docs generation
         run: |
           if [ -n "$(git status --untracked-files=no --porcelain docs)" ]; then

--- a/perf-tests/scripts/check-external-validity.py
+++ b/perf-tests/scripts/check-external-validity.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Decide whether an external load run produced a usable measurement.
+
+This is deliberately *not* a performance check - perf-tests/scripts/check-thresholds.py
+already compares latency and throughput against the baseline, and those numbers are
+informational on GitHub-hosted runners because the hardware varies run to run.
+
+This answers the prior question: did the run actually exercise the registry at all? A run
+where most requests never got a TCP connection is not a slow measurement, it is an absent
+one, and reporting its "throughput" as a result is worse than reporting nothing - the
+figure is dominated by the rate of failed connects. That is exactly what happened when the
+external validation ran at 200 concurrent clients on a GitHub runner: ~95% ECONNREFUSED in
+bursts on a ~30-40s cycle (a restart loop), published as a throughput number, for weeks,
+while the job stayed green.
+
+Exit status is 0 when the run is usable and 1 when it is not, so the calling step fails.
+"""
+
+import argparse
+import re
+import sys
+
+# "> KO       1,406,042 (94.74%)" in Gatling's Response Time Distribution block.
+KO_LINE = re.compile(r"^>\s*KO\s+([\d,]+)\s+\(\s*([\d.]+)%\)", re.MULTILINE)
+# "> request count   | 1,484,140 |    78,098 | 1,406,042"
+REQUEST_COUNT_LINE = re.compile(
+    r"^>\s*request count\s*\|\s*([\d,]+)\s*\|\s*([\d,]+)\s*\|\s*([\d,]+)", re.MULTILINE
+)
+# Gatling echoes each distinct failure with its own share of the total errors.
+ERROR_LINE = re.compile(r"^>\s*(\S.*?)\s{2,}([\d,]+)\s+\(\s*[\d.]+%\)", re.MULTILINE)
+
+# Failures that mean the target was not reachable, as opposed to the target answering with
+# something we did not want. The distinction matters: a 500 is the registry being unhappy,
+# an ECONNREFUSED is the registry not being there.
+UNREACHABLE_MARKERS = (
+    "Connection refused",
+    "Connection reset by peer",
+    "Premature close",
+    "connection timed out",
+    "No route to host",
+)
+
+
+def _int(text):
+    return int(text.replace(",", ""))
+
+
+def parse(log_text):
+    ko_match = KO_LINE.search(log_text)
+    count_match = REQUEST_COUNT_LINE.search(log_text)
+    if not ko_match or not count_match:
+        return None
+
+    total, ok, ko = (_int(g) for g in count_match.groups())
+    unreachable = 0
+    # Only the Errors block matters; take everything after the last "---- Errors" header.
+    errors_block = log_text.rsplit("---- Errors", 1)[-1] if "---- Errors" in log_text else ""
+    for label, count in ERROR_LINE.findall(errors_block):
+        if any(marker in label for marker in UNREACHABLE_MARKERS):
+            unreachable += _int(count)
+
+    return {
+        "total": total,
+        "ok": ok,
+        "ko": ko,
+        "ko_percent": float(ko_match.group(2)),
+        "unreachable": unreachable,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", help="run-external-load.sh console log")
+    parser.add_argument(
+        "--max-ko-percent",
+        type=float,
+        default=25.0,
+        help="fail above this percentage of failed requests (default: 25)",
+    )
+    args = parser.parse_args()
+
+    try:
+        with open(args.log, encoding="utf-8", errors="replace") as handle:
+            log_text = handle.read()
+    except OSError as exc:
+        print(f"::error::Cannot read {args.log}: {exc}")
+        return 1
+
+    stats = parse(log_text)
+    if stats is None:
+        print("::error::No parseable Gatling summary in the external load log - the run did not complete.")
+        return 1
+
+    print("### External load run validity")
+    print("")
+    print("| metric | value |")
+    print("| --- | --- |")
+    print(f"| requests | {stats['total']:,} |")
+    print(f"| ok | {stats['ok']:,} |")
+    print(f"| failed | {stats['ko']:,} ({stats['ko_percent']:.2f}%) |")
+    print(f"| of which unreachable (connect/reset/close) | {stats['unreachable']:,} |")
+    print(f"| threshold | {args.max_ko_percent:.2f}% |")
+    print("")
+
+    if stats["ko_percent"] > args.max_ko_percent:
+        detail = ""
+        if stats["unreachable"] > stats["ko"] / 2:
+            detail = (
+                " Most failures are connect-level, so the registry was unreachable for much of"
+                " the run rather than merely slow - check the captured diagnostics for restarts."
+            )
+        print(
+            f"::error::External load run is not a usable measurement: {stats['ko_percent']:.2f}%"
+            f" of {stats['total']:,} requests failed (threshold {args.max_ko_percent:.2f}%).{detail}"
+        )
+        return 1
+
+    print(f"Run is usable: {stats['ko_percent']:.2f}% failed requests is within the "
+          f"{args.max_ko_percent:.2f}% threshold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/perf-tests/scripts/test_check_external_validity.py
+++ b/perf-tests/scripts/test_check_external_validity.py
@@ -1,0 +1,135 @@
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location(
+    "check_external_validity",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "check-external-validity.py"),
+)
+cev = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cev)
+
+
+COLLAPSED = """
+========================================================================================================================
+---- Global Information -------------------------------------------------------------|---Total---|-----OK----|----KO----
+> request count                                                                      | 1,484,140 |    78,098 | 1,406,042
+> mean throughput (rps)                                                              |   7,420.7 |    390.49 |  7,030.21
+---- Response Time Distribution ----------------------------------------------------------------------------------------
+> OK: t < 800 ms                                                                                         75,703   (5.1%)
+> KO                                                                                                  1,406,042 (94.74%)
+---- Errors ------------------------------------------------------------------------------------------------------------
+> j.n.ConnectException: finishConnect(..) failed with error(-111): Connection refused                 1,404,879 (99.92%)
+> status.find.is(200), but actually found 500                                                               686  (0.05%)
+> j.i.IOException: Premature close                                                                          467  (0.03%)
+========================================================================================================================
+"""
+
+HEALTHY = """
+========================================================================================================================
+---- Global Information -------------------------------------------------------------|---Total---|-----OK----|----KO----
+> request count                                                                      |     9,739 |     9,739 |         0
+---- Response Time Distribution ----------------------------------------------------------------------------------------
+> OK: t < 800 ms                                                                                          9,739   (100%)
+> KO                                                                                                          0     (0%)
+========================================================================================================================
+"""
+
+# Target reachable, but answering with errors - slow/unhappy, not absent.
+APP_ERRORS = """
+========================================================================================================================
+---- Global Information -------------------------------------------------------------|---Total---|-----OK----|----KO----
+> request count                                                                      |     1,000 |       600 |       400
+---- Response Time Distribution ----------------------------------------------------------------------------------------
+> KO                                                                                                        400    (40%)
+---- Errors ------------------------------------------------------------------------------------------------------------
+> status.find.is(200), but actually found 500                                                               400   (100%)
+========================================================================================================================
+"""
+
+
+class ParseTests(unittest.TestCase):
+
+    def test_collapsed_run_counts_and_attributes_unreachable(self):
+        stats = cev.parse(COLLAPSED)
+        self.assertEqual(stats["total"], 1484140)
+        self.assertEqual(stats["ok"], 78098)
+        self.assertEqual(stats["ko"], 1406042)
+        self.assertAlmostEqual(stats["ko_percent"], 94.74)
+        # Connection refused + premature close, but not the HTTP 500s.
+        self.assertEqual(stats["unreachable"], 1404879 + 467)
+
+    def test_healthy_run(self):
+        stats = cev.parse(HEALTHY)
+        self.assertEqual(stats["total"], 9739)
+        self.assertEqual(stats["ko"], 0)
+        self.assertEqual(stats["ko_percent"], 0.0)
+        self.assertEqual(stats["unreachable"], 0)
+
+    def test_http_errors_are_not_counted_as_unreachable(self):
+        stats = cev.parse(APP_ERRORS)
+        self.assertEqual(stats["ko"], 400)
+        self.assertEqual(stats["unreachable"], 0)
+
+    def test_no_summary_returns_none(self):
+        self.assertIsNone(cev.parse("Gatling started...\nno summary here\n"))
+
+
+class ExitStatusTests(unittest.TestCase):
+
+    def _run(self, text, argv_extra=()):
+        path = os.path.join(self._dir, "log.txt")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        argv = sys.argv
+        sys.argv = ["check-external-validity.py", path, *argv_extra]
+        buffer = io.StringIO()
+        try:
+            with redirect_stdout(buffer):
+                code = cev.main()
+        finally:
+            sys.argv = argv
+        return code, buffer.getvalue()
+
+    def setUp(self):
+        import tempfile
+        self._tmp = tempfile.TemporaryDirectory()
+        self._dir = self._tmp.name
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_collapsed_run_fails(self):
+        code, out = self._run(COLLAPSED)
+        self.assertEqual(code, 1)
+        self.assertIn("not a usable measurement", out)
+        self.assertIn("connect-level", out)
+
+    def test_healthy_run_passes(self):
+        code, out = self._run(HEALTHY)
+        self.assertEqual(code, 0)
+        self.assertIn("Run is usable", out)
+
+    def test_threshold_is_respected(self):
+        # 40% failures: over the default 25, under an explicit 50.
+        self.assertEqual(self._run(APP_ERRORS)[0], 1)
+        self.assertEqual(self._run(APP_ERRORS, ("--max-ko-percent", "50"))[0], 0)
+
+    def test_app_error_failure_is_not_blamed_on_unreachability(self):
+        _, out = self._run(APP_ERRORS)
+        self.assertNotIn("connect-level", out)
+
+    def test_missing_summary_fails(self):
+        code, out = self._run("nothing useful\n")
+        self.assertEqual(code, 1)
+        self.assertIn("did not complete", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #10003

`Performance Tests (main)` has been green while its external high-concurrency read validation failed ~95% of requests on every run. Full evidence in #10003; summary of the three faults and what changes here.

## 1. Nothing could fail

The step was `continue-on-error: true` *and* ended in `|| true`, so neither the load script's exit status nor Gatling's own `<=1% failed events` assertion could surface.

Removed the `|| true`. The exit status is captured with `|| RC=$?` — rather than `RC=$?` on the next line, which `set -e` never reaches — so the step summary is still written before the status is re-raised. The step stays `continue-on-error`, so this marks it red without failing the job on a merely slow run.

## 2. The target was down, not slow

Refused requests arrive in bursts on a ~30-40s cycle, which is repeated unavailability rather than a steady error rate. The premise stated in `run-external-load.sh` — that running the generator outside the cluster gives it the machine's own resources — holds on a dedicated box but not on a GitHub-hosted runner, where Minikube is that same machine and everything contends for 4 vCPUs.

CI concurrency drops from 200 to 50 via `PERF_EXTERNAL_USERS`. The script's own default stays 200 for dedicated machines and the sizing-guide methodology is unchanged.

**50 is an informed estimate, not a measured figure.** 200 demonstrably collapses; the in-cluster job passes at 20. If 50 still collapses, this job will now go red rather than report a fabricated number — that is the intent, and the diagnostics below will explain it.

## 3. Nothing explained it

New "Capture cluster diagnostics" step records pod state, events, deployment description, current *and previous* container logs, and restart counts, whatever the outcome. Previously a collapsed run left only a Gatling report full of ECONNREFUSED.

## Gating validity separately from performance

Latency and throughput stay informational — runner hardware genuinely varies. Whether the run *happened* is a different question and is now gated.

`perf-tests/scripts/check-external-validity.py` parses the Gatling summary, distinguishes connect-level failures (target absent) from HTTP errors (target unhappy), and fails above a 25% failure rate. Its output is captured rather than piped, since `| tee` would make tee's status the step's — the same class of mistake as the `|| true` being removed here.

## Verification

Run against the real artifacts from run 33779773642:

- the 95.76% collapsed run exits 1 and reports `Most failures are connect-level, so the registry was unreachable for much of the run rather than merely slow`
- the healthy in-cluster run (9,739 requests, 0 failed) exits 0

9 unit tests cover collapsed, healthy, HTTP-error-only, threshold boundary and unparseable-log cases, including that an HTTP-500-only failure is *not* attributed to unreachability. They run in the lint job next to the existing `perf-comparison-tests` parser tests, which is why `verify.yaml` is touched.

Both workflow files parse, and the changed shell was exercised under `bash -e` for both outcomes.
