### PR TITLE
fix(rest): accept whole-number decimal literals for integer prompt template defaults

### DIFF
--- a/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
+++ b/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
@@ -59,6 +59,13 @@ public class PromptRenderingService {
     private static final Pattern UNLESS_BLOCK_PATTERN =
             Pattern.compile("\\{\\{#unless\\s+(\\w+)\\}\\}((?:(?!\\{\\{/unless\\}\\})[\\s\\S])*?)\\{\\{/unless\\}\\}");
 
+    private static final String TYPE_STRING = "string";
+    private static final String TYPE_INTEGER = "integer";
+    private static final String TYPE_NUMBER = "number";
+    private static final String TYPE_BOOLEAN = "boolean";
+    private static final String TYPE_ARRAY = "array";
+    private static final String TYPE_OBJECT = "object";
+
     /**
      * Renders a prompt template by substituting variables.
      *
@@ -179,7 +186,7 @@ public class PromptRenderingService {
             if (effective == null) {
                 effective = new HashMap<>(variables);
             }
-            String declaredType = field.getValue().path("type").asText("string");
+            String declaredType = field.getValue().path("type").asText(TYPE_STRING);
             effective.put(varName, convertDefaultValue(defaultNode, declaredType));
         }
 
@@ -195,7 +202,7 @@ public class PromptRenderingService {
      */
     private Object convertDefaultValue(JsonNode defaultNode, String declaredType) {
         Object value = MAPPER.convertValue(defaultNode, Object.class);
-        if ("integer".equals(declaredType) && value instanceof Double doubleValue
+        if (TYPE_INTEGER.equals(declaredType) && value instanceof Double doubleValue
                 && doubleValue == Math.rint(doubleValue) && !doubleValue.isInfinite()) {
             return doubleValue.longValue();
         }
@@ -248,7 +255,7 @@ public class PromptRenderingService {
      */
     private void validateValue(String varName, Object value, JsonNode varSchema,
             List<RenderValidationError> errors) {
-        String expectedType = varSchema.path("type").asText("string");
+        String expectedType = varSchema.path("type").asText(TYPE_STRING);
         RenderValidationError typeError = validateType(varName, value, expectedType);
         if (typeError != null) {
             errors.add(typeError);
@@ -264,7 +271,7 @@ public class PromptRenderingService {
         }
 
         // Validate range for numeric types
-        if ("integer".equals(expectedType) || "number".equals(expectedType)) {
+        if (TYPE_INTEGER.equals(expectedType) || TYPE_NUMBER.equals(expectedType)) {
             RenderValidationError rangeError = validateRange(varName, value, varSchema);
             if (rangeError != null) {
                 errors.add(rangeError);
@@ -308,12 +315,12 @@ public class PromptRenderingService {
         String actualType = getTypeName(value);
 
         boolean valid = switch (expectedType) {
-            case "string" -> value instanceof String;
-            case "integer" -> value instanceof Integer || value instanceof Long;
-            case "number" -> value instanceof Number;
-            case "boolean" -> value instanceof Boolean;
-            case "array" -> value instanceof List;
-            case "object" -> value instanceof Map;
+            case TYPE_STRING -> value instanceof String;
+            case TYPE_INTEGER -> value instanceof Integer || value instanceof Long;
+            case TYPE_NUMBER -> value instanceof Number;
+            case TYPE_BOOLEAN -> value instanceof Boolean;
+            case TYPE_ARRAY -> value instanceof List;
+            case TYPE_OBJECT -> value instanceof Map;
             default -> true; // Unknown types pass validation
         };
 
@@ -392,12 +399,12 @@ public class PromptRenderingService {
      */
     private String getTypeName(Object value) {
         if (value == null) return "null";
-        if (value instanceof String) return "string";
-        if (value instanceof Integer || value instanceof Long) return "integer";
-        if (value instanceof Number) return "number";
-        if (value instanceof Boolean) return "boolean";
-        if (value instanceof List) return "array";
-        if (value instanceof Map) return "object";
+        if (value instanceof String) return TYPE_STRING;
+        if (value instanceof Integer || value instanceof Long) return TYPE_INTEGER;
+        if (value instanceof Number) return TYPE_NUMBER;
+        if (value instanceof Boolean) return TYPE_BOOLEAN;
+        if (value instanceof List) return TYPE_ARRAY;
+        if (value instanceof Map) return TYPE_OBJECT;
         return value.getClass().getSimpleName();
     }
 

--- a/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
+++ b/app/src/main/java/io/apicurio/registry/services/PromptRenderingService.java
@@ -179,10 +179,27 @@ public class PromptRenderingService {
             if (effective == null) {
                 effective = new HashMap<>(variables);
             }
-            effective.put(varName, MAPPER.convertValue(defaultNode, Object.class));
+            String declaredType = field.getValue().path("type").asText("string");
+            effective.put(varName, convertDefaultValue(defaultNode, declaredType));
         }
 
         return effective != null ? effective : variables;
+    }
+
+    /**
+     * Converts a declared default's JSON node to a Java value, coercing a whole-number decimal
+     * literal (e.g. {@code 5.0}) to {@code Long} when the variable's declared type is
+     * {@code integer}. YAML and JSON numeric literals with a decimal point always deserialize as
+     * a floating-point type, even when they represent a whole number, so without this coercion an
+     * {@code integer}-typed default written as {@code 5.0} would fail its own type validation.
+     */
+    private Object convertDefaultValue(JsonNode defaultNode, String declaredType) {
+        Object value = MAPPER.convertValue(defaultNode, Object.class);
+        if ("integer".equals(declaredType) && value instanceof Double doubleValue
+                && doubleValue == Math.rint(doubleValue) && !doubleValue.isInfinite()) {
+            return doubleValue.longValue();
+        }
+        return value;
     }
 
     /**

--- a/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
+++ b/app/src/test/java/io/apicurio/registry/services/PromptRenderingServiceTest.java
@@ -498,6 +498,75 @@ public class PromptRenderingServiceTest {
         Assertions.assertEquals("count", response.getValidationErrors().get(0).getVariableName());
     }
 
+    @Test
+    public void testWholeNumberDecimalDefaultIsAcceptedForIntegerType() {
+        // A YAML/JSON numeric literal with a decimal point always deserializes as a
+        // floating-point value, even when it represents a whole number (5.0 -> Double 5.0).
+        // An "integer"-typed default written this way must still be accepted and rendered
+        // as a plain integer, not reported as a type mismatch against its own default.
+        String yamlContent = """
+            templateId: limits
+            template: "Limit: {{max_results}}"
+            variables:
+              max_results:
+                type: integer
+                default: 5.0
+            """;
+
+        ContentHandle content = ContentHandle.create(yamlContent);
+
+        RenderPromptResponse response = renderingService.render(content, Map.of(),
+                "default", "limits", "1.0");
+
+        Assertions.assertTrue(response.getValidationErrors().isEmpty());
+        Assertions.assertEquals("Limit: 5", response.getRendered());
+    }
+
+    @Test
+    public void testFractionalDefaultIsStillRejectedForIntegerType() {
+        // A genuinely fractional default (not a whole number) must still fail validation
+        // against an "integer" type; only whole-number decimal literals are coerced.
+        String yamlContent = """
+            templateId: limits
+            template: "Limit: {{max_results}}"
+            variables:
+              max_results:
+                type: integer
+                default: 5.5
+            """;
+
+        ContentHandle content = ContentHandle.create(yamlContent);
+
+        RenderPromptResponse response = renderingService.render(content, Map.of(),
+                "default", "limits", "1.0");
+
+        Assertions.assertEquals(1, response.getValidationErrors().size());
+        Assertions.assertEquals("max_results", response.getValidationErrors().get(0).getVariableName());
+        Assertions.assertEquals("integer", response.getValidationErrors().get(0).getExpectedType());
+    }
+
+    @Test
+    public void testWholeNumberDecimalDefaultUnaffectedForNumberType() {
+        // A "number"-typed default should be unaffected by the integer-specific coercion
+        // and keep its original decimal representation.
+        String yamlContent = """
+            templateId: temp
+            template: "Temperature: {{temp}}"
+            variables:
+              temp:
+                type: number
+                default: 5.0
+            """;
+
+        ContentHandle content = ContentHandle.create(yamlContent);
+
+        RenderPromptResponse response = renderingService.render(content, Map.of(),
+                "default", "temp", "1.0");
+
+        Assertions.assertTrue(response.getValidationErrors().isEmpty());
+        Assertions.assertEquals("Temperature: 5.0", response.getRendered());
+    }
+
     // ===== Enum Validation Tests =====
 
     @Test


### PR DESCRIPTION
Closes #10016

## Summary

An `integer`-typed prompt template variable's declared `default` is rejected by its own
type validation when written as a whole-number decimal literal (e.g. `default: 5.0`),
because Jackson always deserializes a YAML/JSON decimal literal as a `Double`, and
`validateType()` only accepted `Integer`/`Long` for `type: integer`. Since
`validateAppliedDefaults()` runs this check against every default that gets filled in
(added by #9309), a template author writing a perfectly natural default like `5.0` gets
a spurious "Type mismatch: expected integer but got number" error, even though the
caller never touched that variable.

This PR coerces a whole-number `Double`/`Float` default to `Long` in `applyDefaults()`
when the variable's declared type is `integer`. A genuinely fractional default (e.g.
`5.5`) is untouched and still correctly rejected. `number`-typed defaults are unaffected.

Verified with a standalone repro against the project's Jackson/YAML versions:
```
default: 5              -> Integer = 5
default: 5.0            -> Double  = 5.0   (previously failed integer type check)
default: 1000000000000  -> Long    = 1000000000000
```

Also extracted the repeated `"integer"`/`"string"` type-name literals in
`PromptRenderingService` into named constants, addressing the SonarCloud
maintainability findings raised on this PR's diff.

## Checklist

- [x] No overlapping open PRs for the same issue
- [x] Checked the [Tried & Rejected list](https://github.com/Apicurio/apicurio-registry/discussions/8364)
- [x] Tests added for new code paths
- [x] Tested locally: `./mvnw test -pl app -Dtest=PromptRenderingServiceTest -Dlocal` — 60/60 passing
- [x] `./mvnw checkstyle:check -pl app` passes (zero violations)
- [x] All commits have DCO sign-off (`git commit -s`)

### Notes

- **Local test run**: previously blocked in my environment because the reactor's
  `java-sdk` module (a compile dependency of `app`) requires the Kiota code generator,
  which needs a working .NET/libicu runtime. That's now resolved (`libicu-dev`
  installed), and `./mvnw test -pl app -Dtest=PromptRenderingServiceTest -Dlocal`
  passes all 60 tests, including the 3 new regression tests for this fix.
