### PR TITLE
fix(ui): show the ProblemDetails message when a prompt template render fails

### DIFF
--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.test.ts
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.test.ts
@@ -3,6 +3,7 @@ import {
     buildInitialValues,
     buildVersionIdentity,
     coerceEnumValue,
+    renderErrorMessage,
     shouldAcceptRenderResponse
 } from "./PromptTemplateTestPanel.utils";
 
@@ -109,5 +110,26 @@ describe("shouldAcceptRenderResponse", () => {
 
     it("rejects a stale response after the version identity changes", () => {
         expect(shouldAcceptRenderResponse(3, 3, "g::a::1", "g::a::2")).toBe(false);
+    });
+});
+
+describe("renderErrorMessage", () => {
+    it("prefers the ProblemDetails detail", () => {
+        expect(renderErrorMessage({
+            title: "Bad Request",
+            detail: "Variable 'customerName' is required but was not provided."
+        })).toBe("Variable 'customerName' is required but was not provided.");
+    });
+
+    it("falls back to the ProblemDetails title", () => {
+        expect(renderErrorMessage({ title: "Not Found" })).toBe("Not Found");
+    });
+
+    it("uses the message of a plain error", () => {
+        expect(renderErrorMessage(new Error("Network Error"))).toBe("Network Error");
+    });
+
+    it("uses the generic text when nothing is usable", () => {
+        expect(renderErrorMessage(undefined)).toBe("Error rendering prompt template");
     });
 });

--- a/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.ts
+++ b/ui/ui-app/src/app/components/promptTemplate/PromptTemplateTestPanel.utils.ts
@@ -89,3 +89,8 @@ export const shouldAcceptRenderResponse = (
 ): boolean => {
     return requestId === latestRequestId && requestVersionIdentity === currentVersionIdentity;
 };
+
+/** Text shown when a Render request fails: ProblemDetails detail, then title, then the error message. */
+export const renderErrorMessage = (err: any): string => {
+    return err?.detail || err?.title || err?.message || "Error rendering prompt template";
+};

--- a/ui/ui-app/src/app/components/promptTemplate/usePromptTemplateTestPanelState.ts
+++ b/ui/ui-app/src/app/components/promptTemplate/usePromptTemplateTestPanelState.ts
@@ -4,6 +4,7 @@ import { RenderPromptResponse, RenderPromptValidationError } from "@models/Rende
 import {
     buildInitialValues,
     buildVersionIdentity,
+    renderErrorMessage,
     shouldAcceptRenderResponse
 } from "./PromptTemplateTestPanel.utils";
 import { VariableSchema } from "./promptTemplateVariables";
@@ -112,7 +113,7 @@ export const usePromptTemplateTestPanelState = (
                 )) {
                     return;
                 }
-                setError(err?.message || "Error rendering prompt template");
+                setError(renderErrorMessage(err));
             })
             .finally(() => {
                 if (!shouldAcceptRenderResponse(


### PR DESCRIPTION
Closes #9423

## Summary

When a render request fails, the Test Prompt panel showed the generic "Error rendering prompt template" no matter what the server said. `renderPromptTemplate` rejects with the ProblemDetails body, and the panel only looked at `err.message`, which a ProblemDetails object does not have.

The panel now reads `detail`, then `title`, then `message`, the same order ArtifactPage and RulesPage already use for rule failures. The lookup lives in `PromptTemplateTestPanel.utils.ts` next to the other panel helpers so it can be unit tested.

Before and after, with the render call answered by the 400 body from the issue:

![Render Error alert before and after](https://raw.githubusercontent.com/iamtanishqjain/apicurio-registry/assets/9423/render-error.png)

Three files, 29 lines added, 1 removed. No dependency or config changes.

## Checklist

- [ ] Linked issue has maintainer approval
- [x] No overlapping open PRs for the same issue
- [x] Checked the [Tried & Rejected list](https://github.com/Apicurio/apicurio-registry/discussions/8364)
- [x] Tests added for new code paths
- [x] Tested locally: `npm run lint` and `npm run test` in `ui/ui-app` (23/23 in the utils suite)
- [ ] `./mvnw checkstyle:check -pl <module>` passes (UI only, no Java touched)
- [x] All commits have DCO sign-off (`git commit -s`)
