### PR TITLE
fix(config): correct AI Catalog and ARD availableSince

### DIFF
--- a/app/src/main/java/io/apicurio/registry/aicatalog/AiCatalogConfig.java
+++ b/app/src/main/java/io/apicurio/registry/aicatalog/AiCatalogConfig.java
@@ -15,19 +15,19 @@ import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_AIC
 public class AiCatalogConfig {
 
     @ConfigProperty(name = "apicurio.ai-catalog.enabled", defaultValue = "false")
-    @Info(category = CATEGORY_AICATALOG, description = "Enable the AI Catalog well-known discovery endpoint", availableSince = "3.3.2", experimental = true)
+    @Info(category = CATEGORY_AICATALOG, description = "Enable the AI Catalog well-known discovery endpoint", availableSince = "3.3.3", experimental = true)
     boolean enabled;
 
     @ConfigProperty(name = "apicurio.ai-catalog.publisher-domain")
-    @Info(category = CATEGORY_AICATALOG, description = "The publisher domain segment used when building 'urn:air:' identifiers for AI Catalog entries. When not configured, the domain is derived from the incoming request's host and port.", availableSince = "3.3.2")
+    @Info(category = CATEGORY_AICATALOG, description = "The publisher domain segment used when building 'urn:air:' identifiers for AI Catalog entries. When not configured, the domain is derived from the incoming request's host and port.", availableSince = "3.3.3")
     Optional<String> publisherDomain;
 
     @ConfigProperty(name = "apicurio.ai-catalog.host-name", defaultValue = "Apicurio Registry")
-    @Info(category = CATEGORY_AICATALOG, description = "Display name for this registry instance, reported as the AI Catalog host", availableSince = "3.3.2")
+    @Info(category = CATEGORY_AICATALOG, description = "Display name for this registry instance, reported as the AI Catalog host", availableSince = "3.3.3")
     String hostName;
 
     @ConfigProperty(name = "apicurio.ai-catalog.spec-version", defaultValue = "1.0")
-    @Info(category = CATEGORY_AICATALOG, description = "The AI Catalog specification version reported in the catalog document", availableSince = "3.3.2")
+    @Info(category = CATEGORY_AICATALOG, description = "The AI Catalog specification version reported in the catalog document", availableSince = "3.3.3")
     String specVersion;
 
     public boolean isEnabled() {

--- a/app/src/main/java/io/apicurio/registry/ard/ArdConfig.java
+++ b/app/src/main/java/io/apicurio/registry/ard/ArdConfig.java
@@ -13,11 +13,11 @@ import static io.apicurio.common.apps.config.ConfigPropertyCategory.CATEGORY_ARD
 public class ArdConfig {
 
     @ConfigProperty(name = "apicurio.ard.enabled", defaultValue = "false")
-    @Info(category = CATEGORY_ARD, description = "Enable the ARD (Agentic Resource Discovery) well-known API endpoints", availableSince = "3.3.2", experimental = true)
+    @Info(category = CATEGORY_ARD, description = "Enable the ARD (Agentic Resource Discovery) well-known API endpoints", availableSince = "3.3.3", experimental = true)
     boolean enabled;
 
     @ConfigProperty(name = "apicurio.ard.federation.default", defaultValue = "none")
-    @Info(category = CATEGORY_ARD, description = "Default ARD federation mode advertised by this registry. Only 'none' (no federation) is currently implemented.", availableSince = "3.3.2")
+    @Info(category = CATEGORY_ARD, description = "Default ARD federation mode advertised by this registry. Only 'none' (no federation) is currently implemented.", availableSince = "3.3.3")
     String federationDefault;
 
     public boolean isEnabled() {

--- a/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
+++ b/docs/modules/ROOT/partials/getting-started/ref-registry-all-configs.adoc
@@ -96,22 +96,22 @@ The following {registry} configuration options are available for each component 
 |`apicurio.ai-catalog.enabled`
 |`boolean`
 |`false`
-|`3.3.2`
+|`3.3.3`
 |Enable the AI Catalog well-known discovery endpoint _(experimental)_
 |`apicurio.ai-catalog.host-name`
 |`string`
 |`Apicurio Registry`
-|`3.3.2`
+|`3.3.3`
 |Display name for this registry instance, reported as the AI Catalog host
 |`apicurio.ai-catalog.publisher-domain`
 |`optional<string>`
 |
-|`3.3.2`
+|`3.3.3`
 |The publisher domain segment used when building 'urn:air:' identifiers for AI Catalog entries. When not configured, the domain is derived from the incoming request's host and port.
 |`apicurio.ai-catalog.spec-version`
 |`string`
 |`1.0`
-|`3.3.2`
+|`3.3.3`
 |The AI Catalog specification version reported in the catalog document
 |===
 
@@ -163,12 +163,12 @@ The following {registry} configuration options are available for each component 
 |`apicurio.ard.enabled`
 |`boolean`
 |`false`
-|`3.3.2`
+|`3.3.3`
 |Enable the ARD (Agentic Resource Discovery) well-known API endpoints _(experimental)_
 |`apicurio.ard.federation.default`
 |`string`
 |`none`
-|`3.3.2`
+|`3.3.3`
 |Default ARD federation mode advertised by this registry. Only 'none' (no federation) is currently implemented.
 |===
 


### PR DESCRIPTION
Closes #10008

## Summary

Correct the `availableSince` metadata for the six AI Catalog and ARD configuration properties that first ship in 3.3.3, but were documented as available in 3.3.2.

This updates the four properties in `AiCatalogConfig`, the two properties in `ArdConfig`, and the corresponding six "Available from" cells in the generated configuration reference. There are no runtime behavior changes.

## Validation

- `git diff --check` passes.
- `./mvnw -pl app checkstyle:check -Dlocal -DskipTests` passes using JDK 21.
- Verified the configuration-reference diff is limited to the same six version cells.

## Checklist

- [ ] Linked issue has maintainer approval
- [x] No overlapping open PRs for the same issue
- [x] Checked the [Tried & Rejected list](https://github.com/Apicurio/apicurio-registry/discussions/8364)
- [x] Tests added for new code paths — N/A, metadata/documentation-only change
- [ ] Tested locally: `./mvnw test -pl <module> -am -Dlocal` — N/A, no runtime code paths changed
- [x] `./mvnw checkstyle:check -pl <module>` passes
- [x] All commits have DCO sign-off (`git commit -s`)
