### PR TITLE
feat(cli): support artifact branch management

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -512,6 +512,46 @@ acr artifact version comment update -g <group-id> -a <artifact-id> -v <version> 
 acr artifact version comment delete -g <group-id> -a <artifact-id> -v <version> <comment-id>
 ```
 
+### Working with Branches
+
+Branches are named, ordered lists of versions within an artifact (for example a `latest`
+branch, or a `1.x` maintenance line). Every artifact has a system-defined `latest` branch.
+Branch commands use the `groupId`/`artifactId` from the current context when `-g`/`-a` are
+not given.
+
+**List branches (with pagination and JSON output):**
+```bash
+acr artifact branch -g <group-id> -a <artifact-id>
+acr artifact branch -g <group-id> -a <artifact-id> --page <page> --size <size>
+acr artifact branch -g <group-id> -a <artifact-id> --output-type json
+```
+
+**Create a branch (optionally seeded with an initial, tip-to-oldest version list):**
+```bash
+acr artifact branch create <branch-id> -g <group-id> -a <artifact-id> --description <description>
+acr artifact branch create <branch-id> -g <group-id> -a <artifact-id> --version 2.0.0 --version 1.0.0
+acr artifact branch create <branch-id> -g <group-id> -a <artifact-id> --version 2.0.0,1.0.0
+```
+
+**Get, update, or delete branch metadata:**
+```bash
+acr artifact branch get <branch-id> -g <group-id> -a <artifact-id>
+acr artifact branch update <branch-id> -g <group-id> -a <artifact-id> --description <description>
+acr artifact branch delete <branch-id> -g <group-id> -a <artifact-id>
+```
+
+**Manage the versions on a branch:**
+```bash
+# List the versions on a branch (supports --page/--size and --output-type)
+acr artifact branch version -g <group-id> -a <artifact-id> -b <branch-id>
+
+# Add a version to the tip of a branch
+acr artifact branch version add -g <group-id> -a <artifact-id> -b <branch-id> <version>
+
+# Replace the full, ordered (tip-to-oldest) list of versions on a branch
+acr artifact branch version replace -g <group-id> -a <artifact-id> -b <branch-id> <version> [<version>...]
+```
+
 ### Working with Rules
 
 Rules enforce content validation at the global, group, or artifact level.

--- a/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/artifact/ArtifactCommand.java
@@ -1,6 +1,7 @@
 package io.apicurio.registry.cli.artifact;
 
 import io.apicurio.registry.cli.Acr;
+import io.apicurio.registry.cli.branch.BranchCommand;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.ArtifactOrderMixin;
 import io.apicurio.registry.cli.common.ColumnsMixin;
@@ -45,6 +46,7 @@ import static io.apicurio.registry.cli.utils.Conversions.convertToString;
                 ArtifactGetCommand.class,
                 ArtifactRuleCommand.class,
                 ArtifactUpdateCommand.class,
+                BranchCommand.class,
                 VersionCommand.class
         }
 )

--- a/cli/src/main/java/io/apicurio/registry/cli/branch/AbstractBranchCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/branch/AbstractBranchCommand.java
@@ -1,0 +1,45 @@
+package io.apicurio.registry.cli.branch;
+
+import io.apicurio.registry.cli.common.AbstractCommand;
+import io.apicurio.registry.cli.common.IdUtil;
+import io.apicurio.registry.rest.client.RegistryClient;
+import io.apicurio.registry.rest.client.groups.item.artifacts.item.branches.BranchesRequestBuilder;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Shared base for the {@code acr artifact branch} commands. Holds the group and artifact
+ * options, resolves them (falling back to the CLI context), and validates that both exist
+ * before returning the branches request builder for the artifact.
+ */
+@Command
+abstract class AbstractBranchCommand extends AbstractCommand {
+
+    @Option(
+            names = {"-g", "--group"},
+            description = "Group ID. If not provided, uses the groupId from the current context, or 'default'."
+    )
+    protected String groupId;
+
+    @Option(
+            names = {"-a", "--artifact"},
+            description = "Artifact ID. If not provided, uses the artifactId from the current context."
+    )
+    protected String artifactId;
+
+    protected String resolvedGroupId() {
+        return IdUtil.resolveGroupId(groupId, config);
+    }
+
+    protected String resolvedArtifactId() {
+        return IdUtil.resolveArtifactId(artifactId, config);
+    }
+
+    protected BranchesRequestBuilder branches(final String resolvedGroupId, final String resolvedArtifactId) {
+        final RegistryClient registryClient = client.getRegistryClient();
+        IdUtil.validateGroup(registryClient, resolvedGroupId);
+        IdUtil.validateArtifact(registryClient, resolvedGroupId, resolvedArtifactId);
+        return registryClient.groups().byGroupId(resolvedGroupId).artifacts().byArtifactId(resolvedArtifactId)
+                .branches();
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/branch/AbstractBranchVersionCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/branch/AbstractBranchVersionCommand.java
@@ -1,0 +1,28 @@
+package io.apicurio.registry.cli.branch;
+
+import io.apicurio.registry.cli.common.IdUtil;
+import io.apicurio.registry.rest.client.groups.item.artifacts.item.branches.item.versions.VersionsRequestBuilder;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Shared base for the {@code acr artifact branch version add|replace} commands. Adds the
+ * required branch option and validates the branch before returning its versions request
+ * builder.
+ */
+@Command
+abstract class AbstractBranchVersionCommand extends AbstractBranchCommand {
+
+    @Option(
+            names = {"-b", "--branch"},
+            description = "The branch ID.",
+            required = true
+    )
+    protected String branchId;
+
+    protected VersionsRequestBuilder branchVersions(final String resolvedGroupId, final String resolvedArtifactId) {
+        final var branchItem = branches(resolvedGroupId, resolvedArtifactId).byBranchId(branchId);
+        IdUtil.validateBranch(client.getRegistryClient(), resolvedGroupId, resolvedArtifactId, branchId);
+        return branchItem.versions();
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/branch/BranchCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/branch/BranchCommand.java
@@ -1,0 +1,98 @@
+package io.apicurio.registry.cli.branch;
+
+import io.apicurio.registry.cli.common.ColumnsMixin;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.common.PaginationMixin;
+import io.apicurio.registry.cli.utils.Mapper;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+
+import static io.apicurio.registry.cli.common.IdUtil.displayGroupId;
+import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_ID;
+import static io.apicurio.registry.cli.utils.Columns.BRANCH_ID;
+import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
+import static io.apicurio.registry.cli.utils.Columns.DESCRIPTION;
+import static io.apicurio.registry.cli.utils.Columns.GROUP_ID;
+import static io.apicurio.registry.cli.utils.Columns.MODIFIED_BY;
+import static io.apicurio.registry.cli.utils.Columns.MODIFIED_ON;
+import static io.apicurio.registry.cli.utils.Columns.OWNER;
+import static io.apicurio.registry.cli.utils.Columns.SYSTEM_DEFINED;
+import static io.apicurio.registry.cli.utils.Conversions.convert;
+import static io.apicurio.registry.cli.utils.Conversions.convertToString;
+
+/** Lists branches for an artifact with pagination support. */
+@Command(
+        name = "branch",
+        aliases = {"branches"},
+        description = "Work with artifact branches",
+        subcommands = {
+                BranchCreateCommand.class,
+                BranchDeleteCommand.class,
+                BranchGetCommand.class,
+                BranchUpdateCommand.class,
+                BranchVersionCommand.class
+        }
+)
+public class BranchCommand extends AbstractBranchCommand {
+
+    @Mixin
+    private PaginationMixin pagination;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Mixin
+    private ColumnsMixin columns;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var resolvedGroupId = resolvedGroupId();
+        final var resolvedArtifactId = resolvedArtifactId();
+        //noinspection ConstantConditions
+        final var branchResults = convert(branches(resolvedGroupId, resolvedArtifactId).get(r -> {
+            //noinspection ConstantConditions
+            r.queryParameters.offset = (pagination.getPage() - 1) * pagination.getSize();
+            r.queryParameters.limit = pagination.getSize();
+        }));
+        output.writeStdOutChunkWithException(out -> {
+            switch (outputType.getOutputType()) {
+                case json -> {
+                    out.append(Mapper.MAPPER.writeValueAsString(branchResults));
+                    out.append('\n');
+                }
+                case table -> {
+                    final var table = new TableBuilder();
+                    table.addColumns(
+                            GROUP_ID,
+                            ARTIFACT_ID,
+                            BRANCH_ID,
+                            DESCRIPTION,
+                            SYSTEM_DEFINED,
+                            CREATED_ON,
+                            OWNER,
+                            MODIFIED_ON,
+                            MODIFIED_BY
+                    );
+                    branchResults.getBranches().forEach(b -> {
+                        table.addRow(
+                                displayGroupId(b.getGroupId()),
+                                b.getArtifactId(),
+                                b.getBranchId(),
+                                b.getDescription(),
+                                convertToString(b.getSystemDefined()),
+                                convertToString(b.getCreatedOn()),
+                                b.getOwner(),
+                                convertToString(b.getModifiedOn()),
+                                b.getModifiedBy()
+                        );
+                    });
+                    table.setPagination(pagination.getPage(), pagination.getSize(), branchResults.getCount());
+                    table.setSelectedColumns(columns.getColumns());
+                    table.print(out);
+                }
+            }
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/branch/BranchCreateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/branch/BranchCreateCommand.java
@@ -1,0 +1,76 @@
+package io.apicurio.registry.cli.branch;
+
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.rest.client.models.CreateBranch;
+import java.util.List;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import static io.apicurio.registry.cli.branch.BranchGetCommand.printBranch;
+import static io.apicurio.registry.cli.utils.Conversions.convert;
+import static io.apicurio.registry.cli.utils.Utils.isBlank;
+
+/** Creates a new branch for an artifact, optionally with an initial list of versions. */
+@Command(
+        name = "create",
+        aliases = {"add"},
+        description = "Create a new branch"
+)
+public class BranchCreateCommand extends AbstractBranchCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The branch ID."
+    )
+    private String branchId;
+
+    @Option(
+            names = {"--description"},
+            description = "Provide branch description."
+    )
+    private String description;
+
+    @Option(
+            names = {"--version"},
+            paramLabel = "<version>",
+            split = ",",
+            description = "A version to place on the branch initially, ordered from the tip to the oldest. "
+                    + "Repeat the option or use a comma-separated list to add several."
+    )
+    private List<String> versions;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var resolvedGroupId = resolvedGroupId();
+        final var resolvedArtifactId = resolvedArtifactId();
+
+        final var newBranch = new CreateBranch();
+        newBranch.setBranchId(branchId);
+        if (!isBlank(description)) {
+            newBranch.setDescription(description);
+        }
+        if (versions != null) {
+            newBranch.setVersions(versions);
+        }
+
+        //noinspection ConstantConditions
+        final var result = convert(branches(resolvedGroupId, resolvedArtifactId).post(newBranch));
+        switch (outputType.getOutputType()) {
+            case json -> output.writeStdErrChunk(out -> successMessage(out, resolvedGroupId, resolvedArtifactId, branchId));
+            case table -> output.writeStdOutChunk(out -> successMessage(out, resolvedGroupId, resolvedArtifactId, branchId));
+        }
+        printBranch(output, result, outputType.getOutputType());
+    }
+
+    private static void successMessage(final StringBuilder out, final String groupId,
+                                       final String artifactId, final String branchId) {
+        out.append("Branch '").append(branchId).append("' created successfully for artifact '")
+                .append(artifactId).append("' in group '").append(groupId).append("'.\n");
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/branch/BranchDeleteCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/branch/BranchDeleteCommand.java
@@ -1,0 +1,32 @@
+package io.apicurio.registry.cli.branch;
+
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/** Deletes a branch from an artifact. System-defined branches cannot be deleted. */
+@Command(
+        name = "delete",
+        aliases = {"remove", "rm"},
+        description = "Delete a branch"
+)
+public class BranchDeleteCommand extends AbstractBranchCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The branch ID."
+    )
+    private String branchId;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var resolvedGroupId = resolvedGroupId();
+        final var resolvedArtifactId = resolvedArtifactId();
+        branches(resolvedGroupId, resolvedArtifactId).byBranchId(branchId).delete();
+        output.writeStdOutChunk(out -> {
+            out.append("Branch '").append(branchId).append("' for artifact '")
+                    .append(resolvedArtifactId).append("' in group '")
+                    .append(resolvedGroupId).append("' deleted successfully.\n");
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/branch/BranchGetCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/branch/BranchGetCommand.java
@@ -1,0 +1,80 @@
+package io.apicurio.registry.cli.branch;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apicurio.registry.cli.common.OutputType;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.v3.beans.BranchMetaData;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Parameters;
+
+import static io.apicurio.registry.cli.common.IdUtil.displayGroupId;
+import static io.apicurio.registry.cli.utils.Columns.ARTIFACT_ID;
+import static io.apicurio.registry.cli.utils.Columns.BRANCH_ID;
+import static io.apicurio.registry.cli.utils.Columns.CREATED_ON;
+import static io.apicurio.registry.cli.utils.Columns.DESCRIPTION;
+import static io.apicurio.registry.cli.utils.Columns.FIELD;
+import static io.apicurio.registry.cli.utils.Columns.GROUP_ID;
+import static io.apicurio.registry.cli.utils.Columns.MODIFIED_BY;
+import static io.apicurio.registry.cli.utils.Columns.MODIFIED_ON;
+import static io.apicurio.registry.cli.utils.Columns.OWNER;
+import static io.apicurio.registry.cli.utils.Columns.SYSTEM_DEFINED;
+import static io.apicurio.registry.cli.utils.Columns.VALUE;
+import static io.apicurio.registry.cli.utils.Conversions.convert;
+import static io.apicurio.registry.cli.utils.Conversions.convertToString;
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+
+/** Retrieves a branch's metadata. */
+@Command(
+        name = "get",
+        description = "Get a branch"
+)
+public class BranchGetCommand extends AbstractBranchCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The branch ID."
+    )
+    private String branchId;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var resolvedGroupId = resolvedGroupId();
+        final var resolvedArtifactId = resolvedArtifactId();
+        //noinspection ConstantConditions
+        final var branch = convert(branches(resolvedGroupId, resolvedArtifactId)
+                .byBranchId(branchId).get());
+        printBranch(output, branch, outputType.getOutputType());
+    }
+
+    static void printBranch(final OutputBuffer output, final BranchMetaData branch,
+                            final OutputType outputType) throws JsonProcessingException {
+        output.writeStdOutChunkWithException(out -> {
+            switch (outputType) {
+                case json -> {
+                    out.append(MAPPER.writeValueAsString(branch));
+                    out.append('\n');
+                }
+                case table -> {
+                    final var table = new TableBuilder();
+                    table.addColumns(FIELD, VALUE);
+                    table.addRow(GROUP_ID, displayGroupId(branch.getGroupId()));
+                    table.addRow(ARTIFACT_ID, branch.getArtifactId());
+                    table.addRow(BRANCH_ID, branch.getBranchId());
+                    table.addRow(DESCRIPTION, branch.getDescription());
+                    table.addRow(SYSTEM_DEFINED, convertToString(branch.getSystemDefined()));
+                    table.addRow(CREATED_ON, convertToString(branch.getCreatedOn()));
+                    table.addRow(OWNER, branch.getOwner());
+                    table.addRow(MODIFIED_ON, convertToString(branch.getModifiedOn()));
+                    table.addRow(MODIFIED_BY, branch.getModifiedBy());
+                    table.print(out);
+                }
+            }
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/branch/BranchUpdateCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/branch/BranchUpdateCommand.java
@@ -1,0 +1,46 @@
+package io.apicurio.registry.cli.branch;
+
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.rest.client.models.EditableBranchMetaData;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+/** Updates a branch's metadata (description). */
+@Command(
+        name = "update",
+        description = "Update a branch"
+)
+public class BranchUpdateCommand extends AbstractBranchCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The branch ID."
+    )
+    private String branchId;
+
+    @Option(
+            names = {"--description"},
+            description = "Updated branch description."
+    )
+    private String description;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        if (description == null) {
+            throw new CliException("At least one update option is required (--description).",
+                    CliException.VALIDATION_ERROR_RETURN_CODE);
+        }
+        final var resolvedGroupId = resolvedGroupId();
+        final var resolvedArtifactId = resolvedArtifactId();
+        final var updatedBranch = new EditableBranchMetaData();
+        updatedBranch.setDescription(description);
+        branches(resolvedGroupId, resolvedArtifactId).byBranchId(branchId).put(updatedBranch);
+        output.writeStdOutChunk(out -> {
+            out.append("Branch '").append(branchId).append("' for artifact '")
+                    .append(resolvedArtifactId).append("' in group '")
+                    .append(resolvedGroupId).append("' updated successfully.\n");
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/branch/BranchVersionAddCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/branch/BranchVersionAddCommand.java
@@ -1,0 +1,34 @@
+package io.apicurio.registry.cli.branch;
+
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.rest.client.models.AddVersionToBranch;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/** Adds a version to the tip of a branch. */
+@Command(
+        name = "add",
+        description = "Add a version to a branch"
+)
+public class BranchVersionAddCommand extends AbstractBranchVersionCommand {
+
+    @Parameters(
+            index = "0",
+            description = "The version to add to the tip of the branch."
+    )
+    private String version;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var resolvedGroupId = resolvedGroupId();
+        final var resolvedArtifactId = resolvedArtifactId();
+        final var body = new AddVersionToBranch();
+        body.setVersion(version);
+        branchVersions(resolvedGroupId, resolvedArtifactId).post(body);
+        output.writeStdOutChunk(out -> {
+            out.append("Version '").append(version).append("' added to branch '")
+                    .append(branchId).append("' for artifact '").append(resolvedArtifactId)
+                    .append("' in group '").append(resolvedGroupId).append("'.\n");
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/branch/BranchVersionCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/branch/BranchVersionCommand.java
@@ -1,0 +1,61 @@
+package io.apicurio.registry.cli.branch;
+
+import io.apicurio.registry.cli.common.CliException;
+import io.apicurio.registry.cli.common.ColumnsMixin;
+import io.apicurio.registry.cli.common.OutputTypeMixin;
+import io.apicurio.registry.cli.common.PaginationMixin;
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.cli.version.VersionCommand;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+
+import static io.apicurio.registry.cli.utils.Conversions.convert;
+
+/** Lists the versions on a branch with pagination support. */
+@Command(
+        name = "version",
+        aliases = {"versions"},
+        description = "Work with the versions on a branch",
+        subcommands = {
+                BranchVersionAddCommand.class,
+                BranchVersionReplaceCommand.class
+        }
+)
+public class BranchVersionCommand extends AbstractBranchCommand {
+
+    @Option(
+            names = {"-b", "--branch"},
+            description = "The branch ID."
+    )
+    private String branchId;
+
+    @Mixin
+    private PaginationMixin pagination;
+
+    @Mixin
+    private OutputTypeMixin outputType;
+
+    @Mixin
+    private ColumnsMixin columns;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        if (branchId == null) {
+            throw new CliException("The branch ID is required. Provide it via --branch.",
+                    CliException.VALIDATION_ERROR_RETURN_CODE);
+        }
+        final var resolvedGroupId = resolvedGroupId();
+        final var resolvedArtifactId = resolvedArtifactId();
+        final var branchVersions = branches(resolvedGroupId, resolvedArtifactId)
+                .byBranchId(branchId).versions();
+        //noinspection ConstantConditions
+        final var versions = convert(branchVersions.get(r -> {
+            //noinspection ConstantConditions
+            r.queryParameters.offset = (pagination.getPage() - 1) * pagination.getSize();
+            r.queryParameters.limit = pagination.getSize();
+        }));
+        VersionCommand.printVersions(output, versions, outputType.getOutputType(),
+                pagination.getPage(), pagination.getSize(), columns.getColumns());
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/branch/BranchVersionReplaceCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/branch/BranchVersionReplaceCommand.java
@@ -1,0 +1,37 @@
+package io.apicurio.registry.cli.branch;
+
+import io.apicurio.registry.cli.utils.OutputBuffer;
+import io.apicurio.registry.rest.client.models.ReplaceBranchVersions;
+import java.util.List;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/** Replaces the full list of versions on a branch. */
+@Command(
+        name = "replace",
+        description = "Replace the list of versions on a branch"
+)
+public class BranchVersionReplaceCommand extends AbstractBranchVersionCommand {
+
+    @Parameters(
+            index = "0",
+            arity = "1..*",
+            paramLabel = "<version>",
+            description = "The new, ordered list of versions for the branch, from the tip to the oldest."
+    )
+    private List<String> versions;
+
+    @Override
+    public void run(final OutputBuffer output) throws Exception {
+        final var resolvedGroupId = resolvedGroupId();
+        final var resolvedArtifactId = resolvedArtifactId();
+        final var body = new ReplaceBranchVersions();
+        body.setVersions(versions);
+        branchVersions(resolvedGroupId, resolvedArtifactId).put(body);
+        output.writeStdOutChunk(out -> {
+            out.append("Versions on branch '").append(branchId).append("' for artifact '")
+                    .append(resolvedArtifactId).append("' in group '").append(resolvedGroupId)
+                    .append("' replaced successfully.\n");
+        });
+    }
+}

--- a/cli/src/main/java/io/apicurio/registry/cli/common/IdUtil.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/common/IdUtil.java
@@ -117,6 +117,13 @@ public final class IdUtil {
         client.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId).get();
     }
 
+    // Validates the branch exists for the given artifact.
+    public static void validateBranch(final RegistryClient client, final String groupId,
+                                      final String artifactId, final String branchId) {
+        client.groups().byGroupId(groupId).artifacts().byArtifactId(artifactId)
+                .branches().byBranchId(branchId).get();
+    }
+
     // Validates the version exists for the given artifact.
     public static void validateVersion(final RegistryClient client, final String groupId,
                                        final String artifactId, final String versionExpression) {

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/Columns.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/Columns.java
@@ -23,6 +23,8 @@ public final class Columns {
 
     public static final String VERSION = "Version";
     public static final String STATE = "State";
+    public static final String BRANCH_ID = "Branch ID";
+    public static final String SYSTEM_DEFINED = "System Defined";
     public static final String GLOBAL_ID = "Global ID";
     public static final String CONTENT_ID = "Content ID";
 

--- a/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/utils/Conversions.java
@@ -4,11 +4,14 @@ import io.apicurio.registry.cli.common.CliException;
 import io.apicurio.registry.rest.client.models.Labels;
 import io.apicurio.registry.rest.v3.beans.ArtifactMetaData;
 import io.apicurio.registry.rest.v3.beans.ArtifactSearchResults;
+import io.apicurio.registry.rest.v3.beans.BranchMetaData;
+import io.apicurio.registry.rest.v3.beans.BranchSearchResults;
 import io.apicurio.registry.rest.v3.beans.Comment;
 import io.apicurio.registry.rest.v3.beans.GroupMetaData;
 import io.apicurio.registry.rest.v3.beans.GroupSearchResults;
 import io.apicurio.registry.rest.v3.beans.Rule;
 import io.apicurio.registry.rest.v3.beans.SearchedArtifact;
+import io.apicurio.registry.rest.v3.beans.SearchedBranch;
 import io.apicurio.registry.rest.v3.beans.SearchedGroup;
 import io.apicurio.registry.rest.v3.beans.SearchedVersion;
 import io.apicurio.registry.rest.v3.beans.VersionMetaData;
@@ -160,6 +163,43 @@ public final class Conversions {
                 .build();
     }
 
+    public static BranchMetaData convert(io.apicurio.registry.rest.client.models.BranchMetaData branch) {
+        return BranchMetaData.builder()
+                .groupId(branch.getGroupId())
+                .artifactId(branch.getArtifactId())
+                .branchId(branch.getBranchId())
+                .description(branch.getDescription())
+                .systemDefined(branch.getSystemDefined())
+                .createdOn(convert(branch.getCreatedOn()))
+                .owner(branch.getOwner())
+                .modifiedOn(convert(branch.getModifiedOn()))
+                .modifiedBy(branch.getModifiedBy())
+                .build();
+    }
+
+    public static SearchedBranch convert(io.apicurio.registry.rest.client.models.SearchedBranch branch) {
+        return SearchedBranch.builder()
+                .groupId(branch.getGroupId())
+                .artifactId(branch.getArtifactId())
+                .branchId(branch.getBranchId())
+                .description(branch.getDescription())
+                .systemDefined(branch.getSystemDefined())
+                .createdOn(convert(branch.getCreatedOn()))
+                .owner(branch.getOwner())
+                .modifiedOn(convert(branch.getModifiedOn()))
+                .modifiedBy(branch.getModifiedBy())
+                .build();
+    }
+
+    public static BranchSearchResults convert(io.apicurio.registry.rest.client.models.BranchSearchResults searchResults) {
+        return BranchSearchResults.builder()
+                .branches(searchResults.getBranches().stream()
+                        .map(Conversions::convert)
+                        .collect(Collectors.toList()))
+                .count(searchResults.getCount())
+                .build();
+    }
+
     public static Comment convert(io.apicurio.registry.rest.client.models.Comment comment) {
         return Comment.builder()
                 .commentId(comment.getCommentId())
@@ -227,6 +267,10 @@ public final class Conversions {
     }
 
     public static String convertToString(Long value) {
+        return ofNullable(value).map(String::valueOf).orElse("");
+    }
+
+    public static String convertToString(Boolean value) {
         return ofNullable(value).map(String::valueOf).orElse("");
     }
 

--- a/cli/src/main/java/io/apicurio/registry/cli/version/VersionCommand.java
+++ b/cli/src/main/java/io/apicurio/registry/cli/version/VersionCommand.java
@@ -1,14 +1,18 @@
 package io.apicurio.registry.cli.version;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.apicurio.registry.cli.common.AbstractCommand;
 import io.apicurio.registry.cli.common.ColumnsMixin;
 import io.apicurio.registry.cli.common.IdUtil;
+import io.apicurio.registry.cli.common.OutputType;
 import io.apicurio.registry.cli.common.OutputTypeMixin;
 import io.apicurio.registry.cli.common.PaginationMixin;
 import io.apicurio.registry.cli.common.VersionOrderMixin;
 import io.apicurio.registry.cli.utils.Mapper;
 import io.apicurio.registry.cli.utils.OutputBuffer;
 import io.apicurio.registry.cli.utils.TableBuilder;
+import io.apicurio.registry.rest.v3.beans.VersionSearchResults;
+import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
@@ -82,8 +86,20 @@ public class VersionCommand extends AbstractCommand {
                     r.queryParameters.orderby = ordering.getOrderBy();
                     r.queryParameters.order = ordering.getOrder();
                 }));
+        printVersions(output, versions, outputType.getOutputType(),
+                pagination.getPage(), pagination.getSize(), columns.getColumns());
+    }
+
+    /**
+     * Renders a page of version search results as JSON or as a table, applying the given
+     * pagination footer and column selection. Shared by the artifact and branch version
+     * listing commands.
+     */
+    public static void printVersions(final OutputBuffer output, final VersionSearchResults versions,
+                                     final OutputType outputType, final int page, final int size,
+                                     final List<String> selectedColumns) throws JsonProcessingException {
         output.writeStdOutChunkWithException(out -> {
-            switch (outputType.getOutputType()) {
+            switch (outputType) {
                 case json -> {
                     out.append(Mapper.MAPPER.writeValueAsString(versions));
                     out.append('\n');
@@ -116,8 +132,8 @@ public class VersionCommand extends AbstractCommand {
                                 v.getOwner()
                         );
                     });
-                    table.setPagination(pagination.getPage(), pagination.getSize(), versions.getCount());
-                    table.setSelectedColumns(columns.getColumns());
+                    table.setPagination(page, size, versions.getCount());
+                    table.setSelectedColumns(selectedColumns);
                     table.print(out);
                 }
             }

--- a/cli/src/test/java/io/apicurio/registry/cli/BranchCommandTest.java
+++ b/cli/src/test/java/io/apicurio/registry/cli/BranchCommandTest.java
@@ -1,0 +1,286 @@
+package io.apicurio.registry.cli;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apicurio.registry.rest.v3.beans.BranchMetaData;
+import io.apicurio.registry.rest.v3.beans.BranchSearchResults;
+import io.apicurio.registry.rest.v3.beans.VersionSearchResults;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static io.apicurio.registry.cli.utils.Mapper.MAPPER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the artifact branch CLI commands.
+ */
+@QuarkusTest
+@TestMethodOrder(OrderAnnotation.class)
+public class BranchCommandTest extends AbstractCLITest {
+
+    private static final String TEST_GROUP = "branch-test-group-" + System.currentTimeMillis();
+    private static final String TEST_ARTIFACT = "branch-test-artifact-" + System.currentTimeMillis();
+
+    private void createArtifactVersion(String version, String type) throws Exception {
+        final Path tempFile = Files.createTempFile("branch-test", ".json");
+        Files.writeString(tempFile, "{\"type\": \"" + type + "\"}");
+        try {
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("artifact", "version", "create", "-g", TEST_GROUP,
+                    "-a", TEST_ARTIFACT, "--file", tempFile.toString(), version);
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @Test
+    @Order(0)
+    public void testSetup() throws Exception {
+        executeAndAssertSuccess("group", "create", TEST_GROUP);
+        final Path tempFile = Files.createTempFile("branch-test", ".json");
+        Files.writeString(tempFile, "{\"type\": \"string\"}");
+        try {
+            out.getBuffer().setLength(0);
+            executeAndAssertSuccess("artifact", "create", "-g", TEST_GROUP,
+                    "--type", "JSON", "--file", tempFile.toString(), "--version", "1.0.0", TEST_ARTIFACT);
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+        createArtifactVersion("2.0.0", "integer");
+        createArtifactVersion("3.0.0", "boolean");
+    }
+
+    @Test
+    public void testBranchHelp() {
+        testHelpCommand("artifact", "branch");
+        testHelpCommand("artifact", "branch", "create");
+        testHelpCommand("artifact", "branch", "get");
+        testHelpCommand("artifact", "branch", "update");
+        testHelpCommand("artifact", "branch", "delete");
+        testHelpCommand("artifact", "branch", "version");
+        testHelpCommand("artifact", "branch", "version", "add");
+        testHelpCommand("artifact", "branch", "version", "replace");
+    }
+
+    @Test
+    @Order(1)
+    public void testBranchListContainsSystemBranch() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "branch", "-g", TEST_GROUP, "-a", TEST_ARTIFACT,
+                "--output-type", "json");
+        var branches = MAPPER.readValue(out.toString(), BranchSearchResults.class);
+
+        assertThat(branches.getBranches())
+                .as(withCliOutput("Every artifact has a system-defined 'latest' branch."))
+                .anyMatch(b -> "latest".equals(b.getBranchId()) && Boolean.TRUE.equals(b.getSystemDefined()));
+    }
+
+    @Test
+    @Order(2)
+    public void testBranchCreate() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "branch", "create", "-g", TEST_GROUP, "-a", TEST_ARTIFACT,
+                "--description", "Stable 1.x line", "--output-type", "json", "1.x");
+        var branch = MAPPER.readValue(out.toString(), BranchMetaData.class);
+
+        assertThat(branch.getBranchId())
+                .as(withCliOutput("Created branch should have the requested ID"))
+                .isEqualTo("1.x");
+        assertThat(branch.getDescription())
+                .as(withCliOutput("Created branch should have the requested description"))
+                .isEqualTo("Stable 1.x line");
+        assertThat(branch.getSystemDefined())
+                .as(withCliOutput("A user-created branch is not system-defined"))
+                .isFalse();
+    }
+
+    @Test
+    @Order(3)
+    public void testBranchCreateWithInitialVersions() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "branch", "create", "-g", TEST_GROUP, "-a", TEST_ARTIFACT,
+                "--version", "2.0.0,1.0.0", "2.x");
+
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "branch", "version", "-g", TEST_GROUP, "-a", TEST_ARTIFACT,
+                "-b", "2.x", "--output-type", "json");
+        var versions = MAPPER.readValue(out.toString(), VersionSearchResults.class);
+
+        assertThat(versions.getVersions())
+                .as(withCliOutput("Branch should have been created with the two initial versions"))
+                .hasSize(2)
+                .extracting("version")
+                .containsExactlyInAnyOrder("2.0.0", "1.0.0");
+    }
+
+    @Test
+    @Order(4)
+    public void testBranchListWithPagination() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "branch", "-g", TEST_GROUP, "-a", TEST_ARTIFACT,
+                "--output-type", "json", "-p", "1", "-s", "1");
+        var branches = MAPPER.readValue(out.toString(), BranchSearchResults.class);
+
+        assertThat(branches.getBranches())
+                .as(withCliOutput("Page 1 with size 1 should return a single branch"))
+                .hasSize(1);
+        assertThat(branches.getCount())
+                .as(withCliOutput("Total count should be 3 (latest, 1.x, 2.x)"))
+                .isEqualTo(3);
+    }
+
+    @Test
+    @Order(5)
+    public void testBranchGet() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "branch", "get", "-g", TEST_GROUP, "-a", TEST_ARTIFACT,
+                "--output-type", "json", "1.x");
+        var branch = MAPPER.readValue(out.toString(), BranchMetaData.class);
+
+        assertThat(branch.getBranchId())
+                .as(withCliOutput("Retrieved branch should have the correct ID"))
+                .isEqualTo("1.x");
+        assertThat(branch.getDescription())
+                .as(withCliOutput("Retrieved branch should have the correct description"))
+                .isEqualTo("Stable 1.x line");
+    }
+
+    @Test
+    @Order(6)
+    public void testBranchUpdate() throws JsonProcessingException {
+        executeAndAssertSuccess("artifact", "branch", "update", "-g", TEST_GROUP, "-a", TEST_ARTIFACT,
+                "--description", "Updated description", "1.x");
+
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "branch", "get", "-g", TEST_GROUP, "-a", TEST_ARTIFACT,
+                "--output-type", "json", "1.x");
+        var branch = MAPPER.readValue(out.toString(), BranchMetaData.class);
+        assertThat(branch.getDescription())
+                .as(withCliOutput("Updated branch should have the new description"))
+                .isEqualTo("Updated description");
+    }
+
+    @Test
+    @Order(7)
+    public void testBranchVersionAdd() throws JsonProcessingException {
+        executeAndAssertSuccess("artifact", "branch", "version", "add", "-g", TEST_GROUP, "-a", TEST_ARTIFACT,
+                "-b", "1.x", "1.0.0");
+
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "branch", "version", "-g", TEST_GROUP, "-a", TEST_ARTIFACT,
+                "-b", "1.x", "--output-type", "json");
+        var versions = MAPPER.readValue(out.toString(), VersionSearchResults.class);
+        assertThat(versions.getVersions())
+                .as(withCliOutput("The added version should be at the tip of the branch"))
+                .hasSize(1)
+                .extracting("version")
+                .containsExactly("1.0.0");
+    }
+
+    @Test
+    @Order(8)
+    public void testBranchVersionReplace() throws JsonProcessingException {
+        executeAndAssertSuccess("artifact", "branch", "version", "replace", "-g", TEST_GROUP, "-a", TEST_ARTIFACT,
+                "-b", "1.x", "3.0.0", "2.0.0", "1.0.0");
+
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "branch", "version", "-g", TEST_GROUP, "-a", TEST_ARTIFACT,
+                "-b", "1.x", "--output-type", "json");
+        var versions = MAPPER.readValue(out.toString(), VersionSearchResults.class);
+        assertThat(versions.getVersions())
+                .as(withCliOutput("The branch version list should have been fully replaced"))
+                .hasSize(3)
+                .extracting("version")
+                .containsExactlyInAnyOrder("3.0.0", "2.0.0", "1.0.0");
+    }
+
+    @Test
+    @Order(9)
+    public void testBranchVersionListWithPagination() throws JsonProcessingException {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "branch", "version", "-g", TEST_GROUP, "-a", TEST_ARTIFACT,
+                "-b", "1.x", "--output-type", "json", "-p", "1", "-s", "2");
+        var versions = MAPPER.readValue(out.toString(), VersionSearchResults.class);
+        assertThat(versions.getVersions())
+                .as(withCliOutput("Page 1 with size 2 should return two versions"))
+                .hasSize(2);
+        assertThat(versions.getCount())
+                .as(withCliOutput("Total count should be 3"))
+                .isEqualTo(3);
+    }
+
+    @Test
+    @Order(10)
+    public void testBranchTableOutput() {
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "branch", "-g", TEST_GROUP, "-a", TEST_ARTIFACT);
+        assertThat(out.toString())
+                .as(withCliOutput("Table output should contain the branch column headers"))
+                .contains("Branch ID")
+                .contains("System Defined")
+                .contains("1.x");
+    }
+
+    @Test
+    @Order(11)
+    public void testBranchUsesContextIds() throws Exception {
+        executeAndAssertSuccess("context", "delete", "--all");
+        executeAndAssertSuccess("context", "create", "branch-ctx", registryUrl,
+                "--group", TEST_GROUP, "--artifact", TEST_ARTIFACT);
+
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "branch", "--output-type", "json");
+        var branches = MAPPER.readValue(out.toString(), BranchSearchResults.class);
+        assertThat(branches.getBranches())
+                .as(withCliOutput("Should list branches using groupId/artifactId from context"))
+                .anyMatch(b -> "1.x".equals(b.getBranchId()));
+
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "branch", "get", "--output-type", "json", "2.x");
+        var branch = MAPPER.readValue(out.toString(), BranchMetaData.class);
+        assertThat(branch.getBranchId())
+                .as(withCliOutput("branch get should resolve IDs from context"))
+                .isEqualTo("2.x");
+    }
+
+    @Test
+    @Order(12)
+    public void testBranchDelete() throws JsonProcessingException {
+        executeAndAssertSuccess("artifact", "branch", "delete", "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "2.x");
+
+        out.getBuffer().setLength(0);
+        executeAndAssertSuccess("artifact", "branch", "-g", TEST_GROUP, "-a", TEST_ARTIFACT,
+                "--output-type", "json");
+        var branches = MAPPER.readValue(out.toString(), BranchSearchResults.class);
+        assertThat(branches.getBranches())
+                .as(withCliOutput("Deleted branch should no longer be listed"))
+                .noneMatch(b -> "2.x".equals(b.getBranchId()));
+    }
+
+    @Test
+    public void testBranchMissingArtifactId() {
+        executeAndAssertFailure("artifact", "branch", "-g", TEST_GROUP);
+        executeAndAssertFailure("artifact", "branch", "get", "-g", TEST_GROUP, "1.x");
+        executeAndAssertFailure("artifact", "branch", "version", "-g", TEST_GROUP, "-b", "latest");
+    }
+
+    @Test
+    public void testBranchNonExistent() {
+        executeAndAssertFailure("artifact", "branch", "get",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "does-not-exist");
+        executeAndAssertFailure("artifact", "branch", "-g", "non-existent-group", "-a", TEST_ARTIFACT);
+        executeAndAssertFailure("artifact", "branch", "version", "add",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "-b", "does-not-exist", "1.0.0");
+    }
+
+    @Test
+    public void testBranchUpdateNoOptions() {
+        executeAndAssertFailure("artifact", "branch", "update",
+                "-g", TEST_GROUP, "-a", TEST_ARTIFACT, "1.x");
+    }
+}


### PR DESCRIPTION
Add `acr artifact branch` commands covering branch CRUD and the management of versions inside a branch, reusing the existing Java SDK branch operations, pagination mixin, and JSON/table output:

* `artifact branch` lists branches (with pagination)
* `artifact branch create` creates a branch with an optional initial version list (`--version`, repeatable or comma-separated)
* `artifact branch get` / `update` / `delete` manage branch metadata
* `artifact branch version` lists the versions on a branch (with pagination)
* `artifact branch version add` appends a version to a branch tip
* `artifact branch version replace` replaces a branch's version list

Group and artifact IDs fall back to the CLI context when `-g`/`-a` are not provided, matching the other artifact-scoped commands.

Closes #9920

## Summary

<!-- What does this PR do and why? -->

Adds complete artifact branch management support to the Apicurio Registry CLI.

The implementation adds the `acr artifact branch` command hierarchy for branch CRUD operations and branch version management. It reuses the existing CLI infrastructure and generated Java SDK branch operations without requiring any REST API, OpenAPI, or SDK changes.

The implementation also adds pagination, JSON/table output, context-based `groupId` and `artifactId` resolution, and tests covering the new command paths.

## Checklist

* [ ] Linked issue has maintainer approval
* [ ] No overlapping open PRs for the same issue
* [ ] Checked the [[Tried & Rejected list](https://github.com/Apicurio/apicurio-registry/discussions/8364)](https://github.com/Apicurio/apicurio-registry/discussions/8364)
* [x] Tests added for new code paths
* [x] Tested locally: `./mvnw test -pl cli -Dtest=BranchCommandTest`
* [x] `./mvnw checkstyle:check -pl cli` passes
* [ ] All commits have DCO sign-off (`git commit -s`)

<!-- If your PR is still in progress, open it as a Draft. CI will not run
     until the PR is marked ready for review and accepted by a maintainer. -->