### PR TITLE
fix(ci): stop the stale sweep from clearing its own label on every run

### DIFF
--- a/.github/pr-lifecycle.yml
+++ b/.github/pr-lifecycle.yml
@@ -29,7 +29,7 @@ stale:
   stale_message: |
     This PR has been inactive. @{author}, please update or comment
     to keep it open. It will be closed {close_window} if no activity occurs.
-    Use `/unstale` to remove this label.
+    Use `/unstale` to remove this label.{assignees}
   close_message: |
     Closing this PR due to inactivity. Feel free to reopen if you
     want to continue working on it.

--- a/.github/scripts/pr-lifecycle.js
+++ b/.github/scripts/pr-lifecycle.js
@@ -1615,7 +1615,11 @@ async function handleStale({ github, context, core }) {
     const effectiveDaysUntilClose = isWaitingOnAuthor ? daysUntilCloseWaitingOnAuthor : daysUntilClose;
 
     if (hasLabel(pr, LABELS.STALE)) {
-      const { data: events } = await github.rest.issues.listEventsForTimeline({
+      // Must be paginated: the timeline is oldest-first, so on a long-lived PR
+      // an unpaginated read either misses the current stale label entirely
+      // (skipping the PR forever) or picks up a previous one, which backdates
+      // staleSince and makes intervening activity look like it came after.
+      const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
         owner, repo, issue_number: pr.number, per_page: 100,
       });
 
@@ -1628,11 +1632,14 @@ async function handleStale({ github, context, core }) {
       const staleSince = new Date(staleEvent.created_at);
       const daysSinceStale = (now - staleSince) / (1000 * 60 * 60 * 24);
 
+      // Only events that carry created_at are considered. 'committed' events
+      // are deliberately not in the list: they have no created_at at all (the
+      // commit date lives in author.date), so they cannot be ordered against
+      // staleSince, and a push already clears the label via handlePrPush.
       const hasActivity = events.some(e => {
-        if (new Date(e.created_at) <= staleSince) return false;
+        if (!e.created_at || new Date(e.created_at) <= staleSince) return false;
         if (e.actor?.login === BOT_LOGIN || e.user?.login === BOT_LOGIN) return false;
-        return e.event === 'commented' || e.event === 'committed' ||
-               e.event === 'head_ref_force_pushed';
+        return e.event === 'commented' || e.event === 'head_ref_force_pushed';
       });
 
       // pr is a snapshot from before this run, so a PR can't hit both the
@@ -1653,9 +1660,18 @@ async function handleStale({ github, context, core }) {
       const closeWindow = graceDays <= 0
         ? 'as soon as the next check'
         : `in ${graceDays} more day${graceDays === 1 ? '' : 's'}`;
+      // Assignees are the maintainers on the hook for the PR, so they get a cc
+      // too — most of these PRs lapse waiting on review, not on the author.
+      const assignees = (pr.assignees || [])
+        .map(a => a.login)
+        .filter(login => login !== pr.user.login);
+      const assigneeMention = assignees.length
+        ? `\n\ncc ${assignees.map(login => `@${login}`).join(' ')}`
+        : '';
       const staleMessage = (config.stale?.stale_message || 'This PR is stale.')
         .replace(/\{author\}/g, pr.user.login)
-        .replace(/\{close_window\}/g, closeWindow);
+        .replace(/\{close_window\}/g, closeWindow)
+        .replace(/\{assignees\}/g, assigneeMention);
       await api.postComment(pr.number, staleMessage);
       core.info(`PR #${pr.number} marked as stale`);
     }

--- a/.github/scripts/pr-lifecycle.test.js
+++ b/.github/scripts/pr-lifecycle.test.js
@@ -472,3 +472,176 @@ test('legacy orchestrator/auto-merge migrates to native auto-merge', async () =>
   assert.match(w.calls.graphql[0].query, /enablePullRequestAutoMerge/);
 });
 
+
+// ---------------------------------------------------------------------------
+// Stale sweep
+//
+// The sweep decides "has anything happened since we labelled this stale?" by
+// walking the issue timeline. Two properties of that API make it easy to get
+// wrong, and both regressed in production: the timeline is paginated
+// oldest-first, and not every event carries created_at.
+// ---------------------------------------------------------------------------
+
+const DAY = 24 * 60 * 60 * 1000;
+const ago = days => new Date(Date.now() - days * DAY).toISOString();
+
+const STALE_CONFIG = {
+  maintainers: [], merge: { strategy: 'rebase' },
+  stale: {
+    days_until_stale: 7,
+    days_until_close: 14,
+    days_until_stale_waiting_on_author: 4,
+    days_until_close_waiting_on_author: 7,
+    stale_message: 'Inactive. @{author}, update or comment. Closed {close_window}.{assignees}',
+    close_message: 'Closing due to inactivity.',
+  },
+};
+
+// timelinePages models the real pagination shape: github.paginate concatenates
+// every page, while an unpaginated call would only ever see pages[0].
+function makeStaleWorld({ labels = [LABELS.READY_FOR_REVIEW], updatedDaysAgo = 30,
+                          timelinePages = [[]], assignees = [] } = {}) {
+  const prLabels = new Set(labels);
+  const calls = { added: [], removed: [], comments: [], closed: [] };
+
+  const pr = {
+    number: 42,
+    draft: false,
+    labels: [...prLabels].map(name => ({ name })),
+    user: { login: 'contributor' },
+    assignees: assignees.map(login => ({ login })),
+    head: { sha: SHA, ref: 'feature-x' },
+    base: { ref: 'not-main' }, // skip reconcile; this suite is about staleness
+    updated_at: ago(updatedDaysAgo),
+  };
+
+  const github = {
+    rest: {
+      issues: {
+        addLabels: async ({ labels: ls }) => ls.forEach(l => { prLabels.add(l); calls.added.push(l); }),
+        removeLabel: async ({ name }) => { prLabels.delete(name); calls.removed.push(name); },
+        createComment: async ({ body }) => calls.comments.push(body),
+        getLabel: async () => { const e = new Error('nf'); e.status = 404; throw e; },
+        createLabel: async () => ({}),
+        updateLabel: async () => ({}),
+        listEventsForTimeline: 'listEventsForTimeline',
+      },
+      pulls: {
+        list: 'pulls.list',
+        update: async ({ pull_number, state }) => calls.closed.push({ pull_number, state }),
+      },
+    },
+    paginate: async (fn) => {
+      if (fn === 'pulls.list') return [pr];
+      if (fn === 'listEventsForTimeline') return timelinePages.flat();
+      return [];
+    },
+  };
+
+  const core = { info: () => {}, warning: () => {}, error: () => {} };
+  return { github, core, calls, prLabels };
+}
+
+function staleContext() {
+  return { repo: { owner: 'Apicurio', repo: 'apicurio-registry' } };
+}
+
+const staleLabelEvent = daysAgo => ({
+  event: 'labeled', label: { name: LABELS.STALE }, created_at: ago(daysAgo),
+  actor: { login: 'github-actions[bot]' },
+});
+
+// A 'committed' timeline event as GitHub actually returns it: no created_at
+// and no actor — the commit date lives in author.date. Treating it as activity
+// made every PR with a commit look permanently active, so the stale label was
+// stripped on the next sweep and nothing ever closed.
+const committedEvent = daysAgo => ({
+  event: 'committed', sha: SHA, author: { name: 'C', date: ago(daysAgo) },
+});
+
+test('stale: old commit in the timeline does not count as activity', async () => {
+  await withConfig(STALE_CONFIG, async () => {
+    const w = makeStaleWorld({
+      labels: [LABELS.READY_FOR_REVIEW, LABELS.STALE],
+      timelinePages: [[committedEvent(30), staleLabelEvent(1)]],
+    });
+    await lifecycle.handleStale({ github: w.github, context: staleContext(), core: w.core });
+    assert.ok(!w.calls.removed.includes(LABELS.STALE),
+      'stale label must survive a commit that predates it');
+  });
+});
+
+test('stale: a human comment after the label clears it', async () => {
+  await withConfig(STALE_CONFIG, async () => {
+    const w = makeStaleWorld({
+      labels: [LABELS.READY_FOR_REVIEW, LABELS.STALE],
+      timelinePages: [[staleLabelEvent(2),
+        { event: 'commented', created_at: ago(1), user: { login: 'contributor' } }]],
+    });
+    await lifecycle.handleStale({ github: w.github, context: staleContext(), core: w.core });
+    assert.ok(w.calls.removed.includes(LABELS.STALE));
+  });
+});
+
+test('stale: the bot own warning comment does not count as activity', async () => {
+  await withConfig(STALE_CONFIG, async () => {
+    const w = makeStaleWorld({
+      labels: [LABELS.READY_FOR_REVIEW, LABELS.STALE],
+      timelinePages: [[staleLabelEvent(1),
+        { event: 'commented', created_at: ago(1), actor: { login: 'github-actions[bot]' },
+          user: { login: 'github-actions[bot]' } }]],
+    });
+    await lifecycle.handleStale({ github: w.github, context: staleContext(), core: w.core });
+    assert.ok(!w.calls.removed.includes(LABELS.STALE));
+  });
+});
+
+test('stale: label event on a later timeline page is still found', async () => {
+  await withConfig(STALE_CONFIG, async () => {
+    // Page 1 holds an old stale cycle and the activity that cleared it; the
+    // current label is on page 2. Reading only page 1 backdates staleSince,
+    // making that old activity look recent — and the label gets stripped.
+    const w = makeStaleWorld({
+      labels: [LABELS.READY_FOR_REVIEW, LABELS.STALE],
+      timelinePages: [
+        [staleLabelEvent(20), { event: 'commented', created_at: ago(19), user: { login: 'contributor' } }],
+        [staleLabelEvent(1)],
+      ],
+    });
+    await lifecycle.handleStale({ github: w.github, context: staleContext(), core: w.core });
+    assert.ok(!w.calls.removed.includes(LABELS.STALE),
+      'activity predating the current stale label must not clear it');
+  });
+});
+
+test('stale: closes once the grace period has elapsed', async () => {
+  await withConfig(STALE_CONFIG, async () => {
+    const w = makeStaleWorld({
+      labels: [LABELS.READY_FOR_REVIEW, LABELS.STALE],
+      timelinePages: [[committedEvent(30), staleLabelEvent(8)]], // grace is 14 - 7 = 7
+    });
+    await lifecycle.handleStale({ github: w.github, context: staleContext(), core: w.core });
+    assert.deepEqual(w.calls.closed, [{ pull_number: 42, state: 'closed' }]);
+  });
+});
+
+test('stale: warning ccs the assignees but not the author', async () => {
+  await withConfig(STALE_CONFIG, async () => {
+    const w = makeStaleWorld({ assignees: ['maintainer-jane', 'contributor'] });
+    await lifecycle.handleStale({ github: w.github, context: staleContext(), core: w.core });
+    assert.ok(w.calls.added.includes(LABELS.STALE));
+    assert.equal(w.calls.comments.length, 1);
+    assert.match(w.calls.comments[0], /cc @maintainer-jane/);
+    assert.equal((w.calls.comments[0].match(/@contributor/g) || []).length, 1,
+      'the author is already addressed by name and must not be cc-ed again');
+  });
+});
+
+test('stale: warning with no assignees has no cc line', async () => {
+  await withConfig(STALE_CONFIG, async () => {
+    const w = makeStaleWorld();
+    await lifecycle.handleStale({ github: w.github, context: staleContext(), core: w.core });
+    assert.equal(w.calls.comments.length, 1);
+    assert.doesNotMatch(w.calls.comments[0], /cc @/);
+  });
+});

--- a/.github/workflows/scripts-tests.yaml
+++ b/.github/workflows/scripts-tests.yaml
@@ -1,0 +1,48 @@
+name: Scripts Tests
+
+# Unit tests for the Node scripts under .github/scripts.
+#
+# These deliberately do NOT live in pr-validation.yml, even though it already
+# had a test step: that workflow runs on pull_request_target and checks out the
+# base branch on purpose (it needs a write token and must never execute PR
+# code), so its tests only ever exercise main's copy of the scripts. A change
+# to a script could not fail its own PR there.
+#
+# pull_request is the right trigger here: it checks out the PR head, and these
+# tests need nothing but a read-only token to run.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [main]
+    paths:
+      - '.github/scripts/**'
+      - '.github/pr-lifecycle.yml'
+      - '.github/workflows/scripts-tests.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test .github Scripts
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'Apicurio'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24.20.0
+
+      # Listed individually rather than as a directory: `node --test <dir>`
+      # resolves the argument as a module on Node 24 and fails.
+      - name: Run unit tests
+        run: |
+          node --test .github/scripts/pr-validation.test.js \
+                      .github/scripts/pr-lifecycle.test.js


### PR DESCRIPTION
Closes #10038

The stale sweep applied `lifecycle/stale`, posted the warning, and then removed the label again on the next scheduled run — on essentially every PR. Nothing was ever auto-closed (one auto-closure in the last 45 days), and contributors were re-warned roughly weekly forever. Full evidence in #10038.

### `committed` events are no longer treated as activity

```js
if (new Date(e.created_at) <= staleSince) return false;
```

Timeline `committed` events have no `created_at` at all — the commit date lives in `author.date`. `new Date(undefined)` is `Invalid Date`, and comparing it against `staleSince` yields `false`, so the date guard let every commit through regardless of age. Those events also carry no `actor`/`user`, so the bot guard did not catch them either. Any PR with a commit therefore looked permanently active — which is every PR.

Rather than reading the date from `author.date`, commits are dropped from the activity set entirely:

- a push already clears the label via `handlePrSynchronize`, so this path was redundant;
- `author.date` is when a commit was *written*, not when it arrived, so a rebase of old work or a long-lived local branch would have kept reading as stale even after a fresh push.

`commented` and `head_ref_force_pushed` still count, and events without a usable timestamp are now rejected explicitly instead of slipping through a NaN comparison.

### The timeline is now paginated

```js
const { data: events } = await github.rest.issues.listEventsForTimeline({ ... per_page: 100 });
```

Only page 1 was fetched, and the timeline is ordered oldest-first, so on a PR with more than 100 events either:

- the current stale-label event was not on page 1 → `if (!staleEvent) continue` skipped the PR permanently, leaving it labelled and never re-evaluated (this is why #9602 is the only open PR still carrying `lifecycle/stale`); or
- an earlier stale-label event shadowed it → `staleSince` was backdated by weeks, so ordinary intervening comments counted as fresh activity.

### Stale warnings now cc the assignees

Most of these PRs lapse waiting on review, not on the author, so the warning now cc's the PR assignees through a new `{assignees}` placeholder in `stale_message`. The author is excluded from the cc (they are already addressed by name), and the placeholder resolves to nothing when there are no assignees, so the message is unchanged for unassigned PRs.

### Tests

Adds seven `handleStale` tests covering both bugs, the close path, and the cc behaviour. Six of them fail against `main`.

`pr-lifecycle.test.js` existed but was not wired into any workflow, so it has never run. It does **not** go into `pr-validation.yml`, despite that workflow already having a `Run unit tests` step: `pr-validation.yml` runs on `pull_request_target` and deliberately checks out the base branch (it needs a write token and must never execute PR code), so the tests there only ever exercise `main`'s copy of the scripts — a change to a script cannot fail its own PR. Verified on this PR: that step ran `node --test .github/scripts/pr-validation.test.js`, the version on `main`.

So the tests get a small `Scripts Tests` workflow on `pull_request` (read-only token, checks out the PR head, path-filtered to `.github/scripts/**` and `.github/pr-lifecycle.yml`), running both test files — 62 tests, all passing.

### Expected behaviour on merge

Nothing closes en masse. Only #9602 currently holds `lifecycle/stale`; every other PR had its label stripped by this bug, so they re-enter through the warning branch and get a fresh label, a fresh warning and the full grace period. #9602 has been labelled since 2026-09-07 with no human activity and is `waiting-on-author` (3-day grace), so it becomes eligible to close on the first sweep after 2026-09-10 — worth a look before this merges if that PR should be kept.
