### PR TITLE
feat(ci): require a milestone on PRs and the issues they close

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,3 +16,8 @@ Closes #<issue-number>
 
 <!-- If your PR is still in progress, open it as a Draft. CI will not run
      until the PR is marked ready for review and accepted by a maintainer. -->
+
+<!-- The PR validation check also requires a milestone on this PR and on the
+     issue it closes. Setting one needs triage permission, so a maintainer
+     does it -- there is no checklist item for you here, and the check turns
+     green on its own once they have. -->

--- a/.github/scripts/pr-validation.js
+++ b/.github/scripts/pr-validation.js
@@ -8,6 +8,7 @@
 // Blocking checks (fail the GitHub check):
 //   - issue link: the body references an issue this PR closes
 //   - DCO sign-off: every commit carries a Signed-off-by trailer
+//   - milestone: the PR and every issue it closes carry an open milestone
 //
 // Advisory only (reported, never blocking):
 //   - duplicate PRs, matched by linked issue or by overlapping files
@@ -124,6 +125,62 @@ function checkDcoSignOff(commits) {
     detail: `${unsigned.length} commit(s) are missing a \`Signed-off-by:\` trailer:\n\n${list}\n\n`
       + 'Sign off with `git commit -s`, or repair existing commits with '
       + '`git rebase --signoff upstream/main` and force-push.',
+  };
+}
+
+/**
+ * The issues this PR closes, fetched so their milestones can be checked. A
+ * lookup that fails (deleted issue, a number that is really a PR in another
+ * repo) is skipped rather than reported: the milestone check should not
+ * invent a violation out of an API error.
+ */
+async function fetchLinkedIssues(github, owner, repo, linkedIssues, core) {
+  const issues = [];
+  for (const number of linkedIssues) {
+    try {
+      const { data } = await github.rest.issues.get({ owner, repo, issue_number: number });
+      issues.push(data);
+    } catch (e) {
+      core.warning(`Could not load issue #${number} for the milestone check: ${e.message}`);
+    }
+  }
+  return issues;
+}
+
+/**
+ * Milestones drive the release notes (generated from the milestone's issues)
+ * and make work findable after the fact, so both the PR and everything it
+ * closes need one. A closed milestone is treated as missing — it belongs to a
+ * release that already shipped, so nothing new can land in it.
+ *
+ * Setting a milestone needs triage permission, so this is the one blocking
+ * check an outside contributor cannot clear themselves. The message says so.
+ */
+function checkMilestone(pr, issues) {
+  const problems = [];
+
+  const describe = (subject, milestone) => {
+    if (!milestone) {
+      problems.push(`- ${subject} has no milestone.`);
+    } else if (milestone.state === 'closed') {
+      problems.push(`- ${subject} is on milestone \`${milestone.title}\`, which is closed.`);
+    }
+  };
+
+  describe('This PR', pr.milestone);
+  for (const issue of issues) {
+    describe(`Issue #${issue.number}`, issue.milestone);
+  }
+
+  if (problems.length === 0) {
+    return null;
+  }
+  return {
+    name: 'Milestone',
+    detail: `${problems.join('\n')}\n\n`
+      + 'Setting a milestone requires triage permission, so **a maintainer has to '
+      + 'do this** — there is no action for the PR author here. The milestone '
+      + 'determines which release notes this work appears in.',
   };
 }
 
@@ -290,9 +347,11 @@ async function validate({ github, context, core }) {
   });
 
   const linkedIssues = extractLinkedIssues(pr.body, owner, repo);
+  const issues = await fetchLinkedIssues(github, owner, repo, linkedIssues, core);
   const violations = [
     checkIssueLink(linkedIssues),
     checkDcoSignOff(commits),
+    checkMilestone(pr, issues),
   ].filter(Boolean);
 
   let duplicates = { byIssue: [], byFile: [] };
@@ -326,4 +385,5 @@ module.exports = {
   hasSignOff,
   checkIssueLink,
   checkDcoSignOff,
+  checkMilestone,
 };

--- a/.github/scripts/pr-validation.test.js
+++ b/.github/scripts/pr-validation.test.js
@@ -11,6 +11,7 @@ const {
   hasSignOff,
   checkIssueLink,
   checkDcoSignOff,
+  checkMilestone,
 } = require('./pr-validation.js');
 
 const OWNER = 'Apicurio';
@@ -175,13 +176,21 @@ const SIGNED_COMMIT = (sha, subject) => (
 );
 const UNSIGNED_COMMIT = (sha, subject) => ({ sha, ...commitWith(subject, 'dev@example.com') });
 
+// Most tests are not about milestones, so PRs and linked issues carry an open
+// one by default and the milestone check stays quiet. Tests that do care pass
+// `milestone: null` on the PR fixture or seed `issuesByNumber`.
+const OPEN_MILESTONE = { title: '3.4.0', state: 'open' };
+const CLOSED_MILESTONE = { title: '3.3.3', state: 'closed' };
+
 /**
  * Fake octokit client covering only the calls pr-validation.js makes.
  * `commitsByPr` and `filesByPr` are keyed by PR number; `openPrs` seeds
- * github.rest.pulls.list. Every write call is recorded onto `calls` so
- * tests can assert on exact arguments.
+ * github.rest.pulls.list; `issuesByNumber` seeds github.rest.issues.get for
+ * the milestone check. Every write call is recorded onto `calls` so tests can
+ * assert on exact arguments.
  */
-function createFakeGithub({ commitsByPr = {}, openPrs = [], filesByPr = {} } = {}) {
+function createFakeGithub({ commitsByPr = {}, openPrs = [], filesByPr = {},
+                            issuesByNumber = {} } = {}) {
   const calls = {
     createdComments: [], updatedComments: [], addedLabels: [], removedLabels: [], listParams: [],
   };
@@ -203,6 +212,11 @@ function createFakeGithub({ commitsByPr = {}, openPrs = [], filesByPr = {} } = {
         ),
       },
       issues: {
+        get: async ({ issue_number }) => {
+          const issue = issuesByNumber[issue_number];
+          if (issue instanceof Error) throw issue;
+          return { data: issue ?? { number: issue_number, milestone: OPEN_MILESTONE } };
+        },
         listComments: async ({ issue_number }) => (
           { data: comments.filter(c => c.issue_number === issue_number) }
         ),
@@ -268,7 +282,12 @@ function withDefaultBase(prs) {
 
 function makeContext(pr) {
   const [withBase] = withDefaultBase([pr]);
-  return { repo: { owner: OWNER, repo: REPO }, payload: { pull_request: withBase } };
+  // Same idea as base.ref above: default to a milestoned PR so tests that are
+  // not about milestones do not all have to say so.
+  return {
+    repo: { owner: OWNER, repo: REPO },
+    payload: { pull_request: { milestone: OPEN_MILESTONE, ...withBase } },
+  };
 }
 
 test('validate(): unsigned commit fails the check, labels the PR, and posts one comment', async (t) => {
@@ -468,4 +487,107 @@ test('validate(): a duplicate-detection failure still reports a real violation',
   assert.match(getFailed(), /Issue link/);
   assert.match(getFailed(), /DCO sign-off/);
   assert.match(calls.createdComments[0].body, /Issue link/);
+});
+
+// ---------------------------------------------------------------------------
+// Milestone check
+//
+// Both the PR and every issue it closes need an open milestone: the release
+// notes are generated from a milestone's issues, and the PR's own milestone
+// keeps the work findable by search. Unlike the other blocking checks this
+// one is not the author's to fix, which is why the message says who must act.
+// ---------------------------------------------------------------------------
+
+test('checkMilestone(): passes when the PR and its issues are milestoned', () => {
+  const violation = checkMilestone(
+    { milestone: OPEN_MILESTONE },
+    [{ number: 42, milestone: OPEN_MILESTONE }]
+  );
+  assert.equal(violation, null);
+});
+
+test('checkMilestone(): reports a PR with no milestone', () => {
+  const violation = checkMilestone({ milestone: null }, []);
+  assert.match(violation.detail, /This PR has no milestone/);
+  assert.match(violation.detail, /a maintainer has to do this/);
+});
+
+test('checkMilestone(): a closed milestone counts as missing', () => {
+  const violation = checkMilestone({ milestone: CLOSED_MILESTONE }, []);
+  assert.match(violation.detail, /`3\.3\.3`, which is closed/);
+});
+
+test('checkMilestone(): reports each unmilestoned issue separately', () => {
+  const violation = checkMilestone({ milestone: OPEN_MILESTONE }, [
+    { number: 42, milestone: null },
+    { number: 43, milestone: CLOSED_MILESTONE },
+    { number: 44, milestone: OPEN_MILESTONE },
+  ]);
+  assert.match(violation.detail, /Issue #42 has no milestone/);
+  assert.match(violation.detail, /Issue #43 is on milestone/);
+  assert.doesNotMatch(violation.detail, /Issue #44/);
+});
+
+test('validate(): an unmilestoned PR fails the check and is labelled', async (t) => {
+  stubConfig(t, { auto_accept: [] });
+  const pr = {
+    number: 1, user: { login: 'contributor' }, body: 'Closes #42',
+    labels: [], draft: false, milestone: null,
+  };
+  const { github, calls } = createFakeGithub({
+    commitsByPr: { 1: [SIGNED_COMMIT('aaaaaaaa1111', 'fix: a')] },
+  });
+  const { core, getFailed } = createFakeCore();
+
+  await validate({ github, context: makeContext(pr), core });
+
+  assert.match(getFailed(), /Milestone/);
+  assert.deepEqual(calls.addedLabels, [{ issue_number: 1, labels: ['lifecycle/validation-failed'] }]);
+  assert.match(calls.createdComments[0].body, /This PR has no milestone/);
+});
+
+test('validate(): a milestoned PR closing an unmilestoned issue still fails', async (t) => {
+  stubConfig(t, { auto_accept: [] });
+  const pr = { number: 1, user: { login: 'contributor' }, body: 'Closes #42', labels: [], draft: false };
+  const { github, calls } = createFakeGithub({
+    commitsByPr: { 1: [SIGNED_COMMIT('aaaaaaaa1111', 'fix: a')] },
+    issuesByNumber: { 42: { number: 42, milestone: null } },
+  });
+  const { core, getFailed } = createFakeCore();
+
+  await validate({ github, context: makeContext(pr), core });
+
+  assert.match(getFailed(), /Milestone/);
+  assert.match(calls.createdComments[0].body, /Issue #42 has no milestone/);
+});
+
+test('validate(): an issue that cannot be fetched is warned about, not failed', async (t) => {
+  stubConfig(t, { auto_accept: [] });
+  const pr = { number: 1, user: { login: 'contributor' }, body: 'Closes #42', labels: [], draft: false };
+  const { github } = createFakeGithub({
+    commitsByPr: { 1: [SIGNED_COMMIT('aaaaaaaa1111', 'fix: a')] },
+    issuesByNumber: { 42: new Error('Not Found') },
+  });
+  const { core, warnings, getFailed } = createFakeCore();
+
+  await validate({ github, context: makeContext(pr), core });
+
+  assert.equal(getFailed(), null);
+  assert.ok(warnings.some(w => /Could not load issue #42/.test(w)));
+});
+
+test('validate(): exempt bot authors skip the milestone check entirely', async (t) => {
+  stubConfig(t, { auto_accept: ['renovate[bot]'] });
+  const pr = {
+    number: 1, user: { login: 'renovate[bot]' }, body: '',
+    labels: [], draft: false, milestone: null,
+  };
+  const { github, calls } = createFakeGithub({});
+  const { core, getFailed } = createFakeCore();
+
+  await validate({ github, context: makeContext(pr), core });
+
+  assert.equal(getFailed(), null);
+  assert.deepEqual(calls.addedLabels, []);
+  assert.deepEqual(calls.createdComments, []);
 });

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -12,7 +12,10 @@ name: PR Validation
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, edited]
+    # milestoned/demilestoned matter because the milestone check is the one
+    # blocking check the PR author cannot clear: without them the check would
+    # stay red until an unrelated push after a maintainer sets the milestone.
+    types: [opened, reopened, synchronize, edited, milestoned, demilestoned]
     branches: [main]
 
 permissions:


### PR DESCRIPTION
Closes #10041

Adds a blocking `Milestone` check to PR validation, alongside the existing issue-link and DCO checks.

### What it checks

- the PR carries a milestone;
- every issue the PR closes carries a milestone;
- neither milestone is closed — a closed milestone belongs to a release that already shipped, so it is treated the same as missing.

Verifying the milestone is the *correct* one is deliberately out of scope: inferring the target version is effectively auto-assignment, which is #9373.

### Why both

Release notes are generated in `release-release-notes.yaml` from `gh issue list --milestone`, so the **issue** milestone is the one that decides whether work appears in the notes at all. The **PR** milestone is not read there, but it makes merged work findable afterwards (`is:pr milestone:"3.4.0"`) and covers the quick fix that landed without an issue.

This is intentionally strict. None of the 30 most recently created issues has a milestone, so expect this to be red on most PRs at first — that is the point.

### The one asymmetry worth reviewing

Setting a milestone requires triage permission, so this is the first blocking check an **outside contributor cannot clear themselves**. Three things follow, all in this PR:

- the failure message states that a maintainer has to act and there is nothing for the author to do;
- `PULL_REQUEST_TEMPLATE.md` says the same, as a comment rather than a checklist item — a checkbox would be a task the author cannot complete;
- `pr-validation.yml` gains `milestoned` and `demilestoned` activity types. Without them the check would stay red until some later unrelated push, since setting a milestone would not re-run validation.

Note that setting the *PR* milestone re-runs validation, which re-reads the linked issues — so a maintainer doing both in either order ends up green. Setting only the *issue* milestone does not re-trigger anything on its own.

Worth being explicit that "blocking" here means a red check and `lifecycle/validation-failed`, not a merge block: that label appears nowhere in `pr-lifecycle.js`, and branch protection requires only `Verification Gate`. A maintainer can still merge over it.

### Not needed

Milestone *creation* is already handled — `release-milestones.yaml` closes the released milestone and creates the next one on every release (8/8 recent releases, `3.3.4` is its output), so the milestone to assign always exists.

### Tests

Eight new tests: the pure `checkMilestone` cases (PR missing, closed milestone, per-issue reporting), and `validate()` end to end for an unmilestoned PR, a milestoned PR closing an unmilestoned issue, an unfetchable issue warning rather than failing, and exempt bot authors skipping the check.

Existing fixtures default to a milestoned PR and milestoned linked issues via `makeContext`/`issuesByNumber`, mirroring how `base.ref` was already defaulted, so tests that are not about milestones did not have to change. 70 tests pass across both script test files.
