### PR TITLE
docs: refresh the PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Use this template to report a bug in this project
 title: ""
-labels: Bug
+labels: type/bug
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: "Feature request"
 about: Propose a feature request that you think will improve this project
 title: ''
-labels: Enhancement
+labels: type/enhancement
 assignees: ''
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@ Closes #<issue-number>
 ## Checklist
 
 - [ ] Linked issue has maintainer approval
+- [ ] This is my only open PR (each contributor may have one open at a time)
 - [ ] No overlapping open PRs for the same issue
 - [ ] Checked the [Tried & Rejected list](https://github.com/Apicurio/apicurio-registry/discussions/8364)
 - [ ] Tests added for new code paths
@@ -14,10 +15,18 @@ Closes #<issue-number>
 - [ ] `./mvnw checkstyle:check -pl <module>` passes
 - [ ] All commits have DCO sign-off (`git commit -s`)
 
-<!-- If your PR is still in progress, open it as a Draft. CI will not run
-     until the PR is marked ready for review and accepted by a maintainer. -->
+<!-- Still in progress? Open it as a Draft. The orchestrator ignores drafts,
+     but Quick Check still runs on every push so you get fast feedback.
 
-<!-- The PR validation check also requires a milestone on this PR and on the
+     Once the PR is ready for review there is no acceptance step: it goes
+     straight to lifecycle/ready-for-review. Quick Check runs on every push;
+     the full verification suite runs once a maintainer approves the PR (it
+     runs immediately for trusted authors) and is the final merge gate.
+
+     The PR validation check also requires a milestone on this PR and on the
      issue it closes. Setting one needs triage permission, so a maintainer
      does it -- there is no checklist item for you here, and the check turns
-     green on its own once they have. -->
+     green on its own once they have.
+
+     Full details, including the lifecycle labels and the commands you can
+     use: .github/PR_LIFECYCLE.md -->

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -238,7 +238,7 @@ non-Java changes (docs, UI).
 |----------|---------|---------|----------|
 | `validate-docs.yaml` | PR (docs/**), workflow_call | Runs `docs-playbook/_build-all.sh` to validate documentation builds | ~10 min |
 | `validate-openapi.yaml` | PR (openapi.json), workflow_call | Lints OpenAPI spec with `@rhoas/spectral-ruleset` | ~5 min |
-| `pr-validation.yml` | `pull_request_target` opened/reopened/synchronize/edited | Checks the PR body links an issue and every commit is DCO signed; flags possible duplicate PRs by linked issue or overlapping files. Independent of the lifecycle: a red check never blocks `/accept`, and PRs are not auto-closed. Uses `pull_request_target` (write token) instead of `pull_request` so it can comment/label on fork PRs; it never checks out the PR head, only the base branch and PR metadata via the API | <1 min |
+| `pr-validation.yml` | `pull_request_target` opened/reopened/synchronize/edited/milestoned/demilestoned | Checks the PR body links an issue, every commit is DCO signed, and the PR plus every issue it closes carries an open milestone; flags possible duplicate PRs by linked issue or overlapping files. Independent of the lifecycle: a red check never blocks a merge, and PRs are not auto-closed. Uses `pull_request_target` (write token) instead of `pull_request` so it can comment/label on fork PRs; it never checks out the PR head, only the base branch and PR metadata via the API. The milestone activity types matter because setting a milestone is the only way to clear that check | <1 min |
 
 ## Release Workflows
 


### PR DESCRIPTION
Closes #10043

### PR template

The closing note described the lifecycle as it worked before the triage/accept stage was removed:

> CI will not run until the PR is marked ready for review and accepted by a maintainer.

Both halves were wrong:

- **CI does run.** `quick-check.yaml` triggers on `pull_request` with no draft filter, and its own header describes covering "draft pushes".
- **There is no acceptance step.** The command table is `reject`/`merge`/`unstale`/`retry`; `/accept` is gone, and `reconcile()` states "there is no separate triage/accept stage". What waits for approval is the *full* suite, decided by `verify-decide.yaml`.

Replaced with the wording the orchestrator already posts in its welcome message, so the two agree, plus a pointer to `PR_LIFECYCLE.md` — which was accurate all along and is where the labels and commands are documented.

Also adds the one-open-PR-per-contributor rule to the checklist. It is enforced (`max_contributor_prs: 1`, and `initNewPr` auto-closes the second PR) but appeared nowhere a contributor would read before opening one, so the first they learn of it is their PR being closed.

Left alone deliberately: "No overlapping open PRs for the same issue" is now detected automatically by the duplicate advisory, but it still reads fine as a nudge.

### Issue templates

`bug_report.md` and `feature_request.md` applied labels named `Bug` and `Enhancement`. Those labels do not exist in this repository — the type labels are `type/bug`, `type/enhancement`, `type/epic`, and so on — so neither template was applying any label at all. Corrected to the real names.

### Workflows README

`.github/workflows/README.md` documented `pr-validation.yml` with a stale trigger list, no mention of the milestone check added in #10042, and a reference to `/accept` blocking. Updated to match what the workflow now does.

This was meant to ride along with #10042, but that merged first, so it lands here instead.
