### PR TITLE
fix(references): fail rewrite for avro and protobuf

### DIFF
--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/GroupsResourceTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/v3/GroupsResourceTest.java
@@ -60,6 +60,7 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.anything;
 import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.equalToObject;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -1968,6 +1969,76 @@ public class GroupsResourceTest extends AbstractResourceTestBase {
                 .body("components.schemas.Widget.type", equalTo("object"))
                 .body("components.schemas.Widget.properties.name.type", equalTo("string"))
                 .body("components.schemas.Widget.properties.description.type", equalTo("string"));
+    }
+
+    @Test
+    public void testGetArtifactVersionWithReferencesRewriteNotSupportedForAvro() throws Exception {
+        String referencedAvroContent = resourceToString("../avro-referenced-type.json");
+        String avroWithRefContent = resourceToString("../avro-with-reference.json");
+
+        createArtifact(GROUP, "testRewriteNotSupported/ReferencedType", ArtifactType.AVRO,
+                referencedAvroContent, ContentTypes.APPLICATION_JSON);
+
+        List<ArtifactReference> refs = Collections.singletonList(ArtifactReference.builder()
+                .name("com.example.common.Address")
+                .groupId(GROUP)
+                .artifactId("testRewriteNotSupported/ReferencedType")
+                .version("1")
+                .build());
+        createArtifactWithReferences(GROUP, "testRewriteNotSupported/WithReference", ArtifactType.AVRO,
+                avroWithRefContent, ContentTypes.APPLICATION_JSON, refs);
+
+        given().when().pathParam("groupId", GROUP)
+                .pathParam("artifactId", "testRewriteNotSupported/WithReference")
+                .queryParam("references", "REWRITE")
+                .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/branch=latest/content")
+                .then().statusCode(400)
+                .body("name", equalTo("DereferencingNotSupportedException"))
+                .body("title", containsString("REWRITE"));
+    }
+
+    @Test
+    public void testGetArtifactVersionWithReferencesRewriteNotSupportedForProtobuf() throws Exception {
+        String protobufTypeContent = """
+                syntax = \"proto3\";
+
+                package com.example.common;
+
+                message Address {
+                  string street = 1;
+                }
+                """;
+        String protobufWithRefContent = """
+                syntax = \"proto3\";
+
+                import \"common.proto\";
+
+                package com.example.order;
+
+                message Order {
+                  com.example.common.Address shipping = 1;
+                }
+                """;
+
+        createArtifact(GROUP, "testRewriteNotSupported/ProtobufType", ArtifactType.PROTOBUF,
+                protobufTypeContent, ContentTypes.APPLICATION_PROTOBUF);
+
+        List<ArtifactReference> refs = Collections.singletonList(ArtifactReference.builder()
+                .name("common.proto")
+                .groupId(GROUP)
+                .artifactId("testRewriteNotSupported/ProtobufType")
+                .version("1")
+                .build());
+        createArtifactWithReferences(GROUP, "testRewriteNotSupported/ProtobufWithReference",
+                ArtifactType.PROTOBUF, protobufWithRefContent, ContentTypes.APPLICATION_PROTOBUF, refs);
+
+        given().when().pathParam("groupId", GROUP)
+                .pathParam("artifactId", "testRewriteNotSupported/ProtobufWithReference")
+                .queryParam("references", "REWRITE")
+                .get("/registry/v3/groups/{groupId}/artifacts/{artifactId}/versions/branch=latest/content")
+                .then().statusCode(400)
+                .body("name", equalTo("DereferencingNotSupportedException"))
+                .body("title", containsString("REWRITE"));
     }
 
     /**

--- a/docs/modules/ROOT/pages/getting-started/assembly-managing-registry-artifacts-api.adoc
+++ b/docs/modules/ROOT/pages/getting-started/assembly-managing-registry-artifacts-api.adoc
@@ -226,6 +226,10 @@ In some situations, having an artifact's content with the referenced content inl
 
 This support is currently implemented for Avro, JSON Schema, Protobuf, OpenAPI, and AsyncAPI when the parameter is present in a particular API operation. The parameter is not supported in other schema types.
 
+NOTE: `references=REWRITE` is currently supported for JSON Schema, OpenAPI, and AsyncAPI.
+For Avro and Protobuf artifacts, requesting `references=REWRITE` returns HTTP `400`
+(`DereferencingNotSupportedException`).
+
 .Prerequisites
 
 * {registry} is installed and running in your environment.
@@ -451,5 +455,4 @@ hostname on which the target {registry} is deployed. For example: `\http://my-ta
 .Additional resources
 * {registry-rest-api}
 //* For details on export tools for migrating from {registry} version 1.x to 2.x, see link:https://github.com/Apicurio/apicurio-registry/tree/main/utils/exportV1[Apicurio Registry export utility for 1.x versions].
-
 

--- a/schema-util/avro/src/main/java/io/apicurio/registry/avro/content/dereference/AvroDereferencer.java
+++ b/schema-util/avro/src/main/java/io/apicurio/registry/avro/content/dereference/AvroDereferencer.java
@@ -4,6 +4,7 @@ import io.apicurio.registry.avro.util.AvroParserAccessor;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.content.dereference.ContentDereferencer;
+import io.apicurio.registry.content.dereference.DereferencingNotSupportedException;
 import io.apicurio.registry.types.ContentTypes;
 import org.apache.avro.Schema;
 
@@ -28,7 +29,6 @@ public class AvroDereferencer implements ContentDereferencer {
         // defined in another .avsc file. The location of that other file is not included in the Avro
         // specification (in other words there is no "import" statement). So rewriting is meaningless
         // in Avro.
-        // TODO: Should we throw an exception instead of failing silently?
-        return content;
+        throw new DereferencingNotSupportedException("Artifact type AVRO does not support references=REWRITE.");
     }
 }

--- a/schema-util/protobuf/src/main/java/io/apicurio/registry/protobuf/content/dereference/ProtobufDereferencer.java
+++ b/schema-util/protobuf/src/main/java/io/apicurio/registry/protobuf/content/dereference/ProtobufDereferencer.java
@@ -5,6 +5,7 @@ import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import io.apicurio.registry.content.ContentHandle;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.content.dereference.ContentDereferencer;
+import io.apicurio.registry.content.dereference.DereferencingNotSupportedException;
 import io.apicurio.registry.types.ContentTypes;
 import io.apicurio.registry.utils.protobuf.schema.FileDescriptorUtils;
 import io.apicurio.registry.utils.protobuf.schema.ProtobufFile;
@@ -48,7 +49,6 @@ public class ProtobufDereferencer implements ContentDereferencer {
      */
     @Override
     public TypedContent rewriteReferences(TypedContent content, Map<String, String> resolvedReferenceUrls) {
-        // TODO not yet implemented (perhaps cannot be implemented?)
-        return content;
+        throw new DereferencingNotSupportedException("Artifact type PROTOBUF does not support references=REWRITE.");
     }
 }


### PR DESCRIPTION
## What

This PR fixes issue #10045 by making `references=REWRITE` explicit for artifact types that do not
support rewrite semantics.

- AVRO: `AvroDereferencer.rewriteReferences()` now throws
  `DereferencingNotSupportedException`.
- PROTOBUF: `ProtobufDereferencer.rewriteReferences()` now throws
  `DereferencingNotSupportedException`.
- Added REST regression tests in `GroupsResourceTest` to verify both cases return HTTP `400`.
- Updated REST API docs to clarify current `references=REWRITE` support matrix:
  JSON Schema/OpenAPI/AsyncAPI supported, AVRO/PROTOBUF return `400`.

## Why

Before this change, AVRO and PROTOBUF silently returned unchanged content when clients requested
`?references=REWRITE`. That behavior looked successful but did not perform any rewrite, which was
confusing and error-prone.

Returning a clear `400` makes the API contract explicit and prevents silent no-op behavior.

## Verification

Executed locally:

- `./mvnw -pl app -Dtest=GroupsResourceTest#testGetArtifactVersionWithReferencesRewriteNotSupportedForAvro,GroupsResourceTest#testGetArtifactVersionWithReferencesRewriteNotSupportedForProtobuf test`
  - Result: 2 tests run, 0 failures
- `./mvnw checkstyle:check -pl app,schema-util/avro,schema-util/protobuf`
  - Result: 0 violations

(For local setup, also ran once to ensure updated modules were available to app tests:
`./mvnw -pl schema-util/avro,schema-util/protobuf -am -DskipTests install`.)

Fixes #10045
