### PR TITLE
refactor(ui): use generated SDK client for artifact version content requests (#10069)

### DIFF
--- a/ui/ui-app/src/services/useGroupsService.test.ts
+++ b/ui/ui-app/src/services/useGroupsService.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Paging } from "@models/Paging.ts";
+import { HeadersInspectionOptions } from "@microsoft/kiota-http-fetchlibrary";
+import { HandleReferencesTypeObject } from "@sdk/lib/generated-client/models";
 
 const { axiosGetMock, createAuthOptionsMock, getRegistryClientMock } = vi.hoisted(() => {
     // useConfigService.ts reads this global at module load time (normally injected
@@ -152,29 +154,30 @@ describe("useGroupsService pagination", () => {
 
 describe("useGroupsService content loading", () => {
     it("returns artifact version content with the response content type", async () => {
-        createAuthOptionsMock.mockResolvedValue({
-            headers: {
-                Authorization: "Bearer test-token"
+        const get = vi.fn().mockImplementation((options: any) => {
+            const headerOption = options?.options?.[0];
+            if (headerOption) {
+                headerOption.getResponseHeaders().add("content-type", "application/x-yaml; charset=utf-8");
             }
+            return Promise.resolve(new TextEncoder().encode("templateId: prompt\ntemplate: Hello {{name}}\n").buffer);
         });
-        axiosGetMock.mockResolvedValue({
-            data: "templateId: prompt\ntemplate: Hello {{name}}\n",
-            headers: {
-                "content-type": "application/x-yaml; charset=utf-8"
-            }
-        });
+        const byVersionExpression = vi.fn(() => ({ content: { get } }));
+        const byArtifactId = vi.fn(() => ({ versions: { byVersionExpression } }));
+        const byGroupId = vi.fn(() => ({ artifacts: { byArtifactId } }));
+        getRegistryClientMock.mockReturnValue({ groups: { byGroupId } });
 
         const service = useGroupsService();
         const result = await service.getArtifactVersionContentWithType("default", "my-prompt", "1");
 
-        expect(axiosGetMock).toHaveBeenCalledWith(
-            "http://localhost:8080/apis/registry/v3/groups/default/artifacts/my-prompt/versions/1/content",
+        expect(byGroupId).toHaveBeenCalledWith("default");
+        expect(byArtifactId).toHaveBeenCalledWith("my-prompt");
+        expect(byVersionExpression).toHaveBeenCalledWith("1");
+        expect(get).toHaveBeenCalledWith(
             expect.objectContaining({
                 headers: {
-                    Authorization: "Bearer test-token",
                     Accept: "*"
                 },
-                responseType: "text"
+                options: [expect.any(HeadersInspectionOptions)]
             })
         );
         expect(result).toEqual({
@@ -184,42 +187,81 @@ describe("useGroupsService content loading", () => {
     });
 
     it("normalizes latest to the latest branch when loading content with type", async () => {
-        createAuthOptionsMock.mockResolvedValue({});
-        axiosGetMock.mockResolvedValue({
-            data: "{}",
-            headers: {}
+        const get = vi.fn().mockImplementation(() => {
+            return Promise.resolve(new TextEncoder().encode("{}").buffer);
         });
+        const byVersionExpression = vi.fn(() => ({ content: { get } }));
+        const byArtifactId = vi.fn(() => ({ versions: { byVersionExpression } }));
+        const byGroupId = vi.fn(() => ({ artifacts: { byArtifactId } }));
+        getRegistryClientMock.mockReturnValue({ groups: { byGroupId } });
 
         const service = useGroupsService();
         await service.getArtifactVersionContentWithType(null, "my-prompt", "latest");
 
-        expect(axiosGetMock.mock.calls[0][0]).toBe(
-            "http://localhost:8080/apis/registry/v3/groups/default/artifacts/my-prompt/versions/branch%3Dlatest/content"
-        );
+        expect(byGroupId).toHaveBeenCalledWith("default");
+        expect(byVersionExpression).toHaveBeenCalledWith("branch=latest");
     });
 
     it("returns non-prompt content without transforming the response body", async () => {
         const xmlContent = "<?xml version=\"1.0\"?>\n<schema>\n    <element name=\"example\" />\n</schema>\n";
-        createAuthOptionsMock.mockResolvedValue({});
-        axiosGetMock.mockResolvedValue({
-            data: xmlContent,
-            headers: {
-                "content-type": "application/xml"
+        const get = vi.fn().mockImplementation((options: any) => {
+            const headerOption = options?.options?.[0];
+            if (headerOption) {
+                headerOption.getResponseHeaders().add("content-type", "application/xml");
             }
+            return Promise.resolve(new TextEncoder().encode(xmlContent).buffer);
         });
+        const byVersionExpression = vi.fn(() => ({ content: { get } }));
+        const byArtifactId = vi.fn(() => ({ versions: { byVersionExpression } }));
+        const byGroupId = vi.fn(() => ({ artifacts: { byArtifactId } }));
+        getRegistryClientMock.mockReturnValue({ groups: { byGroupId } });
 
         const service = useGroupsService();
         const result = await service.getArtifactVersionContentWithType("default", "my-xsd", "2");
 
-        expect(axiosGetMock).toHaveBeenCalledWith(
-            "http://localhost:8080/apis/registry/v3/groups/default/artifacts/my-xsd/versions/2/content",
-            expect.objectContaining({
-                responseType: "text",
-                transformResponse: [expect.any(Function)]
-            })
-        );
         expect(result.content).toBe(xmlContent);
         expect(result.contentType).toBe("application/xml");
+    });
+
+    it("returns dereferenced artifact version content with references query parameter", async () => {
+        const dereferencedContent = "{\"openapi\": \"3.0.0\", \"info\": { \"title\": \"Dereferenced API\" }}";
+        const get = vi.fn().mockResolvedValue(new TextEncoder().encode(dereferencedContent).buffer);
+        const byVersionExpression = vi.fn(() => ({ content: { get } }));
+        const byArtifactId = vi.fn(() => ({ versions: { byVersionExpression } }));
+        const byGroupId = vi.fn(() => ({ artifacts: { byArtifactId } }));
+        getRegistryClientMock.mockReturnValue({ groups: { byGroupId } });
+
+        const service = useGroupsService();
+        const result = await service.getArtifactVersionContentDereferenced("default", "my-api", "1");
+
+        expect(byGroupId).toHaveBeenCalledWith("default");
+        expect(byArtifactId).toHaveBeenCalledWith("my-api");
+        expect(byVersionExpression).toHaveBeenCalledWith("1");
+        expect(get).toHaveBeenCalledWith(
+            expect.objectContaining({
+                headers: {
+                    Accept: "*"
+                },
+                queryParameters: {
+                    references: HandleReferencesTypeObject.DEREFERENCE
+                }
+            })
+        );
+        expect(result).toBe(dereferencedContent);
+    });
+
+    it("normalizes latest to the latest branch for dereferenced content", async () => {
+        const get = vi.fn().mockResolvedValue(new TextEncoder().encode("{}").buffer);
+        const byVersionExpression = vi.fn(() => ({ content: { get } }));
+        const byArtifactId = vi.fn(() => ({ versions: { byVersionExpression } }));
+        const byGroupId = vi.fn(() => ({ artifacts: { byArtifactId } }));
+        getRegistryClientMock.mockReturnValue({ groups: { byGroupId } });
+
+        const service = useGroupsService();
+        await service.getArtifactVersionContentDereferenced(null, "my-api", "latest");
+
+        expect(byGroupId).toHaveBeenCalledWith("default");
+        expect(byVersionExpression).toHaveBeenCalledWith("branch=latest");
     });
 });
 

--- a/ui/ui-app/src/services/useGroupsService.ts
+++ b/ui/ui-app/src/services/useGroupsService.ts
@@ -5,6 +5,7 @@ import { ContentTypes } from "@models/ContentTypes.ts";
 import { RenderPromptResponse } from "@models/RenderPromptResponse.ts";
 import axios from "axios";
 import { Paging } from "@models/Paging.ts";
+import { HeadersInspectionOptions } from "@microsoft/kiota-http-fetchlibrary";
 import {
     AddVersionToBranch,
     ArtifactMetaData,
@@ -20,7 +21,9 @@ import {
     EditableArtifactMetaData, EditableBranchMetaData,
     EditableGroupMetaData,
     EditableVersionMetaData,
-    GroupMetaData, NewComment, ReferenceType, ReferenceTypeObject, ReplaceBranchVersions,
+    GroupMetaData,
+    HandleReferencesTypeObject,
+    NewComment, ReferenceType, ReferenceTypeObject, ReplaceBranchVersions,
     ReferenceGraph,
     ReferenceGraphDirection,
     Rule,
@@ -249,48 +252,54 @@ const versionExpressionFor = (version: string): string => {
     return version === "latest" ? "branch=latest" : version;
 };
 
-const buildVersionContentEndpoint = (config: ConfigService, groupId: string|null, artifactId: string, version: string, queryParams?: any): string => {
-    return createEndpoint(config.artifactsUrl(), "/groups/:groupId/artifacts/:artifactId/versions/:version/content", {
-        groupId: normalizeGroupId(groupId),
-        artifactId,
-        version: versionExpressionFor(version)
-    }, queryParams);
-};
-
 const getResponseContentType = (headers: any): string => {
-    const header = typeof headers?.get === "function" ? headers.get("content-type") : headers?.["content-type"];
+    if (!headers) {
+        return ContentTypes.APPLICATION_JSON;
+    }
+    if (typeof headers.tryGetValue === "function") {
+        const values = headers.tryGetValue("content-type");
+        if (values && values.length > 0 && typeof values[0] === "string") {
+            return values[0];
+        }
+    }
+    const header = typeof headers.get === "function" ? headers.get("content-type") : headers["content-type"];
+    if (header instanceof Set) {
+        const val = header.values().next().value;
+        if (typeof val === "string") {
+            return val;
+        }
+    }
     return typeof header === "string" ? header : ContentTypes.APPLICATION_JSON;
 };
 
 const getArtifactVersionContentWithType = async (config: ConfigService, auth: AuthService, groupId: string|null, artifactId: string, version: string): Promise<ArtifactVersionContent> => {
-    const endpoint = buildVersionContentEndpoint(config, groupId, artifactId, version);
-    const options = await createAuthOptions(auth);
-    return axios.get(endpoint, {
-        ...options,
-        headers: {
-            ...options.headers,
-            "Accept": "*"
-        },
-        responseType: "text",
-        transformResponse: [(data: any) => data]
-    }).then(response => ({
-        content: response.data as string,
-        contentType: getResponseContentType(response.headers)
-    }));
+    const headersOptions: HeadersInspectionOptions = new HeadersInspectionOptions({
+        inspectResponseHeaders: true
+    });
+    return getRegistryClient(config, auth).groups.byGroupId(normalizeGroupId(groupId)).artifacts.byArtifactId(artifactId).versions
+        .byVersionExpression(versionExpressionFor(version)).content.get({
+            headers: {
+                "Accept": "*"
+            },
+            options: [headersOptions]
+        }).then(value => ({
+            content: arrayDecoder.decode(value!),
+            contentType: getResponseContentType(headersOptions.getResponseHeaders())
+        }));
 };
 
 const getArtifactVersionContentDereferenced = async (config: ConfigService, auth: AuthService, groupId: string|null, artifactId: string, version: string): Promise<string> => {
-    const endpoint = buildVersionContentEndpoint(config, groupId, artifactId, version, { references: "DEREFERENCE" });
-    const options = await createAuthOptions(auth);
-    return axios.get(endpoint, {
-        ...options,
-        headers: {
-            ...options.headers,
-            "Accept": "*"
-        },
-        responseType: "text",
-        transformResponse: [(data: any) => data]
-    }).then(response => response.data as string);
+    return getRegistryClient(config, auth).groups.byGroupId(normalizeGroupId(groupId)).artifacts.byArtifactId(artifactId).versions
+        .byVersionExpression(versionExpressionFor(version)).content.get({
+            headers: {
+                "Accept": "*"
+            },
+            queryParameters: {
+                references: HandleReferencesTypeObject.DEREFERENCE
+            }
+        }).then(value => {
+            return arrayDecoder.decode(value!);
+        });
 };
 
 const getArtifactVersions = async (config: ConfigService, auth: AuthService, groupId: string|null, artifactId: string, sortBy: VersionSortBy, sortOrder: SortOrder, paging: Paging): Promise<VersionSearchResults> => {


### PR DESCRIPTION
### Description
Migrate `getArtifactVersionContentWithType` and `getArtifactVersionContentDereferenced` in `useGroupsService.ts` from direct, hand-rolled `axios.get()` calls to the generated Kiota SDK client (`getRegistryClient(...)`).

- Used `HeadersInspectionOptions` from `@microsoft/kiota-http-fetchlibrary` to expose response headers and extract `Content-Type` for `getArtifactVersionContentWithType`.
- Passed `queryParameters: { references: HandleReferencesTypeObject.DEREFERENCE }` for `getArtifactVersionContentDereferenced`.
- Enhanced `getResponseContentType` to read from Kiota `Headers` instances.
- Removed unused `buildVersionContentEndpoint` helper.
- Updated unit tests in `useGroupsService.test.ts` to test both methods via the generated client mock.

Closes #10069

### Type of Change
- [x] Refactoring / Maintenance (non-breaking change which improves codebase structure)

### Verification
- `npm test` in `ui/ui-app` (170/170 tests passed)
- `npm run build` in `ui/ui-app` (`tsc && vite build` completed cleanly)
- `npm run lint` in `ui/ui-app` (0 errors)