### PR TITLE
fix(ui): guard VersionCompareModal against stale version content responses

### DIFF
--- a/ui/ui-app/src/app/components/modals/VersionCompareModal.test.tsx
+++ b/ui/ui-app/src/app/components/modals/VersionCompareModal.test.tsx
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * These tests drive the component's load effect directly rather than rendering it, which is the
+ * same approach used by useThemeService.test.tsx. The vitest environment is "node", so there is no
+ * DOM available to render into.
+ *
+ * The behaviour under test is that a load belonging to a superseded version pair can no longer
+ * write state, which is what newLoaderGuard() provides. See #8880 for the original fix that
+ * introduced the guard for the page loaders.
+ */
+
+const setters: Record<string, any> = {};
+let effects: Array<{ fn: () => any; deps: any[] }> = [];
+let stateIndex = 0;
+const stateNames = ["version1Content", "version2Content", "isLoading", "error"];
+
+vi.mock("react", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react")>();
+    return {
+        ...actual,
+        useState: vi.fn((init: any) => {
+            const name = stateNames[stateIndex] ?? `extra${stateIndex}`;
+            stateIndex++;
+            if (!setters[name]) {
+                setters[name] = vi.fn();
+            }
+            return [typeof init === "function" ? init() : init, setters[name]];
+        }),
+        useEffect: vi.fn((fn: any, deps: any[]) => {
+            effects.push({ fn, deps });
+        })
+    };
+});
+
+// The vitest environment is "node", so PatternFly's CSS side effects cannot load. Only the load
+// effect is under test here, so the presentational imports are stubbed out.
+vi.mock("@patternfly/react-core", () => ({ Spinner: () => null, Alert: () => null }));
+vi.mock("@patternfly/react-core/deprecated", () => ({ Modal: () => null }));
+vi.mock("@app/components", () => ({ DiffView: () => null }));
+vi.mock("./VersionCompareModal.css", () => ({}));
+
+const getArtifactVersionContent = vi.fn();
+vi.mock("@services/useGroupsService.ts", () => ({
+    useGroupsService: () => ({ getArtifactVersionContent })
+}));
+
+const deferred = () => {
+    let resolve!: (v: string) => void;
+    let reject!: (e: unknown) => void;
+    const promise = new Promise<string>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+};
+
+const version = (name: string, createdOn: string) => ({ version: name, createdOn } as any);
+
+/** Renders the component function once and returns the load effect that was registered. */
+const runComponent = async (version1: any, version2: any) => {
+    const { VersionCompareModal } = await import("./VersionCompareModal");
+    stateIndex = 0;
+    effects = [];
+    (VersionCompareModal as any)({
+        isOpen: true,
+        groupId: "g",
+        artifactId: "a",
+        version1,
+        version2,
+        onClose: vi.fn()
+    });
+    // The first effect is the loader; the second resets state when the modal closes.
+    return effects[0];
+};
+
+describe("VersionCompareModal load guard", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        for (const key of Object.keys(setters)) {
+            delete setters[key];
+        }
+        stateIndex = 0;
+        effects = [];
+    });
+
+    it("ignores a resolution belonging to a superseded version pair", async () => {
+        const a1 = deferred();
+        const a2 = deferred();
+        getArtifactVersionContent.mockReturnValueOnce(a1.promise).mockReturnValueOnce(a2.promise);
+
+        const first = await runComponent(version("1", "2026-01-01"), version("2", "2026-01-02"));
+        const cleanup = first.fn();
+
+        // The user picks a different pair, so React cleans up the previous effect run.
+        cleanup?.();
+
+        a1.resolve("stale-content-1");
+        a2.resolve("stale-content-2");
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(setters.version1Content).not.toHaveBeenCalled();
+        expect(setters.version2Content).not.toHaveBeenCalled();
+    });
+
+    it("does not clear the loading state from a superseded run", async () => {
+        const a1 = deferred();
+        const a2 = deferred();
+        getArtifactVersionContent.mockReturnValueOnce(a1.promise).mockReturnValueOnce(a2.promise);
+
+        const first = await runComponent(version("1", "2026-01-01"), version("2", "2026-01-02"));
+        const cleanup = first.fn();
+        setters.isLoading.mockClear();
+        cleanup?.();
+
+        a1.resolve("x");
+        a2.resolve("y");
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(setters.isLoading).not.toHaveBeenCalled();
+    });
+
+    it("does not surface an error from a superseded run", async () => {
+        const a1 = deferred();
+        const a2 = deferred();
+        getArtifactVersionContent.mockReturnValueOnce(a1.promise).mockReturnValueOnce(a2.promise);
+
+        const first = await runComponent(version("1", "2026-01-01"), version("2", "2026-01-02"));
+        const cleanup = first.fn();
+        setters.error.mockClear();
+        cleanup?.();
+
+        a1.reject(new Error("boom"));
+        a2.resolve("y");
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(setters.error).not.toHaveBeenCalledWith("Failed to load version content. Please try again.");
+    });
+
+    it("still applies content for the current run, oldest version on the left", async () => {
+        const a1 = deferred();
+        const a2 = deferred();
+        getArtifactVersionContent.mockReturnValueOnce(a1.promise).mockReturnValueOnce(a2.promise);
+
+        // version1 is the newer of the two, so the contents must be swapped.
+        const current = await runComponent(version("2", "2026-02-01"), version("1", "2026-01-01"));
+        current.fn();
+
+        a1.resolve("newer-content");
+        a2.resolve("older-content");
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(setters.version1Content).toHaveBeenCalledWith("older-content");
+        expect(setters.version2Content).toHaveBeenCalledWith("newer-content");
+        expect(setters.isLoading).toHaveBeenCalledWith(false);
+    });
+});

--- a/ui/ui-app/src/app/components/modals/VersionCompareModal.test.tsx
+++ b/ui/ui-app/src/app/components/modals/VersionCompareModal.test.tsx
@@ -13,7 +13,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const setters: Record<string, any> = {};
 let effects: Array<{ fn: () => any; deps: any[] }> = [];
 let stateIndex = 0;
+// Order must match the useState call order in VersionCompareModal.tsx. If a useState is added
+// or reordered there, update this list, otherwise the assertions silently target the wrong
+// setter. expectedStateCount below turns that silent drift into a failing test.
 const stateNames = ["version1Content", "version2Content", "isLoading", "error"];
+const expectedStateCount = stateNames.length;
 
 vi.mock("react", async (importOriginal) => {
     const actual = await importOriginal<typeof import("react")>();
@@ -70,6 +74,8 @@ const runComponent = async (version1: any, version2: any) => {
         version2,
         onClose: vi.fn()
     });
+    // If this fails, VersionCompareModal changed its useState calls and stateNames is stale.
+    expect(stateIndex).toBe(expectedStateCount);
     // The first effect is the loader; the second resets state when the modal closes.
     return effects[0];
 };

--- a/ui/ui-app/src/app/components/modals/VersionCompareModal.tsx
+++ b/ui/ui-app/src/app/components/modals/VersionCompareModal.tsx
@@ -10,6 +10,7 @@ import {
 import { SearchedVersion } from "@sdk/lib/generated-client/models";
 import { GroupsService, useGroupsService } from "@services/useGroupsService.ts";
 import { DiffView } from "@app/components";
+import { LoaderGuard, newLoaderGuard } from "@utils/loader.utils.ts";
 
 /**
  * Properties
@@ -44,13 +45,14 @@ export const VersionCompareModal: FunctionComponent<VersionCompareModalProps> = 
     // Load version contents when modal opens
     useEffect(() => {
         if (isOpen && version1 && version2) {
+            const guard: LoaderGuard = newLoaderGuard();
             setIsLoading(true);
             setError(null);
 
             Promise.all([
                 groups.getArtifactVersionContent(groupId, artifactId, version1.version!),
                 groups.getArtifactVersionContent(groupId, artifactId, version2.version!)
-            ]).then(([content1, content2]) => {
+            ]).then(guard.wrap(([content1, content2]: [string, string]) => {
                 // Determine which version is older based on createdOn date
                 const date1 = new Date(version1.createdOn!);
                 const date2 = new Date(version2.createdOn!);
@@ -64,11 +66,13 @@ export const VersionCompareModal: FunctionComponent<VersionCompareModalProps> = 
                     setVersion2Content(content1);
                 }
                 setIsLoading(false);
-            }).catch((err) => {
+            })).catch(guard.wrap((err: unknown) => {
                 console.error("Error loading version content:", err);
                 setError("Failed to load version content. Please try again.");
                 setIsLoading(false);
-            });
+            }));
+
+            return () => guard.cancel();
         }
     }, [isOpen, version1, version2, groupId, artifactId]);
 


### PR DESCRIPTION
## Summary

Fixes #10073.

`VersionCompareModal` loaded both versions with an unguarded `Promise.all` inside a `useEffect`, so
a response for a superseded pair of versions could still resolve and overwrite state. Applies
`newLoaderGuard()`, the utility added in #8880 for exactly this failure mode, and cancels it in the
effect cleanup.

## Why this is the same problem #8880 solved

#8880 added `newLoaderGuard()` in `utils/loader.utils.ts` and applied it to five page loaders:
`ArtifactPage`, `BranchPage`, `EditorPage`, `GroupPage` and `VersionPage`. `VersionCompareModal`
loads content the same way and was not part of that change, so it kept the original behaviour.

The effect depends on `version1` and `version2`, so it re-runs whenever the selected pair changes.
Without a guard, an earlier `Promise.all` that settles later wins.

## What went wrong before this change

1. **Wrong content shown.** A stale resolution overwrites `version1Content` and `version2Content`.
   The header labels are derived from the current props, so the labels and the content disagree and
   the user is given no signal that anything is off.
2. **Spinner cleared early.** A stale resolution calls `setIsLoading(false)` while the current
   request is still in flight.
3. **A stale rejection destroys a good result.** The `catch` set the error string unconditionally,
   so a failed earlier request could replace correctly loaded content with an error message.

## The change

`ui/ui-app/src/app/components/modals/VersionCompareModal.tsx`

- Create a `newLoaderGuard()` at the start of each effect run.
- Wrap both the `then` and the `catch` callbacks with `guard.wrap(...)`.
- Return `() => guard.cancel()` from the effect so a superseded run can no longer write state.

No behaviour changes for the normal single-load path. The only difference is that callbacks
belonging to a superseded run become no-ops.

## Tests

`ui/ui-app/src/app/components/modals/VersionCompareModal.test.tsx`, 4 new cases.

The vitest environment for this project is `node` with no jsdom or testing-library, so the tests
drive the load effect directly and mock the React hooks, which is the approach
`useThemeService.test.tsx` already uses. PatternFly imports are stubbed because their CSS side
effects cannot load outside a DOM.

- **A superseded resolution is ignored.** Start a load, run the effect cleanup as React would when
  the pair changes, then resolve. Neither content setter is called.
- **A superseded run does not clear the spinner.** Same setup, asserting `setIsLoading` is not
  called after cleanup.
- **A superseded rejection does not surface.** The earlier request rejects after cleanup and no
  error message is set.
- **The current run still works.** Content is applied with the older version on the left, which is
  the existing behaviour, so this doubles as a regression test.

Verified these actually catch the bug: with the guard removed, **3 of the 4 fail**; with it in
place all 4 pass. The fourth is the regression test and passes either way, as intended.

```
npx vitest run src/app/components/modals/VersionCompareModal.test.tsx    4 passed
npx eslint <both files>                                                  clean
```

Full UI suite is unchanged by this PR: 7 test files fail and 135 tests pass both with and without
the change, so those failures are pre-existing and unrelated.

## Notes

- Scope is deliberately one component. `VersionComments.tsx` has four unguarded `.then()` calls and
  looks like a second instance of the same gap, but I have not verified it to the same depth and
  would rather raise it separately than widen this PR.
- No storage variants, no backend, no prompt template scope.
- Uses the existing utility rather than introducing a new pattern.
