### PR TITLE
fix(ui): reload versions on branch switch in BranchOverviewTabContent

### DIFF
--- a/ui/ui-app/src/app/pages/branch/components/tabs/BranchOverviewTabContent.tsx
+++ b/ui/ui-app/src/app/pages/branch/components/tabs/BranchOverviewTabContent.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent, useEffect, useState } from "react";
 import "./BranchOverviewTabContent.css";
 import "@app/styles/empty.css";
 import { IfAuth, IfFeature } from "@app/components";
+import { LoaderGuard, newLoaderGuard } from "@utils/loader.utils.ts";
 import {
     Alert,
     Button,
@@ -62,22 +63,35 @@ export const BranchOverviewTabContent: FunctionComponent<BranchOverviewTabConten
     const groups: GroupsService = useGroupsService();
     const logger: LoggerService = useLoggerService();
 
-    const refresh = (): void => {
-        setLoading(true);
+    useEffect(() => {
+        // Runtime guard: in BranchPage, artifact and branch are cast from state that may
+        // initially be undefined before loaders resolve. Ensure both IDs are present.
+        if (!props.artifact?.artifactId || !props.branch?.branchId) {
+            return;
+        }
 
-        groups.getArtifactBranchVersions(props.artifact.groupId!, props.artifact.artifactId!, props.branch.branchId!, paging).then(sr => {
-            setResults(sr);
-            setLoading(false);
-        }).catch(error => {
-            logger.error(error);
-            setLoading(false);
-            setError(true);
-        });
-    };
+        const guard: LoaderGuard = newLoaderGuard();
+        setLoading(true);
+        setError(false);
+
+        const groupId: string = props.artifact.groupId || "default";
+        groups.getArtifactBranchVersions(groupId, props.artifact.artifactId, props.branch.branchId, paging)
+            .then(guard.wrap((sr: VersionSearchResults) => {
+                setResults(sr);
+                setLoading(false);
+            }))
+            .catch(guard.wrap((error: unknown) => {
+                logger.error(error);
+                setLoading(false);
+                setError(true);
+            }));
+
+        return () => guard.cancel();
+    }, [props.artifact, props.branch?.branchId, paging]);
 
     useEffect(() => {
-        refresh();
-    }, [props.artifact, paging]);
+        setPaging(prev => prev.page === 1 ? prev : { ...prev, page: 1 });
+    }, [props.branch?.branchId]);
 
     const description = (): string => {
         return props.branch.description || "No description";


### PR DESCRIPTION
Closes #10075

## Summary

When navigating between branches of the same artifact on the branch details page (`/explore/:groupId/:artifactId/branches/:branchId`), the page header and description cards updated properly, but the "Versions in branch" table remained stuck displaying the versions from the previously viewed branch.

### Root Cause
The `useEffect` responsible for loading versions watched `[props.artifact, paging]` and omitted `props.branch?.branchId`. When switching between branches on the same artifact, `props.artifact` remains identical and `paging` does not change, so the effect was never re-triggered. In addition, the query was unguarded against in-flight race conditions when switching quickly between branches.

### Changes
- Added `props.branch?.branchId` to the version fetching `useEffect` dependencies.
- Added `LoaderGuard` (`newLoaderGuard()`) from `@utils/loader.utils.ts` and cancelled superseded requests in cleanup to prevent race conditions.
- Added an effect to reset pagination to page 1 whenever the branch changes.
- Ensured `setError(false)` is reset at the start of a new request.
- Added fallback `groupId || "default"` when calling `groups.getArtifactBranchVersions`.

## Checklist

- [ ] Linked issue has maintainer approval
- [x] No overlapping open PRs for the same issue
- [x] Checked the [Tried & Rejected list](https://github.com/Apicurio/apicurio-registry/discussions/8364)
- [ ] Tests added for new code paths
- [x] Tested locally: `./mvnw test -pl <module> -am -Dlocal`
- [x] `./mvnw checkstyle:check -pl <module>` passes
- [x] All commits have DCO sign-off (`git commit -s`)
