### PR TITLE
feat(perf): track the external load run against a recorded baseline

### DIFF
--- a/.github/workflows/perf-main.yaml
+++ b/.github/workflows/perf-main.yaml
@@ -272,6 +272,25 @@ jobs:
           printf '%s\n' "$OUT" >> "$GITHUB_STEP_SUMMARY"
           exit $RC
 
+      # Trend check, the counterpart to "Check results against baseline" above but for the
+      # external run and its own baseline file. Informational, and deliberately so: perf-main
+      # only runs after a merge has landed, and throughput on GitHub-hosted runners varies by
+      # roughly 25% run to run, so this reports into the summary rather than gating. The hard
+      # gate is the validity check above - "did the run happen" is answerable, "is 460 rps
+      # slower than usual" is not, on this hardware.
+      - name: Compare external load run against baseline
+        if: always()
+        continue-on-error: true
+        working-directory: perf-tests
+        run: |
+          LOG=/tmp/external-load-results/console.log
+          if [ ! -f "$LOG" ]; then
+            echo "No external load console log - skipping baseline comparison."
+            exit 0
+          fi
+          python3 scripts/check-external-baseline.py "$LOG" external-baseline.json \
+            --storage '${{ matrix.storage }}'
+
       - name: Upload external validation results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/perf-tests/external-baseline.json
+++ b/perf-tests/external-baseline.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "Baseline for the *external* high-concurrency read validation in perf-main (run-external-load.sh at PERF_EXTERNAL_USERS clients, from outside the cluster). Separate from baseline.json, which covers the in-cluster Gatling Job: the two runs use different concurrency and a different load path, so their numbers are not comparable. Per storage because the backends differ by roughly 3-4x in throughput. Update deliberately, in its own PR, with a comment explaining why - not as a drive-by alongside unrelated work.",
+
+  "_methodology": "Values are drawn from six consecutive green main runs on 2026-09-09/10 at 50 concurrent clients. Latency was stable across those runs (postgresql mean 98-104ms, kafkasql 26-34ms) but throughput varied by roughly 25% run to run (postgresql 351-483 rps, kafkasql 1371-1822 rps) because GitHub-hosted runners differ in hardware and noisy-neighbour conditions. The tolerances below are set so that none of those six runs would have alerted: the point is to catch a real step change, not to relitigate runner variance.",
+
+  "_gating": "Informational only, like check-thresholds.py. perf-main runs after a merge has already landed, so this cannot block anything; it exists to surface a trend in the job summary. Run *validity* is gated separately and hard - see check-external-validity.py.",
+
+  "regressionToleranceFactor": 1.25,
+  "throughputFloorFactor": 0.7,
+
+  "storage": {
+    "postgresql": {
+      "_comment": "Reads are served through Toxiproxy, which injects ~15ms +/- 5ms of latency to approximate a real managed-DB deployment - see k8s/postgresql/toxiproxy.yaml. That is why mean latency is an order of magnitude above kafkasql's.",
+      "throughputRps": 460,
+      "meanResponseTimeMs": 105,
+      "p95ResponseTimeMs": 120,
+      "p99ResponseTimeMs": 135
+    },
+    "kafkasql": {
+      "throughputRps": 1690,
+      "meanResponseTimeMs": 32,
+      "p95ResponseTimeMs": 72,
+      "p99ResponseTimeMs": 95
+    }
+  }
+}

--- a/perf-tests/scripts/check-external-baseline.py
+++ b/perf-tests/scripts/check-external-baseline.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Compare an external load run against perf-tests/external-baseline.json.
+
+This is the trend check for the external high-concurrency validation, and the counterpart
+to check-thresholds.py (which does the same job for the in-cluster Gatling run against
+baseline.json). Like that script it is *informational*: perf-main only runs after a merge
+has already landed, so there is nothing left to block, and throughput on GitHub-hosted
+runners varies by roughly 25% run to run. It prints a job summary and exits 0 even when it
+reports a regression, unless --strict is passed.
+
+Whether the run was valid at all is a separate, hard-gated question - see
+check-external-validity.py. Comparing a collapsed run against a baseline is meaningless, so
+this refuses to report on one.
+
+Usage: check-external-baseline.py <console.log> <external-baseline.json> --storage <name>
+"""
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from gatling_console import parse  # noqa: E402
+
+
+def _fmt(value):
+    if value is None:
+        return "n/a"
+    return f"{value:,.0f}" if value >= 10 else f"{value:,.2f}"
+
+
+def evaluate(stats, baseline, storage):
+    """Return (rows, regressions). A row is (metric, observed, baseline, status)."""
+    per_storage = baseline.get("storage", {}).get(storage)
+    if per_storage is None:
+        return None, None
+
+    latency_tolerance = baseline.get("regressionToleranceFactor", 1.25)
+    throughput_floor = baseline.get("throughputFloorFactor", 0.7)
+
+    rows = []
+    regressions = []
+
+    # Throughput regresses downward, so it has its own floor rather than the latency factor.
+    observed = stats.get("throughput_ok")
+    expected = per_storage.get("throughputRps")
+    if observed is None or expected is None:
+        rows.append(("Throughput (rps)", observed, expected, "unavailable"))
+    else:
+        floor = expected * throughput_floor
+        if observed < floor:
+            regressions.append("Throughput")
+            status = f"REGRESSION (< {floor:,.0f})"
+        else:
+            status = "ok"
+        rows.append(("Throughput (rps)", observed, expected, status))
+
+    for label, key, base_key in (
+        ("Mean response time (ms)", "mean_ms_ok", "meanResponseTimeMs"),
+        ("p95 response time (ms)", "p95_ms_ok", "p95ResponseTimeMs"),
+        ("p99 response time (ms)", "p99_ms_ok", "p99ResponseTimeMs"),
+    ):
+        observed = stats.get(key)
+        expected = per_storage.get(base_key)
+        if observed is None or expected is None:
+            rows.append((label, observed, expected, "unavailable"))
+            continue
+        threshold = expected * latency_tolerance
+        if observed > threshold:
+            regressions.append(label)
+            status = f"REGRESSION (> {threshold:,.0f})"
+        else:
+            status = "ok"
+        rows.append((label, observed, expected, status))
+
+    return rows, regressions
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", help="run-external-load.sh console log")
+    parser.add_argument("baseline", help="external-baseline.json")
+    parser.add_argument("--storage", required=True, help="storage variant, e.g. postgresql")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit non-zero on regression (default: informational, always exits 0)",
+    )
+    args = parser.parse_args()
+
+    try:
+        with open(args.log, encoding="utf-8", errors="replace") as handle:
+            stats = parse(handle.read())
+        with open(args.baseline, encoding="utf-8") as handle:
+            baseline = json.load(handle)
+    except OSError as exc:
+        print(f"Cannot read input: {exc}")
+        return 0 if not args.strict else 1
+
+    if stats is None:
+        print("No parseable Gatling summary - skipping baseline comparison.")
+        return 0 if not args.strict else 1
+
+    # A collapsed run's numbers are not a measurement, so do not dignify them with a
+    # comparison; check-external-validity.py is what fails the job in that case.
+    if stats["ko_percent"] > 25.0:
+        print(
+            f"Run failed {stats['ko_percent']:.2f}% of requests - not comparing against the "
+            "baseline, since a collapsed run's throughput is not a measurement. See the "
+            "validity check."
+        )
+        return 0 if not args.strict else 1
+
+    rows, regressions = evaluate(stats, baseline, args.storage)
+    if rows is None:
+        print(f"No baseline recorded for storage '{args.storage}' - skipping comparison.")
+        return 0
+
+    lines = [
+        f"## External load baseline ({args.storage})",
+        "",
+        "| Metric | Observed | Baseline | Status |",
+        "| --- | --- | --- | --- |",
+    ]
+    for label, observed, expected, status in rows:
+        lines.append(f"| {label} | {_fmt(observed)} | {_fmt(expected)} | {status} |")
+    if regressions:
+        lines.append("")
+        lines.append(f"**Potential regressions detected in:** {', '.join(regressions)}")
+
+    summary = "\n".join(lines)
+    print(summary)
+
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a", encoding="utf-8") as handle:
+            handle.write(summary + "\n")
+
+    if regressions and args.strict:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/perf-tests/scripts/check-external-validity.py
+++ b/perf-tests/scripts/check-external-validity.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Decide whether an external load run produced a usable measurement.
 
-This is deliberately *not* a performance check - perf-tests/scripts/check-thresholds.py
-already compares latency and throughput against the baseline, and those numbers are
+This is deliberately *not* a performance check - check-external-baseline.py compares this
+run's latency and throughput against external-baseline.json, and those numbers are
 informational on GitHub-hosted runners because the hardware varies run to run.
 
 This answers the prior question: did the run actually exercise the registry at all? A run
@@ -17,55 +17,12 @@ Exit status is 0 when the run is usable and 1 when it is not, so the calling ste
 """
 
 import argparse
-import re
+import os
 import sys
 
-# "> KO       1,406,042 (94.74%)" in Gatling's Response Time Distribution block.
-KO_LINE = re.compile(r"^>\s*KO\s+([\d,]+)\s+\(\s*([\d.]+)%\)", re.MULTILINE)
-# "> request count   | 1,484,140 |    78,098 | 1,406,042"
-REQUEST_COUNT_LINE = re.compile(
-    r"^>\s*request count\s*\|\s*([\d,]+)\s*\|\s*([\d,]+)\s*\|\s*([\d,]+)", re.MULTILINE
-)
-# Gatling echoes each distinct failure with its own share of the total errors.
-ERROR_LINE = re.compile(r"^>\s*(\S.*?)\s{2,}([\d,]+)\s+\(\s*[\d.]+%\)", re.MULTILINE)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-# Failures that mean the target was not reachable, as opposed to the target answering with
-# something we did not want. The distinction matters: a 500 is the registry being unhappy,
-# an ECONNREFUSED is the registry not being there.
-UNREACHABLE_MARKERS = (
-    "Connection refused",
-    "Connection reset by peer",
-    "Premature close",
-    "connection timed out",
-    "No route to host",
-)
-
-
-def _int(text):
-    return int(text.replace(",", ""))
-
-
-def parse(log_text):
-    ko_match = KO_LINE.search(log_text)
-    count_match = REQUEST_COUNT_LINE.search(log_text)
-    if not ko_match or not count_match:
-        return None
-
-    total, ok, ko = (_int(g) for g in count_match.groups())
-    unreachable = 0
-    # Only the Errors block matters; take everything after the last "---- Errors" header.
-    errors_block = log_text.rsplit("---- Errors", 1)[-1] if "---- Errors" in log_text else ""
-    for label, count in ERROR_LINE.findall(errors_block):
-        if any(marker in label for marker in UNREACHABLE_MARKERS):
-            unreachable += _int(count)
-
-    return {
-        "total": total,
-        "ok": ok,
-        "ko": ko,
-        "ko_percent": float(ko_match.group(2)),
-        "unreachable": unreachable,
-    }
+from gatling_console import parse  # noqa: E402
 
 
 def main():

--- a/perf-tests/scripts/gatling_console.py
+++ b/perf-tests/scripts/gatling_console.py
@@ -1,0 +1,98 @@
+"""Parser for the Global Information block Gatling prints at the end of a run.
+
+Two perf-tests scripts need these numbers - check-external-validity.py (did the run
+actually exercise the registry?) and check-external-baseline.py (how did it compare to
+the recorded baseline?) - so the parsing lives here rather than being duplicated and
+allowed to drift.
+
+Note the Gatling HTML report's js/stats.js is parsed separately by check-thresholds.py:
+that is a different input format for the in-cluster run, and is deliberately left alone.
+
+The block looks like this, with Total / OK / KO columns:
+
+    ---- Global Information ------------------------|---Total---|-----OK----|----KO----
+    > request count                                 |    92,580 |    92,578 |         2
+    > mean response time (ms)                       |       102 |       101 |    60,001
+    > response time 95th percentile (ms)            |       116 |       116 |    60,001
+    > mean throughput (rps)                         |     462.9 |    462.89 |      0.01
+    ---- Response Time Distribution ----------------------------------------------------
+    > OK: t < 800 ms                                                     92,578   (100%)
+    > KO                                                                      2     (0%)
+    ---- Errors -------------------------------------------------------------------------
+    > j.n.ConnectException: ... Connection refused                   1,404,879 (99.92%)
+
+A dash means "no such requests" (for example the KO column of a run with no failures) and
+is returned as None rather than zero, since those are different facts.
+"""
+
+import re
+
+_ROW = r"^>\s*{label}\s*\|\s*(\S+)\s*\|\s*(\S+)\s*\|\s*(\S+)\s*$"
+
+KO_PERCENT = re.compile(r"^>\s*KO\s+[\d,]+\s+\(\s*([\d.]+)%\)", re.MULTILINE)
+ERROR_LINE = re.compile(r"^>\s*(\S.*?)\s{2,}([\d,]+)\s+\(\s*[\d.]+%\)", re.MULTILINE)
+
+# Failures meaning the target was not reachable, as opposed to it answering with something
+# unwanted. A 500 is the registry being unhappy; an ECONNREFUSED is the registry not being
+# there, and only the latter invalidates a measurement.
+UNREACHABLE_MARKERS = (
+    "Connection refused",
+    "Connection reset by peer",
+    "Premature close",
+    "connection timed out",
+    "No route to host",
+)
+
+
+def _number(text):
+    """Gatling prints thousands separators, and '-' where a column has no data."""
+    text = text.strip()
+    if text in ("-", ""):
+        return None
+    try:
+        return float(text.replace(",", ""))
+    except ValueError:
+        return None
+
+
+def _row(text, label):
+    match = re.search(_ROW.format(label=re.escape(label)), text, re.MULTILINE)
+    if not match:
+        return (None, None, None)
+    return tuple(_number(g) for g in match.groups())
+
+
+def parse(log_text):
+    """Return the run's headline metrics, or None if there is no parseable summary."""
+    if "Global Information" not in log_text:
+        return None
+
+    total, ok, ko = _row(log_text, "request count")
+    if total is None:
+        return None
+
+    ko_percent_match = KO_PERCENT.search(log_text)
+    if ko_percent_match is not None:
+        ko_percent = float(ko_percent_match.group(1))
+    else:
+        ko_percent = (100.0 * ko / total) if (ko is not None and total) else 0.0
+
+    unreachable = 0
+    errors_block = log_text.rsplit("---- Errors", 1)[-1] if "---- Errors" in log_text else ""
+    for label, count in ERROR_LINE.findall(errors_block):
+        if any(marker in label for marker in UNREACHABLE_MARKERS):
+            unreachable += int(count.replace(",", ""))
+
+    # The OK column is what matters for a baseline: throughput and latency of requests that
+    # actually succeeded. Including failures would let a run "improve" by failing faster.
+    return {
+        "total": int(total),
+        "ok": int(ok) if ok is not None else 0,
+        "ko": int(ko) if ko is not None else 0,
+        "ko_percent": ko_percent,
+        "unreachable": unreachable,
+        "throughput_ok": _row(log_text, "mean throughput (rps)")[1],
+        "mean_ms_ok": _row(log_text, "mean response time (ms)")[1],
+        "p95_ms_ok": _row(log_text, "response time 95th percentile (ms)")[1],
+        "p99_ms_ok": _row(log_text, "response time 99th percentile (ms)")[1],
+    }

--- a/perf-tests/scripts/test_check_external_baseline.py
+++ b/perf-tests/scripts/test_check_external_baseline.py
@@ -1,0 +1,175 @@
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import gatling_console
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_BASELINE_PATH = os.path.join(_HERE, os.pardir, "external-baseline.json")
+
+
+def _load_script(name):
+    import importlib.util
+    path = os.path.join(_HERE, name)
+    spec = importlib.util.spec_from_file_location(name.replace("-", "_").rstrip(".py"), path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ceb = _load_script("check-external-baseline.py")
+
+
+HEALTHY_POSTGRESQL = """
+---- Global Information -------------------------------------------------------------|---Total---|-----OK----|----KO----
+> request count                                                                      |    92,580 |    92,578 |         2
+> mean response time (ms)                                                            |       102 |       101 |    60,001
+> response time 95th percentile (ms)                                                 |       116 |       116 |    60,001
+> response time 99th percentile (ms)                                                 |       130 |       130 |    60,001
+> mean throughput (rps)                                                              |     462.9 |    462.89 |      0.01
+---- Response Time Distribution ----------------------------------------------------------------------------------------
+> KO                                                                                                          2     (0%)
+"""
+
+# A run with zero failures prints "-" in the KO column rather than 0.
+NO_FAILURES = """
+---- Global Information -------------------------------------------------------------|---Total---|-----OK----|----KO----
+> request count                                                                      |   336,923 |   336,923 |         0
+> mean response time (ms)                                                            |        28 |        28 |         -
+> response time 95th percentile (ms)                                                 |        68 |        68 |         -
+> response time 99th percentile (ms)                                                 |        89 |        89 |         -
+> mean throughput (rps)                                                              |  1,684.62 |  1,684.62 |         -
+---- Response Time Distribution ----------------------------------------------------------------------------------------
+> KO                                                                                                          0     (0%)
+"""
+
+COLLAPSED = """
+---- Global Information -------------------------------------------------------------|---Total---|-----OK----|----KO----
+> request count                                                                      | 1,396,990 |    59,167 | 1,337,823
+> mean response time (ms)                                                            |        23 |       352 |         7
+> response time 95th percentile (ms)                                                 |       120 |       357 |        10
+> response time 99th percentile (ms)                                                 |       197 |     5,313 |        22
+> mean throughput (rps)                                                              |   7,420.7 |    294.36 |  7,030.21
+---- Response Time Distribution ----------------------------------------------------------------------------------------
+> KO                                                                                                  1,337,823 (95.76%)
+---- Errors ------------------------------------------------------------------------------------------------------------
+> j.n.ConnectException: finishConnect(..) failed with error(-111): Connection refused                 1,336,886 (99.92%)
+> status.find.is(200), but actually found 500                                                               686  (0.05%)
+"""
+
+
+class ConsoleParserTests(unittest.TestCase):
+
+    def test_reads_ok_column_not_total(self):
+        stats = gatling_console.parse(HEALTHY_POSTGRESQL)
+        # The Total column is 102/462.9; the OK column is what a baseline must use.
+        self.assertEqual(stats["mean_ms_ok"], 101.0)
+        self.assertEqual(stats["throughput_ok"], 462.89)
+
+    def test_dash_columns_are_none_not_zero(self):
+        stats = gatling_console.parse(NO_FAILURES)
+        self.assertEqual(stats["ko"], 0)
+        self.assertEqual(stats["throughput_ok"], 1684.62)
+        self.assertEqual(stats["mean_ms_ok"], 28.0)
+
+    def test_collapsed_run_attributes_unreachable_separately_from_http_errors(self):
+        stats = gatling_console.parse(COLLAPSED)
+        self.assertAlmostEqual(stats["ko_percent"], 95.76)
+        self.assertEqual(stats["unreachable"], 1336886)
+
+    def test_no_summary(self):
+        self.assertIsNone(gatling_console.parse("Gatling started\n"))
+
+
+class BaselineEvaluationTests(unittest.TestCase):
+
+    def setUp(self):
+        with open(_BASELINE_PATH, encoding="utf-8") as handle:
+            self.baseline = json.load(handle)
+
+    def _status(self, rows, metric):
+        return next(status for label, _, _, status in rows if label == metric)
+
+    def test_healthy_run_has_no_regressions(self):
+        stats = gatling_console.parse(HEALTHY_POSTGRESQL)
+        rows, regressions = ceb.evaluate(stats, self.baseline, "postgresql")
+        self.assertEqual(regressions, [])
+        self.assertEqual(self._status(rows, "Throughput (rps)"), "ok")
+
+    def test_throughput_regression_is_detected_downward(self):
+        stats = dict(gatling_console.parse(HEALTHY_POSTGRESQL))
+        # floor is 460 * 0.7 = 322
+        stats["throughput_ok"] = 300.0
+        _, regressions = ceb.evaluate(stats, self.baseline, "postgresql")
+        self.assertIn("Throughput", regressions)
+
+    def test_throughput_above_baseline_is_never_a_regression(self):
+        stats = dict(gatling_console.parse(HEALTHY_POSTGRESQL))
+        stats["throughput_ok"] = 5000.0
+        _, regressions = ceb.evaluate(stats, self.baseline, "postgresql")
+        self.assertEqual(regressions, [])
+
+    def test_latency_regression_is_detected_upward(self):
+        stats = dict(gatling_console.parse(HEALTHY_POSTGRESQL))
+        # ceiling is 105 * 1.25 = 131.25
+        stats["mean_ms_ok"] = 200.0
+        _, regressions = ceb.evaluate(stats, self.baseline, "postgresql")
+        self.assertIn("Mean response time (ms)", regressions)
+
+    def test_unknown_storage_returns_no_rows(self):
+        stats = gatling_console.parse(HEALTHY_POSTGRESQL)
+        rows, regressions = ceb.evaluate(stats, self.baseline, "cassandra")
+        self.assertIsNone(rows)
+        self.assertIsNone(regressions)
+
+    def test_missing_metric_is_reported_unavailable_not_regression(self):
+        stats = dict(gatling_console.parse(HEALTHY_POSTGRESQL))
+        stats["p99_ms_ok"] = None
+        rows, regressions = ceb.evaluate(stats, self.baseline, "postgresql")
+        self.assertEqual(self._status(rows, "p99 response time (ms)"), "unavailable")
+        self.assertNotIn("p99 response time (ms)", regressions)
+
+
+class BaselineToleranceRegressionTests(unittest.TestCase):
+    """The baseline must not fire on ordinary runner variance.
+
+    These are the twelve real observations (six consecutive green main runs, both storage
+    variants) the baseline values were derived from. If a future edit to
+    external-baseline.json would have alerted on any of them, it is too tight and this
+    fails - the check is meant to catch a step change, not runner noise.
+    """
+
+    OBSERVED = {
+        "postgresql": [
+            (462.89, 101), (468.85, 101), (350.98, 104),
+            (483.44, 98), (459.04, 103), (467.91, 101),
+        ],
+        "kafkasql": [
+            (1684.62, 28), (1700.47, 27), (1570.42, 30),
+            (1822.17, 26), (1708.14, 28), (1370.70, 34),
+        ],
+    }
+
+    def test_no_recorded_green_run_would_alert(self):
+        with open(_BASELINE_PATH, encoding="utf-8") as handle:
+            baseline = json.load(handle)
+        for storage, runs in self.OBSERVED.items():
+            for throughput, mean_ms in runs:
+                stats = {
+                    "throughput_ok": throughput,
+                    "mean_ms_ok": mean_ms,
+                    "p95_ms_ok": None,
+                    "p99_ms_ok": None,
+                }
+                _, regressions = ceb.evaluate(stats, baseline, storage)
+                self.assertEqual(
+                    regressions, [],
+                    f"{storage} run ({throughput} rps, {mean_ms} ms) would alert",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #10077

Follow-on to #10004. That PR made the external high-concurrency validation trustworthy — 462.9 rps on postgresql, 1,684.6 rps on kafkasql, instead of a headline number that was 94% failed connects. Those figures were still only printed and archived, never compared, so a genuine regression would have looked exactly like a healthy run.

Adds `external-baseline.json` + `check-external-baseline.py`, the counterpart to the existing `baseline.json` / `check-thresholds.py` pair that covers the in-cluster Gatling Job.

## Design notes

**Separate baseline file, per storage.** The external and in-cluster runs use different concurrency and a different load path, so their numbers are not comparable; and the two backends differ by 3-4x in throughput, so one figure cannot cover both.

**Throughput and latency are treated differently.** Latency regresses upward and reuses the existing `regressionToleranceFactor` of 1.25. Throughput regresses *downward* and gets its own `throughputFloorFactor`, so a faster run can never be reported as a regression — applying a single factor to both would have done exactly that.

**Tolerances are measured, not guessed.** From six consecutive green main runs:

| storage | throughput (rps) | mean latency (ms) |
| --- | --- | --- |
| postgresql | 462.9, 468.9, **351.0**, 483.4, 459.0, 467.9 | 101, 101, 104, 98, 103, 101 |
| kafkasql | 1684.6, 1700.5, 1570.4, 1822.2, 1708.1, **1370.7** | 28, 27, 30, 26, 28, 34 |

Latency is stable; throughput swings ~25% with runner hardware. A floor factor of 0.7 clears the worst observed run by 9% (postgresql) and 16% (kafkasql).

`test_no_recorded_green_run_would_alert` pins all twelve observations, so a future edit that tightens the baseline into runner noise fails the build rather than starting a stream of false alarms.

**Informational, like `check-thresholds.py`.** perf-main runs after a merge has already landed, so there is nothing left to block. A `--strict` flag exists for local use. Whether the run was valid at all stays hard-gated by `check-external-validity.py`, and a collapsed run is refused a baseline comparison outright rather than having its meaningless throughput charted — verified against the real 95.76% log from run 33779773642:

```
Run failed 95.76% of requests - not comparing against the baseline, since a
collapsed run's throughput is not a measurement. See the validity check.
```

## Refactor

The Gatling console parser moves into `gatling_console.py`, now shared by the validity and baseline checks rather than duplicated across two scripts that would drift. It reads the **OK** column rather than Total — including failures would let a run "improve" by failing faster — and distinguishes a `-` column (no such requests) from zero.

This touches `check-external-validity.py` from #10004; its behaviour is unchanged and its existing tests still pass untouched.

## Verification

Against the real artifacts from runs 34451171770 (healthy, both variants) and 33779773642 (collapsed):

- healthy postgresql/kafkasql → all metrics `ok`, exit 0
- collapsed → comparison refused, validity check still exits 1

20 unit tests pass (9 existing + 11 new), covering OK-vs-Total column selection, `-` columns, downward throughput regression, upward latency regression, faster-than-baseline not flagged, unknown storage, missing metrics reported `unavailable` rather than as regressions, and the twelve-observation tolerance guard. They run in the lint job via the discovery path added in #10004.
