### PR TITLE
Fix ARD /agents endpoint pagination response

### DIFF
--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/V3WellKnownResource.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/V3WellKnownResource.java
@@ -4,6 +4,7 @@ import io.apicurio.registry.rest.v3.WellResource;
 import io.apicurio.registry.rest.v3.beans.AgentCard;
 import io.apicurio.registry.rest.v3.beans.AgentSearchResults;
 import io.apicurio.registry.rest.v3.beans.AiCatalog;
+import io.apicurio.registry.rest.v3.beans.ArdAgentsResponse;
 import io.apicurio.registry.rest.v3.beans.ArdExploreRequest;
 import io.apicurio.registry.rest.v3.beans.ArdExploreResponse;
 import io.apicurio.registry.rest.v3.beans.ArdSearchRequest;
@@ -85,7 +86,7 @@ public class V3WellKnownResource implements WellResource {
     }
 
     @Override
-    public AiCatalog ardListAgents(String filter, String orderBy, BigInteger pageSize, String pageToken) {
+    public ArdAgentsResponse ardListAgents(String filter, String orderBy, BigInteger pageSize, String pageToken) {
         Integer size = pageSize != null ? pageSize.intValue() : 20;
         return delegate.ardListAgents(filter, orderBy, size, pageToken);
     }

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResource.java
@@ -4,6 +4,7 @@ import io.apicurio.registry.mcptools.rest.beans.McpCompatibleToolsResults;
 import io.apicurio.registry.rest.v3.beans.AgentCard;
 import io.apicurio.registry.rest.v3.beans.AgentSearchResults;
 import io.apicurio.registry.rest.v3.beans.AiCatalog;
+import io.apicurio.registry.rest.v3.beans.ArdAgentsResponse;
 import io.apicurio.registry.rest.v3.beans.ArdExploreRequest;
 import io.apicurio.registry.rest.v3.beans.ArdExploreResponse;
 import io.apicurio.registry.rest.v3.beans.ArdSearchRequest;
@@ -234,7 +235,7 @@ public interface WellKnownResource {
     @GET
     @Path("/ard/agents")
     @Produces(MediaType.APPLICATION_JSON)
-    AiCatalog ardListAgents(
+    ArdAgentsResponse ardListAgents(
             @QueryParam("filter") String filter,
             @QueryParam("orderBy") String orderBy,
             @QueryParam("pageSize") @DefaultValue("20") Integer pageSize,

--- a/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
+++ b/app/src/main/java/io/apicurio/registry/rest/wellknown/WellKnownResourceImpl.java
@@ -15,6 +15,7 @@ import io.apicurio.registry.rest.v3.beans.AgentInterface;
 import io.apicurio.registry.rest.v3.beans.AgentSearchResult;
 import io.apicurio.registry.rest.v3.beans.AgentSearchResults;
 import io.apicurio.registry.rest.v3.beans.AiCatalog;
+import io.apicurio.registry.rest.v3.beans.ArdAgentsResponse;
 import io.apicurio.registry.rest.v3.beans.AiCatalogEntry;
 import io.apicurio.registry.rest.v3.beans.AiCatalogHost;
 import io.apicurio.registry.rest.v3.beans.ArdExploreRequest;
@@ -907,7 +908,7 @@ public class WellKnownResourceImpl implements WellKnownResource {
 
     @Override
     @Authorized(style = AuthorizedStyle.None, level = AuthorizedLevel.Read)
-    public AiCatalog ardListAgents(String filter, String orderBy, Integer pageSize, String pageToken) {
+    public ArdAgentsResponse ardListAgents(String filter, String orderBy, Integer pageSize, String pageToken) {
         if (!ardConfig.isEnabled()) {
             throw new NotFoundException("ARD support is disabled");
         }
@@ -941,9 +942,12 @@ public class WellKnownResourceImpl implements WellKnownResource {
 
         String nextPageToken = toIndex < total ? encodePageToken(toIndex) : null;
 
-        AiCatalog catalog = buildAiCatalog(publisherDomain, entries);
-        catalog.setNextPageToken(nextPageToken);
-        return catalog;
+        ArdAgentsResponse response = new ArdAgentsResponse();
+        response.setItems(entries);
+        response.setTotal(total);
+        response.setPageToken(nextPageToken);
+
+        return response;
     }
 
     @Override

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/ard/WellKnownArdTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/ard/WellKnownArdTest.java
@@ -287,7 +287,7 @@ public class WellKnownArdTest extends AbstractResourceTestBase {
                 .then()
                 .statusCode(200)
                 .body("items", hasSize(1))
-                .body("items.url", hasItem(endsWith(groupId + "/" + agentId3)));
+                .body("items.url", hasItem(endsWith(groupId + "/" + agentId1)));
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/ard/WellKnownArdTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/ard/WellKnownArdTest.java
@@ -248,10 +248,33 @@ public class WellKnownArdTest extends AbstractResourceTestBase {
                 .get("/.well-known/ard/agents")
                 .then()
                 .statusCode(200)
-                .body("specVersion", equalTo("1.0"))
-                .body("host.displayName", equalTo("Apicurio Registry"))
-                .body("entries.url",
-                        hasItem(endsWith(groupId + "/" + agentId)));
+                .body("items.url",
+                    hasItem(endsWith(groupId + "/" + agentId)))
+                .body("total", greaterThanOrEqualTo(1));
+    }
+    @Test
+    public void testArdListAgentsPagination() throws Exception {
+        String groupId = TestUtils.generateGroupId();
+        String unique = TestUtils.generateArtifactId().replace("-", "");
+
+        String agentId1 = "ard-page-a-" + unique;
+        String agentId2 = "ard-page-b-" + unique;
+        String agentId3 = "ard-page-c-" + unique;
+
+        createAgentCard(groupId, agentId1, AGENT_CARD_CONTENT);
+        createAgentCard(groupId, agentId2, AGENT_CARD_CONTENT);
+        createAgentCard(groupId, agentId3, AGENT_CARD_CONTENT);
+
+        givenAtRoot()
+                .when()
+                .contentType(ContentType.JSON)
+                .queryParam("pageSize", 2)
+                .get("/.well-known/ard/agents")
+                .then()
+                .statusCode(200)
+                .body("items", hasSize(2))
+                .body("total", greaterThanOrEqualTo(3))
+                .body("pageToken", notNullValue());
     }
 
     @Test
@@ -271,11 +294,11 @@ public class WellKnownArdTest extends AbstractResourceTestBase {
                 .get("/.well-known/ard/agents")
                 .then()
                 .statusCode(200)
-                .body("entries.url",
-                        hasItem(endsWith(groupId + "/" + agentId)))
-                .body("entries.url",
-                        not(hasItem(endsWith(groupId + "/" + toolId))))
-                .body("entries.type", everyItem(equalTo("application/a2a-agent-card+json")));
+                .body("items.url",
+                    hasItem(endsWith(groupId + "/" + agentId)))
+                .body("items.url",
+                    not(hasItem(endsWith(groupId + "/" + toolId))))
+                .body("items.type", everyItem(equalTo("application/a2a-agent-card+json")));
     }
 
     @Test

--- a/app/src/test/java/io/apicurio/registry/noprofile/rest/ard/WellKnownArdTest.java
+++ b/app/src/test/java/io/apicurio/registry/noprofile/rest/ard/WellKnownArdTest.java
@@ -265,7 +265,7 @@ public class WellKnownArdTest extends AbstractResourceTestBase {
         createAgentCard(groupId, agentId2, AGENT_CARD_CONTENT);
         createAgentCard(groupId, agentId3, AGENT_CARD_CONTENT);
 
-        givenAtRoot()
+        String pageToken = givenAtRoot()
                 .when()
                 .contentType(ContentType.JSON)
                 .queryParam("pageSize", 2)
@@ -274,7 +274,20 @@ public class WellKnownArdTest extends AbstractResourceTestBase {
                 .statusCode(200)
                 .body("items", hasSize(2))
                 .body("total", greaterThanOrEqualTo(3))
-                .body("pageToken", notNullValue());
+                .body("pageToken", notNullValue())
+                .extract()
+                .path("pageToken");
+
+        givenAtRoot()
+                .when()
+                .contentType(ContentType.JSON)
+                .queryParam("pageSize", 2)
+                .queryParam("pageToken", pageToken)
+                .get("/.well-known/ard/agents")
+                .then()
+                .statusCode(200)
+                .body("items", hasSize(1))
+                .body("items.url", hasItem(endsWith(groupId + "/" + agentId3)));
     }
 
     @Test

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -6800,7 +6800,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AiCatalog"
+                  "$ref": "#/components/schemas/ArdAgentsResponse"
                 }
               }
             },
@@ -10053,9 +10053,26 @@
             "items": {
               "$ref": "#/components/schemas/AiCatalogEntry"
             }
+          }
+        }
+      },
+      "ArdAgentsResponse": {
+        "description": "Response body for the ARD GET /agents endpoint.",
+        "required": [
+          "items"
+        ],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AiCatalogEntry"
+            }
           },
-          "nextPageToken": {
-            "description": "Opaque pagination token for retrieving the next page of ARD list results. Only populated by the ARD `GET /agents` endpoint; absent from the static `/.well-known/ai-catalog.json` projection.",
+          "total": {
+            "type": "integer"
+          },
+          "pageToken": {
             "type": "string"
           }
         }

--- a/common/src/main/resources/META-INF/openapi.json
+++ b/common/src/main/resources/META-INF/openapi.json
@@ -10059,7 +10059,7 @@
       "ArdAgentsResponse": {
         "description": "Response body for the ARD GET /agents endpoint.",
         "required": [
-          "items"
+          "items","total"
         ],
         "type": "object",
         "properties": {


### PR DESCRIPTION
Closes #10005 

## Summary

Updates the ARD `GET /.well-known/ard/agents` endpoint to return the paginated `ListResponse`-style response expected by the ARD Registry API.

The endpoint now returns an `ArdAgentsResponse` containing:

* `items` — the matching agent entries
* `total` — the total number of matching entries
* `pageToken` — the token for retrieving the next page

The existing filtering, ordering, pagination, authentication, and feature-gating behavior is preserved. The manifest endpoints (`/.well-known/ai-catalog.json` and `/.well-known/ard.json`) continue to return the `AiCatalog` response format.

Tests have also been updated and added to verify the new response structure and pagination behavior.

## Checklist

* [ ] Linked issue has maintainer approval
* [x] No overlapping open PRs for the same issue
* [ ] Checked the [[Tried & Rejected list](https://github.com/Apicurio/apicurio-registry/discussions/8364)](https://github.com/Apicurio/apicurio-registry/discussions/8364)
* [x] Tests added for new code paths
* [x] Tested locally: `./mvnw test -pl <module> -am -Dlocal`
* [x] `./mvnw checkstyle:check -pl <module>` passes
* [x] All commits have DCO sign-off (`git commit -s`)