### PR TITLE
test(operator): add K8sCell.delete() and migrate ITBase/OLMITBase cleanup

### DIFF
--- a/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/it/ITBase.java
@@ -54,6 +54,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.apicurio.registry.operator.resource.Labels.getOperatorManagedLabels;
+import static io.apicurio.registry.operator.utils.K8sCell.k8sCell;
 import static io.apicurio.registry.operator.utils.Mapper.toYAML;
 import static io.apicurio.registry.utils.Cell.cell;
 import static java.time.Duration.ofSeconds;
@@ -535,23 +536,8 @@ public abstract class ITBase implements OperatorTestContext {
     void afterEach() {
         if (cleanup) {
             log.info("Deleting CRs");
-            client.resources(ApicurioRegistry3.class).delete();
-            try {
-                await().atMost(MEDIUM_DURATION).untilAsserted(() -> {
-                    assertThat(client.resources(ApicurioRegistry3.class).inNamespace(namespace)
-                            .list().getItems()).isEmpty();
-                });
-            } catch (org.awaitility.core.ConditionTimeoutException e) {
-                log.warn("Timed out waiting for graceful CR cleanup, force-removing finalizers");
-                client.resources(ApicurioRegistry3.class).list().getItems().forEach(cr -> {
-                    cr.getMetadata().setFinalizers(List.of());
-                    client.resource(cr).patch();
-                });
-                await().atMost(SHORT_DURATION).untilAsserted(() -> {
-                    assertThat(client.resources(ApicurioRegistry3.class).inNamespace(namespace)
-                            .list().getItems()).isEmpty();
-                });
-            }
+            client.resources(ApicurioRegistry3.class).list().getItems()
+                    .forEach(cr -> k8sCell(client, () -> cr).delete(MEDIUM_DURATION, SHORT_DURATION));
             await().atMost(MEDIUM_DURATION).untilAsserted(() -> {
                 var registryDeployments = client.apps().deployments().inNamespace(namespace)
                         .withLabels(getOperatorManagedLabels()).list().getItems();

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/K8sCell.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/K8sCell.java
@@ -5,10 +5,12 @@ import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import org.awaitility.core.ConditionTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -96,6 +98,34 @@ public class K8sCell<T extends HasMetadata> {
                 }
             }
         });
+    }
+
+    /**
+     * Deletes the resource and waits for it to disappear. If it is still present after
+     * {@code gracefulTimeout} (e.g. blocked by a finalizer), force-clears its finalizers and
+     * waits again up to {@code forceTimeout}. A no-op if the resource does not exist.
+     * <p>
+     * Both waits ignore exceptions: reading a resource that is being torn down races with the API
+     * server dropping its endpoint, so transient read failures are expected while polling for
+     * absence.
+     */
+    public void delete(Duration gracefulTimeout, Duration forceTimeout) {
+        var current = getOptional();
+        if (current.isEmpty()) {
+            return;
+        }
+        client.resource(current.get()).delete();
+        try {
+            await().atMost(gracefulTimeout).ignoreExceptions().until(() -> getOptional().isEmpty());
+        } catch (ConditionTimeoutException ex) {
+            log.warn("Timed out waiting for graceful deletion of {}, force-removing finalizers",
+                    ResourceID.fromResource(current.get()));
+            getOptional().ifPresent(r -> {
+                r.getMetadata().setFinalizers(List.of());
+                client.resource(r).patch();
+            });
+            await().atMost(forceTimeout).ignoreExceptions().until(() -> getOptional().isEmpty());
+        }
     }
 
     /**

--- a/operator/controller/src/test/java/io/apicurio/registry/operator/utils/K8sCellTest.java
+++ b/operator/controller/src/test/java/io/apicurio/registry/operator/utils/K8sCellTest.java
@@ -10,6 +10,9 @@ import io.fabric8.kubernetes.client.dsl.NamespaceableResource;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Proxy;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.apicurio.registry.operator.utils.K8sCell.k8sCell;
@@ -114,6 +117,83 @@ class K8sCellTest {
         assertThat(K8sCell.isRetryableTimeout(other)).isFalse();
     }
 
+    @Test
+    void deleteWaitsForGracefulRemoval() {
+        var item = configMap("cm");
+        item.getMetadata().setFinalizers(new java.util.ArrayList<>(List.of("apicurio.io/some-finalizer")));
+
+        AtomicInteger getCalls = new AtomicInteger();
+        AtomicInteger deleteCalls = new AtomicInteger();
+        AtomicInteger patchCalls = new AtomicInteger();
+        KubernetesClient client = stubClient(new StubBehavior() {
+            @Override
+            public HasMetadata get(HasMetadata resource) {
+                return getCalls.incrementAndGet() < 2 ? resource : null;
+            }
+
+            @Override
+            public void delete(HasMetadata resource) {
+                deleteCalls.incrementAndGet();
+            }
+
+            @Override
+            public HasMetadata patch(HasMetadata resource) {
+                patchCalls.incrementAndGet();
+                return resource;
+            }
+        });
+
+        k8sCell(client, () -> item).delete(Duration.ofSeconds(2), Duration.ofSeconds(1));
+
+        assertThat(deleteCalls.get()).isEqualTo(1);
+        assertThat(getCalls.get()).isGreaterThanOrEqualTo(2);
+        // The force path must not run: finalizers are left untouched when the resource goes away on its own.
+        assertThat(patchCalls.get()).isZero();
+        assertThat(item.getMetadata().getFinalizers()).containsExactly("apicurio.io/some-finalizer");
+    }
+
+    @Test
+    void deleteForceRemovesFinalizersAfterGracefulTimeoutExpires() {
+        var item = configMap("cm");
+        item.getMetadata().setFinalizers(new java.util.ArrayList<>(List.of("apicurio.io/some-finalizer")));
+
+        AtomicInteger patchCalls = new AtomicInteger();
+        AtomicBoolean forceCleared = new AtomicBoolean(false);
+        KubernetesClient client = stubClient(new StubBehavior() {
+            @Override
+            public HasMetadata get(HasMetadata resource) {
+                return forceCleared.get() ? null : resource;
+            }
+
+            @Override
+            public HasMetadata patch(HasMetadata resource) {
+                patchCalls.incrementAndGet();
+                forceCleared.set(true);
+                return resource;
+            }
+        });
+
+        k8sCell(client, () -> item).delete(Duration.ofMillis(300), Duration.ofSeconds(2));
+
+        assertThat(patchCalls.get()).isEqualTo(1);
+        assertThat(item.getMetadata().getFinalizers()).isEmpty();
+    }
+
+    @Test
+    void deleteIsNoOpWhenResourceAlreadyGone() {
+        AtomicInteger deleteCalls = new AtomicInteger();
+        KubernetesClient client = stubClient(new StubBehavior() {
+            @Override
+            public void delete(HasMetadata resource) {
+                deleteCalls.incrementAndGet();
+            }
+        });
+
+        k8sCell(client, () -> (HasMetadata) null).delete(Duration.ofSeconds(1), Duration.ofSeconds(1));
+
+        assertThat(deleteCalls.get()).isZero();
+    }
+
     private static ConfigMap configMap(String name) {
         return new ConfigMapBuilder()
                 .withNewMetadata()
@@ -135,6 +215,13 @@ class K8sCellTest {
         }
 
         default HasMetadata update(HasMetadata resource) {
+            return resource;
+        }
+
+        default void delete(HasMetadata resource) {
+        }
+
+        default HasMetadata patch(HasMetadata resource) {
             return resource;
         }
     }
@@ -171,6 +258,11 @@ class K8sCellTest {
                     case "create" -> behavior.create(item);
                     case "get" -> behavior.get(item);
                     case "update" -> behavior.update(item);
+                    case "patch" -> behavior.patch(item);
+                    case "delete" -> {
+                        behavior.delete(item);
+                        yield null;
+                    }
                     case "toString" -> "stub-resource";
                     case "hashCode" -> System.identityHashCode(proxy);
                     case "equals" -> proxy == args[0];

--- a/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
+++ b/operator/olm-tests/src/test/java/io/apicurio/registry/operator/it/OLMITBase.java
@@ -19,7 +19,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.List;
 
 import static io.apicurio.registry.operator.it.ITBase.MEDIUM_DURATION;
 import static io.apicurio.registry.operator.it.ITBase.SHORT_DURATION;
@@ -181,31 +180,8 @@ public abstract class OLMITBase implements OperatorTestContext {
                     }
                 });
 
-                await().atMost(MEDIUM_DURATION).ignoreExceptions().until(() -> {
-                    log.debug("Deleting ApicurioRegistry3 CRD.");
-                    crd.getOptional().ifPresent(c -> {
-                        client.resource(c).delete();
-                    });
-                    try {
-                        await().atMost(SHORT_DURATION).ignoreExceptions().until(() -> {
-                            var c = crd.getOptional();
-                            if (c.isPresent()) {
-                                log.debug("Waiting on ApicurioRegistry3 CRD to be deleted. Terminating condition: {}", c.get().getStatus().getConditions().stream()
-                                        .filter(cond -> "Terminating".equals(cond.getType())).findFirst().orElse(null));
-                                return false;
-                            } else {
-                                return true;
-                            }
-                        });
-                        return true;
-                    } catch (Exception ex) {
-                        log.debug("Could not delete ApicurioRegistry3 CRD. Trying to force the deletion by deleting the finalizer.");
-                        crd.update(r -> {
-                            r.getMetadata().setFinalizers(List.of());
-                        });
-                        return false;
-                    }
-                });
+                log.debug("Deleting ApicurioRegistry3 CRD.");
+                crd.delete(MEDIUM_DURATION, SHORT_DURATION);
             }
 
             createResource("olmv1/cluster-catalog.yaml");


### PR DESCRIPTION
Closes #9743

## Summary

The finalizer-aware cleanup pattern — delete, wait for the object to go away,
force-clear finalizers if it doesn't, wait again — was written out twice: in
ITBase.afterEach for ApicurioRegistry3 CRs, and in OLMITBase for the CRD. It's
subtle logic that only shows up as a hung suite when it's wrong, so two copies
is a real risk.

Adds K8sCell.delete(gracefulTimeout, forceTimeout) and migrates both call sites
onto it. This is the delete()/finalizer follow-up @jsenko asked for in #9701
(he flagged it as highest value per line changed), after #9742 landed the
conflict-detection fixes.

Two behaviour notes worth a reviewer's eye:

- Both waits ignore exceptions, matching what the OLM call site did explicitly.
  Polling a resource that's being torn down races with the API server dropping
  its endpoint, so transient read failures are expected there.
- ITBase now deletes per CR instead of issuing one bulk delete, so deletions are
  sequential rather than parallel. The set of CRs selected is unchanged (still
  unscoped, same as before). With 0-1 CRs this costs nothing; it's slightly
  slower for the multi-namespace tests.

## Checklist

- [x] Linked issue has maintainer approval
- [x] No overlapping open PRs for the same issue
- [x] Checked the [Tried & Rejected list](https://github.com/Apicurio/apicurio-registry/discussions/8364)
- [x] Tests added for new code paths
- [x] Tested locally: `./mvnw test -pl <module> -am -Dlocal`
- [x] `./mvnw checkstyle:check -pl <module>` passes
- [x] All commits have DCO sign-off (`git commit -s`)