### PR TITLE
docs(test-quality): add Pattern 34 and wire P31-P34 into the scoring skill

### DIFF
--- a/.claude/skills/apicurio-test-quality/SKILL.md
+++ b/.claude/skills/apicurio-test-quality/SKILL.md
@@ -1,31 +1,84 @@
 ---
 name: apicurio-test-quality
-description: Score-based test quality review using the project's 30-pattern catalog (P1-P30). Detects concurrency hazards, timing flakes, CI waste, lifecycle bugs, correctness gaps, and race test quality in changed test files. Labels (concurrency, timing, waste, lifecycle, correctness, hygiene, race) enable targeted agent sweeps. Run before committing test code.
+description: Score-based test quality review using the project's 34-pattern catalog (P1-P34). Detects concurrency hazards, timing flakes, CI waste, lifecycle bugs, correctness gaps, and race test quality in changed test files. Labels (concurrency, timing, waste, lifecycle, correctness, hygiene, race) enable targeted agent sweeps. Run before committing test code, and on any diff that changes concurrency primitives.
 ---
 
 # Test Quality: Pattern-Based Scoring Review
 
-Analyze changed test files against the project's 30 documented test failure patterns
-(P1-P30, see `claudedocs/test-fix-pattern-catalog.md`). Each pattern detector produces
+Analyze changed test files against the project's 34 documented test failure patterns
+(P1-P34, see `claudedocs/test-fix-pattern-catalog.md`). Each pattern detector produces
 a score; violations below threshold block submission. Patterns are labeled for targeted
 agent sweeps: `concurrency`, `timing`, `waste`, `lifecycle`, `correctness`, `hygiene`, `race`.
+
+Every pattern gates at full strength unless the catalog's "Scoring scope" table gives it a
+narrower treatment. That table is the authoritative one; do not keep a second copy of it
+here. Appearing in it does not mean a pattern is exempt: P32 is listed because it gates
+only in its narrow form, and P33 is listed because it does not gate at all.
 
 ## When to use
 
 - Before committing any change that touches `**/src/test/**`
+- Before committing any change that touches concurrency primitives, even with no test
+  files in the diff. That case is what P34 detects.
 - As part of the DoD (after /simplify, before /code-review)
-- On CI as a PR quality gate
+
+No CI job runs this skill. It gates at review time only, so a PR that skips it reaches
+`main` with nothing stopping it.
 
 ## Phase 1: Identify Test Changes
 
+Collect both lists before deciding anything. Use `origin/main` rather than `main`: a
+local `main` that has not been fetched recently resolves the range against a stale base
+and pulls in files that are already upstream.
+
 ```bash
-# Changed test files in the current diff
-git diff --name-only HEAD | grep -E 'src/test/.*\.java$'
-# Or vs main for PR scope
-git diff main...HEAD --name-only | grep -E 'src/test/.*\.java$'
+RANGE="origin/main...HEAD"   # committed work on a branch
+# RANGE="HEAD"               # uncommitted working tree; note there is no "..." here
+
+# 1. Changed test files, including ones git does not track yet
+{ git diff $RANGE --name-only; git ls-files --others --exclude-standard; } \
+  | grep -E 'src/test/.*\.java$' | sort -u
+
+# 2. Production changes to concurrency primitives (the P34 signal)
+git diff $RANGE -- '*.java' '*.ddl' | grep -E '^[+-]' \
+  | grep -vE '^(\+\+\+|---)' \
+  | grep -vE '^[+-]\s*(import |//|\*|/\*)' \
+  | grep -E '(ConcurrentHashMap|AtomicReference|AtomicBoolean|AtomicInteger|volatile |synchronized |compareAndSet|containsKey|computeIfAbsent|putIfAbsent|ON CONFLICT|ON DUPLICATE KEY|MERGE INTO|FOR UPDATE)'
 ```
 
-If no test files are changed, report "No test files in diff, score: 10/10" and stop.
+Three ways this collection silently returns nothing, all of which land on the clean-score
+branch below:
+
+- `HEAD...HEAD` is the empty diff. For uncommitted work use `RANGE="HEAD"` on its own.
+- On `main` itself, `origin/main...HEAD` is empty even with a dirty tree. Check out the
+  branch, or use `RANGE="HEAD"`.
+- `git diff` never reports untracked files, so a brand-new test class is invisible to a
+  range. The `git ls-files --others` arm above is what covers that case for list 1.
+
+Both greps read `+` and `-` lines, because removing a `synchronized` or deleting a
+double-checked-locking block is a concurrency change that a `^\+` filter cannot see. That
+blindness is Pattern 31's own shape applied to this skill.
+
+The pathspec is load-bearing. Without it the grep matches this file and the catalog, both of
+which quote the pattern in prose, and a docs-only diff produces false hits. `.ddl` is in the
+list because a uniqueness constraint is what makes an UPSERT possible and the schema lives in
+`app/src/main/resources/io/apicurio/registry/storage/impl/sql/*.ddl`, not in `.java`. There is
+no `.sql` entry: the only two tracked `.sql` files are an example init script and a Postgres
+cleanup script, neither of which is a schema. The `^+++` and `^---` filters drop diff headers,
+which would otherwise match on any path containing a pattern word. The last exclusion drops
+import and comment lines: 88 of 981 raw hits, 9%, measured with `git grep -hE` over tracked
+`*.java` at `origin/main` using the alternation above. None of them is itself a concurrency fix.
+
+Treat the result as a signal, not a verdict. The map-method alternatives catch a
+check-then-act sequence only when it is written with `containsKey` or friends. A fix that
+replaces a hand-rolled `get()` test with a guarded write matches nothing, so read the
+production hunks when the change description suggests a race even if this returns empty.
+
+Pass list 2 to Agent 4 whenever it is non-empty, regardless of whether list 1 is empty.
+A concurrency fix that happens to touch one unrelated test file still scores 0 on P34 if
+no test exercises the race, and gating the check on an empty test list misses exactly
+that case. When both lists are empty, report "No test files in diff, score: 10/10" and
+stop: do not launch the agents.
 
 Read the full content of each changed test file (not just the diff). Also read the
 production code they test (to understand shared state, lifecycle, config properties).
@@ -67,7 +120,7 @@ Detect test code that will break under JUnit 5 class-level parallel execution.
 - **P12 (Shared Mutable DTO)**: `private static final` DTOs mutated via setters across
   tests. `final` prevents reassignment but not mutation.
 
-### Agent 2: Timing and CI Waste [labels: `timing`, `waste`] (P2, P4, P9, P17, P21, P24, P27, P28)
+### Agent 2: Timing and CI Waste [labels: `timing`, `waste`] (P2, P4, P9, P17, P21, P24, P27, P28, P29, P32)
 
 Detect test code that will flake under CI load or waste CI time.
 
@@ -92,8 +145,13 @@ Detect test code that will flake under CI load or waste CI time.
 - **P29 (Async-Treated-as-Sync)**: An async operation (K8s delete, container stop) treated
   as complete because the API returned 200. Must poll for actual completion. Look for
   `delete()` or `stop()` calls on K8s/Docker resources followed by no wait/poll.
+- **P32 (QuarkusTest Overuse), narrow form only**: a NEW test class annotated `@QuarkusTest`
+  that has no `@Inject` field and no CDI lookup, so it boots the full runtime to exercise
+  pure logic. Score down only in that case. Do NOT score a test down for using
+  `@QuarkusTest` where the surrounding test classes do; see the catalog's scoring-scope
+  table for why.
 
-### Agent 3: Infrastructure, Lifecycle, and Hygiene [labels: `lifecycle`, `hygiene`] (P8, P11, P14, P16, P19, P22, P23)
+### Agent 3: Infrastructure, Lifecycle, and Hygiene [labels: `lifecycle`, `hygiene`] (P8, P11, P14, P16, P19, P22, P23, P30, P33)
 
 Detect test infrastructure mismanagement and code hygiene issues.
 
@@ -103,20 +161,27 @@ Detect test infrastructure mismanagement and code hygiene issues.
 - **P14 (Unclosed Consumer Leak)**: KafkaConsumer in `@BeforeAll` with no `@AfterAll` close.
 - **P16 (Silent Cleanup Failure)**: `catch (Exception ignored) {}` in cleanup or setup code.
   Also check `TestExecutionListener` implementations that swallow setup exceptions.
-- **P30 (Third-Party Thread Leak)**: `Unreliables.retryUntilTrue/retryUntilSuccess` with a
-  shared mutable resource (consumer, producer). The library leaks background threads that
-  continue accessing the resource after timeout. Replace with caller-thread poll loop.
 - **P19 (Reflective CDI Bypass)**: `Field.setAccessible(true)` OR `Method.setAccessible(true)`
   to inject mocks or invoke private methods. Brittle against renames.
 - **P22 (Orphaned Disabled Test)**: `@Disabled` with no issue reference. Dead code.
 - **P23 (Unbounded Recursive Retry)**: Recursive retry with no counter. StackOverflowError.
+- **P30 (Third-Party Thread Leak)**: `Unreliables.retryUntilTrue/retryUntilSuccess` with a
+  shared mutable resource (consumer, producer). The library leaks background threads that
+  continue accessing the resource after timeout. Replace with caller-thread poll loop.
+- **P33 (ParameterizedTest Underuse), advisory only**: several test methods differing only
+  in their input values, where `@ParameterizedTest` with `@ValueSource` or `@CsvSource`
+  would express the same coverage. Report these in the advisory section. Do not assign
+  them a score and do not let them move this agent's number.
 
-### Agent 4: Correctness and Race Quality [labels: `correctness`, `race`] (P3, P10, P13, P15, P18, P20, P25, P26)
+### Agent 4: Correctness and Race Quality [labels: `correctness`, `race`] (P3, P10, P13, P15, P18, P20, P25, P26, P31, P34)
 
 Evaluate test correctness and race condition testing quality.
 
 - **P3 (Non-Deterministic Race Tests)**: Threading without deterministic coordination.
-  Score 10 for Byteman/CyclicBarrier; score 0 for "hope-based" threading.
+  Score 10 for `CyclicBarrier`, `CountDownLatch` or Byteman rule injection; score 0 for
+  "hope-based" threading. Before suggesting Byteman as the fix, read Pattern 3's
+  Infrastructure note in the catalog: it records whether `-Pbyteman` exists on the current
+  base. When it does not, ask for a barrier.
 - **P10 (Stampede Test Completeness)**: Needs: latency, barrier, exact count assertion.
 - **P13 (Assertion-Free Test)**: Zero assertions; only verifies "no exception thrown."
 - **P15 (Cross-Test Event Bleed)**: Shared consumer accumulates events across tests.
@@ -124,6 +189,26 @@ Evaluate test correctness and race condition testing quality.
 - **P20 (Silent Validation Sink)**: Validation helper catches exceptions and returns normally.
 - **P25 (Benchmark as Test)**: `@Test` on benchmark methods with no assertions.
 - **P26 (Existence-Only Assertion)**: Only `assertNotNull`, no value checks.
+- **P31 (Vacuous Predicate)**: `allMatch()`, `noneMatch()` or a loop
+  body asserted over a collection that can be empty. The assertion passes with zero
+  elements. Also flag any assertion whose failure condition is unreachable, such as a
+  disjunction satisfied by two opposite states (`isInterrupted() || !isAlive()`).
+- **P34 (Concurrency Fix Without Race Test)**: the production side of the diff changes a
+  concurrency primitive or a check-then-act sequence, and no test exercises the race.
+  The Phase 1 grep is a signal, not a verdict. The alternation's own literals are common in
+  single-threaded code: at `origin/main`, `git grep -lE 'containsKey' -- '*/src/main/java/*.java'`
+  reports 55 files and the same command for `'synchronized '` reports 28. The trailing space
+  matters, and dropping it reports 34. Read the hunk before scoring.
+  Score 0 only when a deterministic test is feasible and absent. When the
+  window is genuinely too narrow to force open, the pattern clears on a pointer to a test
+  that covers the same path, or on a reason that names the mechanism blocking a
+  deterministic test: no injection point, no barrier reachable from the test, a race
+  entirely inside a third-party call. A reason that only asserts the race is hard to
+  reproduce is not one of those, or the gate bypasses itself on prose. When a test is
+  present, ask
+  whether it fails against the unfixed code, and say so if that has not been proven by
+  mutation. Ask separately whether it runs in a CI job that actually executes: a test
+  behind an opt-in profile does not stop a revert.
 
 ## Phase 3: Score and Report
 
@@ -139,19 +224,25 @@ Wait for all four agents. Aggregate findings into a scored report:
 | Category | Labels | Patterns | Score | Findings |
 |----------|--------|----------|-------|----------|
 | Concurrency Safety | `concurrency` | P1,P5,P6,P7,P12 | X/10 | N findings |
-| Timing & CI Waste | `timing`,`waste` | P2,P4,P9,P17,P21,P24,P27,P28,P29 | X/10 | N findings |
-| Infra, Lifecycle & Hygiene | `lifecycle`,`hygiene` | P8,P11,P14,P16,P19,P22,P23,P30 | X/10 | N findings |
-| Correctness & Race Quality | `correctness`,`race` | P3,P10,P13,P15,P18,P20,P25,P26 | X/10 | N findings |
+| Timing & CI Waste | `timing`,`waste` | P2,P4,P9,P17,P21,P24,P27,P28,P29,P32 | X/10 | N findings |
+| Infra, Lifecycle & Hygiene | `lifecycle`,`hygiene` | P8,P11,P14,P16,P19,P22,P23,P30 (+P33 advisory) | X/10 | N findings |
+| Correctness & Race Quality | `correctness`,`race` | P3,P10,P13,P15,P18,P20,P25,P26,P31,P34 | X/10 | N findings |
 
 ### Findings (by severity)
 [For each finding: pattern ID, file:line, description, fix suggestion]
+
+### Advisory (not scored)
+[P33 observations, if any]
 ```
 
 The overall score is the weighted average:
 - Concurrency Safety: weight 3 (most common failure class)
-- Timing & Consistency: weight 3
-- Infra & Lifecycle: weight 2
-- Race Test Quality: weight 2
+- Timing & CI Waste: weight 3
+- Infra, Lifecycle & Hygiene: weight 2
+- Correctness & Race Quality: weight 2
+
+P33 is dispatched to Agent 3 but carries no score, which is why the row above lists it
+separately. Agent 3's own number must not move because of it either.
 
 ## Phase 4: Fix (if score < 7.0)
 
@@ -173,11 +264,18 @@ The scores are calibrated against the project's actual history:
 Full catalog with examples, mechanisms, fix templates, and labels:
 `claudedocs/test-fix-pattern-catalog.md`
 
-30 patterns (P1-P30) extracted from 30+ PRs, a 661-file codebase sweep, and a clean-room
-validation run (August 2026). Clean-room validation: 62.5% true-positive rate, zero false
-positives. Known gaps: hand-rolled poll loops (P4), reflective method invocation (P19).
+34 patterns (P1-P34) extracted from 30+ PRs, a 661-file codebase sweep, a clean-room
+validation run (August 2026), and epic #9807.
+
+The clean-room run measured a 62.5% true-positive rate, 20 of the ~32 in-scope findings
+from the earlier sweep, plus 13 files that sweep had missed. It reported no incorrect
+findings, which is not the same as a measured zero false-positive rate. That run carried
+P1-P26; it is what produced P27 and P28. P29-P34 came later and have no measured rate.
+Known gaps: hand-rolled poll loops (P4), reflective method invocation (P19).
 
 Labels: `concurrency`, `timing`, `waste`, `lifecycle`, `correctness`, `hygiene`, `race`.
 
-To run a targeted sweep by label (e.g., only timing/waste patterns):
-pass `--labels timing,waste` to focus the agents on those pattern groups.
+The labels and the four agent groups are two different partitions of the catalog, so a
+label sweep cuts across agents rather than selecting one. To run a targeted sweep (say,
+only timing and waste patterns), pass `--labels timing,waste` and take the pattern list
+from the catalog's Labels table, not from the agent headings above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Full contribution guidelines are in [CONTRIBUTING.md](CONTRIBUTING.md).
 - [ ] Security tests cover: authorized access, unauthorized access (403), edge cases (null tokens, expired sessions).
 - [ ] Tests for CDI annotations (`@Retry`, `@CircuitBreaker`, `@Timeout`) use `@QuarkusTest` with injected beans; plain JUnit with `new` bypasses interceptors.
 - [ ] If CI fails on a test unrelated to your change, report it as a separate issue with the flaky test class, error message, and CI run link.
-- [ ] When the diff touches `**/src/test/**`, run `/apicurio-test-quality` (scores test code against 30 documented failure patterns P1-P30; score below 7.0 blocks submission).
+- [ ] Run `/apicurio-test-quality` when the diff touches `**/src/test/**`, and also when it changes a concurrency primitive with no test file in it at all. The second case is what P34 detects, and gating on the test path alone makes that pattern unreachable. The skill scores against `claudedocs/test-fix-pattern-catalog.md`; anything below 7.0 has to be fixed before submission.
 
 ### Submission
 - [ ] `./mvnw test-compile -pl <module> -am -DskipTests` compiles cleanly (use `test-compile`, not `compile`, when touching test files).

--- a/claudedocs/test-fix-pattern-catalog.md
+++ b/claudedocs/test-fix-pattern-catalog.md
@@ -1,8 +1,8 @@
 # Test Fix Pattern Catalog: Apicurio Registry
 
-**Date**: 2026-08-24 (updated with full-codebase sweep results)
-**Source**: 30+ PRs (May-August 2026) + full codebase sweep of 661 test files
-**Patterns**: 33 (11 original + 15 from sweep + 2 from clean-room + 2 from PR #9800 + 3 from epic #9807)
+**Date**: 2026-09-11 (P34 added; P31-P33 revised; base sweep results from 2026-08-24)
+**Source**: 30+ PRs (May-September 2026) + a codebase sweep of 661 test files
+**Patterns**: 34 (11 original + 15 from sweep + 2 from clean-room + 2 from PR #9800 + 1 from issue #9327 + 2 from epic #9807 + 1 from PR #9789)
 
 This catalog documents recurring test failure classes and their proven fixes, extracted
 from real CI fixes and a full-codebase pattern sweep. Each pattern has a unique ID, labels
@@ -10,17 +10,28 @@ for agent-based filtering, and a fix template.
 
 ## Labels
 
-Labels classify patterns for targeted agent sweeps:
+Labels classify patterns for targeted agent sweeps. This table is derived from the
+`**Labels**:` line of each pattern below, which is the authoritative declaration.
 
 | Label | Meaning | Patterns |
 |---|---|---|
 | `concurrency` | Breaks under parallel class/method execution | P1, P5, P6, P7, P12, P30 |
 | `timing` | Flakes under CI load or slow machines | P2, P4, P9, P17, P21, P24, P27, P29 |
 | `lifecycle` | Infra setup/teardown mismanagement | P5, P8, P11, P14, P16, P30 |
-| `correctness` | Test passes but does not verify what it claims | P7, P13, P18, P20, P26, P27, P28, P29 |
-| `waste` | Burns CI time without improving reliability | P17, P21, P24, P25 |
-| `hygiene` | Code quality, maintainability, dead code | P19, P22, P23 |
-| `race` | Race condition testing quality | P3, P10, P15 |
+| `correctness` | Test passes but does not verify what it claims | P2, P7, P13, P15, P18, P20, P26, P27, P28, P29, P31, P34 |
+| `waste` | Burns CI time without improving reliability | P4, P17, P21, P24, P25, P32 |
+| `hygiene` | Code quality, maintainability, dead code | P19, P22, P23, P33 |
+| `race` | Race condition testing quality | P3, P10, P15, P34 |
+
+## Scoring scope
+
+Every pattern gates the per-PR quality gate unless it appears in the table below. Listing
+only the exceptions means a pattern added later gates by default, with no edit here.
+
+| Pattern | Treatment | Why |
+|---|---|---|
+| P32 | Gating, narrow form only | Score down only when a new `@QuarkusTest` has no CDI injection at all. Most app tests already use `@QuarkusTest` (Pattern 32 carries the count); converting them is backlog work tracked in #9807, not a reason to score down a new test that follows the local convention. |
+| P33 | Advisory, never scored | `@ParameterizedTest` adoption is a style preference. Scoring it would penalize a PR for adding two structurally similar test methods, which is the "rule written too broadly" objection raised in review on #8626. |
 
 ## Pattern 1: Static Field Cross-Class Contamination
 **Labels**: `concurrency`
@@ -79,12 +90,15 @@ await().untilAsserted(() -> {
 
 **Twin test**: Same Byteman rule with the fix applied must make the forced interleaving harmless.
 
-**Infrastructure**: Maven `-Pbyteman` profile, `@EnabledIfSystemProperty(named="byteman.agent")`, configurable script path via `-Dbyteman.script=byteman/<name>.btm`.
+**Infrastructure**: not on `main` yet. The `-Pbyteman` profile arrives with PR #9789. Until that merges, `./mvnw -Pbyteman` names a profile that does not exist. Maven does not fail on that; it prints `[WARNING] The requested profile "byteman" could not be activated because it does not exist` after `BUILD SUCCESS` and exits 0, so the rules never load and the command still looks like it worked.
+
+What the PR branch adds is the profile in `app/pom.xml` plus BMUnit5 4.0.27. Rules are inline: `@WithByteman` on the class, `@BMRules`/`@BMRule` on the method. There are no `.btm` files and no `resourcescript:` to manage, because BMUnit attaches the agent through the JDK Attach API, driven by `-Djdk.attach.allowAttachSelf=true -Dbyteman.agent=true`. `byteman-bmunit5` sits at provided scope outside the profile. That scope satisfies two constraints at once: the test classes still compile without `-Pbyteman`, and FOSSA does not flag the dependency the way it did when the same artifact sat at unconditional test scope. Moving it back to test scope re-breaks the license scan. `@EnabledIfSystemProperty(named="byteman.agent", matches="true")` skips the class when the profile is inactive.
 
 **Key traps**:
 - BYTEMAN-38: `signalWake` before `waitFor` loses the signal. Always use `waitFor(key, TIMEOUT)`.
 - Rule errors are silent (disabled rule, test "passes" because injection never happened). Always assert an observable effect.
 - `signal()` and `setFlag()` do NOT exist. Use `signalWake()` and `flag()`.
+- Nested classes: use `Outer$Inner` in `targetClass`.
 
 **PRs**: #9789 (versionOrder race, SELECT FOR UPDATE fix)
 
@@ -244,8 +258,6 @@ CyclicBarrier barrier = new CyclicBarrier(threadCount);
 **Fix**: Use `wakeup()` (the only thread-safe method), catch `WakeupException` in the consumer loop, and call `close()` from the consumer thread's own `finally` block. Join the consumer thread with a timeout and interrupt as fallback.
 
 **PRs**: #9791 (KafkaSqlRegistryStorage.onDestroy)
-
----
 
 ---
 
@@ -446,8 +458,6 @@ CyclicBarrier barrier = new CyclicBarrier(threadCount);
 
 ---
 
----
-
 ## Pattern 27: Side Effects Inside Awaitility Lambda
 **Labels**: `correctness`, `timing`
 
@@ -491,8 +501,6 @@ await().atMost(10, SECONDS).untilAsserted(() -> {
     assertEquals("expected", getResult().getName());
 });
 ```
-
----
 
 ---
 
@@ -553,51 +561,14 @@ assertTrue(total >= expected, "Expected " + expected + " records, got " + total)
 
 ---
 
----
-
-## Pattern 29: Async-Treated-as-Sync
-**Labels**: `timing`, `correctness`
-
-**Failure class**: Test passes individually but fails under parallel execution. Resources collide from a previous test's teardown still in flight.
-
-**Mechanism**: An asynchronous operation (K8s namespace delete, container stop) is treated as complete because the API returned 200. The caller proceeds without waiting for actual completion.
-
-**Fix**: Poll for the operation's actual completion before returning.
-
-```java
-// BAD: treat API acceptance as completion
-assertThat(client.namespaces().withName(ns).delete()).isNotNull();
-
-// GOOD: wait for actual termination
-client.namespaces().withName(ns).delete();
-await().atMost(60, SECONDS).until(() -> client.namespaces().withName(ns).get() == null);
-```
-
-**PRs**: #9800 (operator namespace teardown race)
-
----
-
-## Pattern 30: Third-Party Thread Leak
-**Labels**: `concurrency`, `lifecycle`
-
-**Failure class**: `ConcurrentModificationException` or thread-safety violations in test N+1 after test N timed out.
-
-**Mechanism**: A library (e.g., `Unreliables`) submits retry loops to a shared thread pool. On timeout, the submitted loop is never cancelled and continues accessing shared mutable state.
-
-**Fix**: Replace with a caller-thread poll loop using an explicit deadline.
-
-**PRs**: #9800 (Debezium Unreliables thread leak)
-
----
-
-## Pattern 31: Vacuous Predicate on Empty Collection
+## Pattern 31: Vacuous Predicate
 **Labels**: `correctness`
 
 **Failure class**: Test always passes regardless of the actual result.
 
-**Mechanism**: `Stream.allMatch()` returns `true` on an empty collection. A test that filters to an empty set and asserts `allMatch(condition)` passes vacuously.
+**Mechanism**: Two shapes. `Stream.allMatch()` and `noneMatch()` return `true` on an empty collection, so a test that filters to an empty set and asserts `allMatch(condition)` passes vacuously. The same failure appears without a collection whenever the failure condition is unreachable: `assertTrue(t.isInterrupted() || !t.isAlive())` is satisfied by both states of a thread, so no thread can fail it.
 
-**Fix**: Assert the collection is non-empty before applying the predicate.
+**Fix**: For the collection form, assert the collection is non-empty before applying the predicate. For the unreachable-condition form, work out which concrete state the test is trying to prove and assert that one state. If a disjunction is genuinely needed, assert the specific value that distinguishes pass from fail alongside it.
 
 **Issues**: #9327 (SearchCommandTest)
 
@@ -629,15 +600,41 @@ await().atMost(60, SECONDS).until(() -> client.namespaces().withName(ns).get() =
 
 ---
 
+## Pattern 34: Concurrency Fix Without Race Test
+**Labels**: `correctness`, `race`
+
+**Failure class**: Silent. The fix compiles and CI passes, but the race it addresses is never tested. A later refactor can reintroduce the same bug undetected.
+
+**Mechanism**: A PR fixes a concurrency bug (TOCTOU, lost update, duplicate key under contention) by changing production code (`ConcurrentHashMap`, `volatile`, `synchronized`, `AtomicReference`, SQL UPSERT replacing DELETE+INSERT) and adds zero test files. The race window is too narrow for a `Thread.sleep`-based test, so no test gets written at all.
+
+**Detection signal**: the diff touches concurrency primitives or replaces a check-then-act sequence, and no test in the diff exercises the race. The runnable form of this check lives in Phase 1 of `/apicurio-test-quality`, which owns the pattern list; do not keep a second copy of the regex here. Note that an empty `src/test/` list is a sufficient condition, not a necessary one: a diff carrying an unrelated test edit still matches this pattern.
+
+**Fix**: Start with what runs on the current base. For SQL races, a `@QuarkusTest` driving two concurrent transactions against the same row is enough. For in-process races, coordinate the threads with a `CyclicBarrier` or `CountDownLatch` so the interleaving is forced rather than hoped for. Reach for a Byteman rule only when no barrier can open the window, and check Pattern 3's Infrastructure note first: on a base where `-Pbyteman` does not exist, a Byteman test is not a fix, it is a test that never runs. Whichever you pick, prove it by mutation: revert the production fix and show the test red.
+
+The worked example to copy is `app/src/test/java/io/apicurio/registry/storage/impl/sql/ConcurrentVersionCreationTest.java`, which arrives with PR #9789. Four things in it are worth carrying to any new rule, and all four are easy to get wrong:
+
+- `targetClass` takes a fully qualified name as a string. Byteman does not resolve imports, so a bare class name matches nothing and the rule is silently disabled.
+- Both rules fire `AT ENTRY`. A call-site location such as `AFTER INVOKE java.util.Map.containsKey 1` rots as soon as anyone edits the method body, and a rule with no valid injection point fails silently.
+- The freeze is released from the *second* thread's entry, not from any exit of the frozen thread. The frozen thread is parked in `waitFor`, so it cannot release itself.
+- Flag names are namespaced with the test class (`ConcurrentVersionCreationTest.writer-entered`). Byteman flags are JVM-global and collide across test classes otherwise.
+
+The test also arms its rules with a system property only after fixture setup, so the freeze rule does not fire during the fixture's own call into the target method.
+
+**PRs**: #9789 (a Byteman race test that passed against the unfixed code until review caught it), #9793 (UPSERT fix whose accompanying test asserted idempotency but never exercised the race)
+
+---
+
 ## Cross-Cutting: Test Infrastructure Investments
 
-These are not patterns per se but infrastructure decisions that enabled the fixes above:
+These are not patterns per se but infrastructure decisions that enabled the fixes above. The
+Status column matters: an investment that has not landed on `main` cannot be relied on by a
+new test.
 
-| Investment | What it enables | PR |
-|---|---|---|
-| JUnit 5 class-level parallelism | Patterns 1, 5, 6, 7 | #9757 |
-| Byteman `-Pbyteman` profile | Pattern 3 | #9789 |
-| mock-oauth2-server | Pattern 10 | #9790 |
-| Awaitility everywhere | Patterns 2, 4, 9 | #8651, #8388 |
-| Surefire `rerunFailingTestsCount` | Pattern 8 (safety net) | #8388 |
-| Per-JVM infrastructure lifecycle | Patterns 5, 8 | #9722 |
+| Investment | What it enables | PR | Status |
+|---|---|---|---|
+| JUnit 5 class-level parallelism | Patterns 1, 5, 6, 7 | #9757 | merged |
+| Byteman `-Pbyteman` profile | Patterns 3, 34 | #9789 | open, not on `main` |
+| mock-oauth2-server | Pattern 10 | #9790 | open, not on `main` |
+| Awaitility everywhere | Patterns 2, 4, 9 | #8651, #8388 | merged |
+| Surefire `rerunFailingTestsCount` | Pattern 8 (safety net) | #8388 | merged |
+| Per-JVM infrastructure lifecycle | Patterns 5, 8 | #9722 | merged |


### PR DESCRIPTION
Closes #10112

## What

`claudedocs/test-fix-pattern-catalog.md` defines 33 patterns.
`.claude/skills/apicurio-test-quality/SKILL.md` declared P1-P30 in three places and
dispatched P1-P30 across its four detector agents. Patterns 31, 32 and 33 from epic #9807
were checked by nothing, so every score the skill produced after those patterns landed was
computed against 30 of 33.

A fourth pattern comes back here. Concurrency Fix Without Race Test went into SKILL.md on
2026-08-27 numbered P31, which collided with the P31 the catalog already had, and it only
ever lived in a WIP stash. Dropping the stash dropped the pattern. It returns as P34.

## Why it matters

P34 is jsenko's standard from #9789. A regression test that has not been shown to fail
against the unfixed code protects nothing, and a test behind a profile CI never activates
does not stop a revert. The skill should have been able to anticipate that review comment.
It could not, because the check did not exist.

## Behavior changes

These change scores, not just wording, so they are listed separately.

- **P32 and P33 stop gating at full strength.** P32 now scores down only when a new
  `@QuarkusTest` class has no CDI injection at all. P33 becomes advisory and carries no
  score. Both were full-strength gates before, so a PR that already passed can score
  differently under this version. This is the largest change in the PR.
- **The trigger in `CLAUDE.md` widens.** The skill now also runs on a diff that changes a
  concurrency primitive and carries no test file. Gating on `**/src/test/**` alone makes
  P34 unreachable, because a diff with no test file in it is exactly what P34 describes.
- **The early exit is gone.** Reporting 10/10 and stopping when no test files changed
  awarded a perfect score to the one case P34 calls a failure.
- **Label membership changed.** `correctness` goes from 8 patterns to 12, `waste` from 4
  to 6, `hygiene` from 3 to 4, `race` from 3 to 4. A `--labels` sweep now selects a
  different set. The per-pattern `**Labels**:` line is stated as the authoritative source
  and the summary table as derived from it.
- **The range base moves from `main` to `origin/main`.** A local `main` that has not been
  fetched resolves against a stale base and pulls in files that are already upstream.

## Other changes

- Phase 1 reads both `+` and `-` lines. Deleting a `synchronized` block is a concurrency
  change that a `+`-only filter cannot see.
- Phase 1 picks up untracked files, because `git diff` never reports a brand-new test class.
- Phase 1 names the three ranges that return nothing by construction. `HEAD...HEAD`,
  `origin/main...HEAD` while sitting on `main`, and a change that exists only in untracked
  files each used to land silently on the clean-score branch.
- Corrected the Byteman infrastructure note. `-Pbyteman` is not on `main`; it arrives with
  #9789. Maven prints a warning for an unknown profile id after `BUILD SUCCESS` and exits
  0, so the documented command looks like it worked while loading no rules. The described
  mechanism was also wrong: that branch uses BMUnit5 inline rules, not `.btm` files driven
  by `-Dbyteman.script`.
- Removed the duplicated Patterns 29 and 30. Each appeared twice.
- Added a Status column to the infrastructure table. Three of its six rows are open PRs,
  and a new test cannot rely on infrastructure that has not landed.
- Removed the claim that CI runs this skill. No job does; `grep -rn "apicurio-test-quality"
  .github/` returns nothing.
- Retracted the clean-room "zero false positives" claim to what the run supports. It
  reported no incorrect findings, which is not a measured false-positive rate.

## Known limitations

- The 62.5% true-positive rate quoted in SKILL.md has no source in this repository. The
  sweep document behind it sits under `claudedocs/`, which is gitignored with five files
  force-added, and it is not one of them. The text now labels the run as unpublished rather
  than citing a path that does not exist. Publishing the document needs its internal
  pattern-count inconsistency reconciled first, so that is tracked separately.
- P32 and P34 state their gate semantics in two places, the catalog's scoring-scope table
  and the detector agent bullet. That duplication is deliberate. Each detector agent
  receives its own bullet rather than the catalog, so a bare cross-reference would leave it
  unable to score. The catalog table stays authoritative and the skill says so.

## Testing

Documentation and skill configuration only. No Java, no build files, no workflows, so
nothing here is covered by a test. Every command quoted in the rewritten Phase 1 was run
against this repository and its output read, including the P34 detector against
`ad227035b` (the K8sCell conflict-detection fix), which returns the expected `AtomicInteger`
hit, and the same detector against this PR's own diff, which correctly returns nothing.

