### PR TITLE
feat(rules): validate MCP tool outputSchema as JSON Schema 

### DIFF
--- a/schema-util/common/pom.xml
+++ b/schema-util/common/pom.xml
@@ -35,6 +35,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.networknt</groupId>
+      <artifactId>json-schema-validator</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
       <exclusions>

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/JsonValidationUtils.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/JsonValidationUtils.java
@@ -1,17 +1,46 @@
 package io.apicurio.registry.rules.validity;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.PathType;
+import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.SchemaValidatorsConfig;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
 import io.apicurio.registry.rules.violation.RuleViolation;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Shared JSON validation utility methods used by content validators for JSON-based artifact types
  * such as AGENT_CARD and MCP_TOOL.
  */
 public final class JsonValidationUtils {
+
+    /**
+     * Dialect used when a schema does not declare {@code $schema}. The MCP specification is written
+     * against JSON Schema without pinning a draft, so the most recent one is assumed.
+     */
+    private static final SpecVersion.VersionFlag DEFAULT_SCHEMA_DIALECT = SpecVersion.VersionFlag.V202012;
+
+    /**
+     * Reports validation failures with JSON Pointer locations, so they can be appended to the
+     * field path a {@link RuleViolation} already uses as its context.
+     */
+    private static final SchemaValidatorsConfig META_VALIDATION_CONFIG = SchemaValidatorsConfig.builder()
+            .pathType(PathType.JSON_POINTER).build();
+
+    /**
+     * Meta-schemas are immutable once built, so they are cached per dialect rather than rebuilt per
+     * call. Each is loaded from a document bundled in the validator library, never over the network.
+     */
+    private static final Map<SpecVersion.VersionFlag, JsonSchema> META_SCHEMAS = new ConcurrentHashMap<>();
 
     private JsonValidationUtils() {
         // Utility class
@@ -95,5 +124,45 @@ public final class JsonValidationUtils {
             }
             index++;
         }
+    }
+
+    /**
+     * Validates that a node is itself a well-formed JSON Schema document, by validating it against
+     * the JSON Schema meta-schema. Violations are reported under {@code basePath}, the JSON Pointer
+     * of the field holding the schema.
+     *
+     * <p>The dialect is taken from the schema's own {@code $schema} when it declares a recognised
+     * one, and is {@link #DEFAULT_SCHEMA_DIALECT} otherwise. A single malformed keyword can fail
+     * several meta-schema branches at once, so at most one violation is reported per location.
+     */
+    public static void validateJsonSchema(JsonNode schemaNode, String basePath,
+            Set<RuleViolation> violations) {
+        Set<String> reportedLocations = new HashSet<>();
+        for (ValidationMessage message : metaSchemaFor(schemaNode).validate(schemaNode)) {
+            String location = message.getInstanceLocation().toString();
+            if (reportedLocations.add(location)) {
+                violations.add(new RuleViolation(messageWithoutLocation(message, location),
+                        basePath + location));
+            }
+        }
+    }
+
+    private static JsonSchema metaSchemaFor(JsonNode schemaNode) {
+        JsonNode declaredDialect = schemaNode.get("$schema");
+        SpecVersion.VersionFlag dialect = declaredDialect != null && declaredDialect.isTextual()
+                ? SpecVersion.VersionFlag.fromId(declaredDialect.asText()).orElse(DEFAULT_SCHEMA_DIALECT)
+                : DEFAULT_SCHEMA_DIALECT;
+        return META_SCHEMAS.computeIfAbsent(dialect, version -> JsonSchemaFactory.getInstance(version)
+                .getSchema(SchemaLocation.of(version.getId()), META_VALIDATION_CONFIG));
+    }
+
+    /**
+     * The library prefixes every message with the instance location, which the violation already
+     * carries as its context.
+     */
+    private static String messageWithoutLocation(ValidationMessage message, String location) {
+        String text = message.getMessage();
+        String prefix = location + ": ";
+        return text.startsWith(prefix) ? text.substring(prefix.length()) : text;
     }
 }

--- a/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/McpToolContentValidator.java
+++ b/schema-util/common/src/main/java/io/apicurio/registry/rules/validity/McpToolContentValidator.java
@@ -117,6 +117,10 @@ public class McpToolContentValidator implements ContentValidator {
             return;
         }
 
+        // Meta-validation below runs only if the MCP-specific checks pass, so a malformed
+        // 'properties' or 'required' reports one clear violation instead of two at the same location.
+        int violationsBeforeStructuralChecks = violations.size();
+
         // inputSchema must have a "type" field with value "object"
         if (!inputSchema.has("type")) {
             violations.add(new RuleViolation("'inputSchema' must have a 'type' field",
@@ -145,6 +149,10 @@ public class McpToolContentValidator implements ContentValidator {
                 JsonValidationUtils.validateStringArray(inputSchema.get("required"),
                         "/inputSchema/required", "required parameter name", violations);
             }
+        }
+
+        if (violations.size() == violationsBeforeStructuralChecks) {
+            JsonValidationUtils.validateJsonSchema(inputSchema, "/inputSchema", violations);
         }
     }
 

--- a/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/McpToolContentValidatorTest.java
+++ b/schema-util/util-provider/src/test/java/io/apicurio/registry/rules/validity/McpToolContentValidatorTest.java
@@ -6,6 +6,7 @@ import io.apicurio.registry.content.McpToolContentAccepter;
 import io.apicurio.registry.content.TypedContent;
 import io.apicurio.registry.content.extract.ExtractedMetaData;
 import io.apicurio.registry.content.extract.McpToolContentExtractor;
+import io.apicurio.registry.rules.violation.RuleViolation;
 import io.apicurio.registry.rules.violation.RuleViolationException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -74,6 +75,54 @@ public class McpToolContentValidatorTest extends ArtifactUtilProviderTestBase {
         Assertions.assertFalse(error.getCauses().isEmpty());
         Assertions.assertTrue(
                 error.getCauses().stream().anyMatch(v -> v.getDescription().contains("inputSchema")));
+    }
+
+    @Test
+    public void testMcpToolInputSchemaIsNotValidJsonSchema() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-invalid-inputschema-jsonschema.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        RuleViolationException error = Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+        Assertions.assertEquals(1, error.getCauses().size());
+        RuleViolation violation = error.getCauses().iterator().next();
+        Assertions.assertEquals("/inputSchema/properties/city/type", violation.getContext());
+        Assertions.assertFalse(violation.getDescription().startsWith("/"),
+                "the location belongs in the context, not repeated in the description");
+    }
+
+    @Test
+    public void testMcpToolInputSchemaIsNotValidJsonSchemaPassesSyntaxOnly() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-invalid-inputschema-jsonschema.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        validator.validate(ValidityLevel.SYNTAX_ONLY, content, Collections.emptyMap());
+    }
+
+    @Test
+    public void testMcpToolComplexInputSchemaIsValid() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-valid-complex-inputschema.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+    }
+
+    @Test
+    public void testMcpToolInputSchemaDeclaringDraft07IsValid() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-draft07-inputschema.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+    }
+
+    @Test
+    public void testMcpToolMalformedInputSchemaReportsStructuralViolationOnly() throws Exception {
+        TypedContent content = resourceToTypedContentHandle("mcptool-inputschema-bad-required.json");
+        McpToolContentValidator validator = new McpToolContentValidator();
+        RuleViolationException error = Assertions.assertThrows(RuleViolationException.class, () -> {
+            validator.validate(ValidityLevel.FULL, content, Collections.emptyMap());
+        });
+        Assertions.assertEquals(1, error.getCauses().size());
+        RuleViolation violation = error.getCauses().iterator().next();
+        Assertions.assertEquals("/inputSchema/required", violation.getContext());
+        Assertions.assertTrue(violation.getDescription().contains("must be an array"));
     }
 
     @Test

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-draft07-inputschema.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-draft07-inputschema.json
@@ -1,0 +1,17 @@
+{
+  "name": "draft07_tool",
+  "description": "inputSchema declares draft-07 and uses tuple-form 'items', which draft-07 allows and 2020-12 does not",
+  "inputSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "coordinate": {
+        "type": "array",
+        "items": [
+          { "type": "string" },
+          { "type": "integer" }
+        ]
+      }
+    }
+  }
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-inputschema-bad-required.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-inputschema-bad-required.json
@@ -1,0 +1,11 @@
+{
+  "name": "bad_required_tool",
+  "description": "inputSchema declares 'required' as a string instead of an array",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "city": { "type": "string" }
+    },
+    "required": "city"
+  }
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-invalid-inputschema-jsonschema.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-invalid-inputschema-jsonschema.json
@@ -1,0 +1,10 @@
+{
+  "name": "typo_type_tool",
+  "description": "inputSchema declares a property type that is not a JSON Schema type",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "city": { "type": "strng" }
+    }
+  }
+}

--- a/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-valid-complex-inputschema.json
+++ b/schema-util/util-provider/src/test/resources/io/apicurio/registry/rules/validity/mcptool-valid-complex-inputschema.json
@@ -1,0 +1,22 @@
+{
+  "name": "complex_schema_tool",
+  "description": "inputSchema uses nesting, arrays and a nullable union",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "user": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "nickname": { "type": ["string", "null"] }
+        },
+        "required": ["id"]
+      },
+      "tags": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    },
+    "required": ["user"]
+  }
+}


### PR DESCRIPTION
Closes #10081

## Summary

`McpToolContentValidator` only checked that `outputSchema` was an object. A malformed schema, such as a property declared as `{"type": "integr"}`, was stored without complaint.

That matters more for `outputSchema` than for any other field, because it is what compatible-tools discovery reads. `extractOutputProperties` in `WellKnownResourceImpl` takes each declared type in `outputSchema.properties` at face value, so a misspelled `"integr"` never matches a candidate's `"integer"`, and tools that could consume the output are silently left out.

This validates `outputSchema` against the JSON Schema meta-schema at `FULL`, using `JsonValidationUtils.validateJsonSchema` from #10106. `NONE` and `SYNTAX_ONLY` are unchanged. Violations go into the existing set and surface through the existing `RuleViolationException`, so error responses keep their current shape.

## Behaviour worth reviewing

- **`outputSchema` stays optional.** Only tools that declare one are validated.
- **The existing object check stays and runs first.** A boolean such as `true` is a valid JSON Schema, so meta-validation alone would accept it, but MCP requires an object.
- **The dialect policy from #10106 applies here too.** An absent `$schema` defaults to 2020-12, and a non-string or unsupported `$schema` is reported at `/outputSchema/$schema` without falling back to another draft.
- **No `type: "object"` requirement is added.** The registry's bundled MCP tool schema does not require it, so enforcing it here would reject tools that are valid today. That can be tracked separately.

## Tests

| Case | Covered by |
|---|---|
| Malformed `outputSchema` is rejected at `/outputSchema/properties/total/type` | `testMcpToolOutputSchemaIsNotValidJsonSchema` |
| The same tool still passes at `SYNTAX_ONLY` | `testMcpToolOutputSchemaIsNotValidJsonSchemaPassesSyntaxOnly` |
| A non-object `outputSchema` keeps the existing violation | `testMcpToolBooleanOutputSchemaIsRejected` |
| An `outputSchema` without `type` is accepted | `testMcpToolOutputSchemaWithoutTypeIsValid` |
| An unsupported `$schema` is reported at `/outputSchema/$schema` | `testMcpToolOutputSchemaDeclaringUnsupportedDialectIsRejected` |
| A tool with no `outputSchema` still passes at `FULL` | existing `testMcpToolMinimal`, whose fixture has no `outputSchema` |
| A well formed `outputSchema` passes | existing `testValidMcpTool` |

## Docs

The validation rules section of `assembly-mcp-tool-features.adoc` now covers `outputSchema` alongside `inputSchema`: the `FULL` bullet, the dialect policy, and the note that existing `FULL` users can now see a malformed `outputSchema` rejected.

## Verification

- `schema-util/common`: 40 tests pass, 0 checkstyle violations
- `schema-util/util-provider`, full suite: 332 tests pass, 0 checkstyle violations
- Each behaviour was checked by reverting it and confirming the matching test fails
- None of the 18 `outputSchema` objects already in the repository fail meta-validation or declare `$schema`, so no existing content is affected

## Checklist

- [x] Linked issue has maintainer approval
- [x] No overlapping open PRs for the same issue
- [x] Checked the [Tried & Rejected list](https://github.com/Apicurio/apicurio-registry/discussions/8364)
- [x] Tests added for new code paths
- [x] Tested locally: `mvn test -pl schema-util/util-provider`, after installing `schema-util/common`
- [x] `./mvnw checkstyle:check -pl schema-util/common` passes
- [x] All commits have DCO sign-off (`git commit -s`)
